### PR TITLE
add a tool to enable adding/removing elements from a VSIX manifest in situ

### DIFF
--- a/ModifyVsixManifest/AddVsixValueOperation.cs
+++ b/ModifyVsixManifest/AddVsixValueOperation.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.XPath;
+
+namespace ModifyVsixManifest
+{
+    internal class AddVsixValueOperation : IVsixManifestOperation
+    {
+        public string Path { get; }
+        public string AttributeName { get; }
+        public string Value { get; }
+
+        public AddVsixValueOperation(string path, string attributeName, string value)
+        {
+            Path = path;
+            AttributeName = attributeName;
+            Value = value;
+        }
+
+        public static AddVsixValueOperation FromSemicolonDelimited(string str)
+        {
+            var parts = str.Split(';');
+            Debug.Assert(parts.Length == 3);
+            return new AddVsixValueOperation(parts[0], parts[1], parts[2]);
+        }
+
+        public void Execute(XDocument document)
+        {
+            var navigator = document.CreateNavigator();
+            var namespaceManager = new XmlNamespaceManager(new NameTable());
+            namespaceManager.AddNamespace("x", document.Root.Name.NamespaceName);
+
+            // unfortunately evaluating
+            var enumerable = (IEnumerable<object>)document.XPathEvaluate(Path, namespaceManager);
+            var node = enumerable.FirstOrDefault() as XObject;
+            if (node is XElement)
+            {
+                var element = (XElement)node;
+                element.Add(new XAttribute(AttributeName, Value));
+            }
+            else
+            {
+                throw new Exception("Unable to find element via XPath");
+            }
+        }
+    }
+}

--- a/ModifyVsixManifest/IVsixManifestOperation.cs
+++ b/ModifyVsixManifest/IVsixManifestOperation.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Xml.Linq;
+
+namespace ModifyVsixManifest
+{
+    internal interface IVsixManifestOperation
+    {
+        void Execute(XDocument document);
+    }
+}

--- a/ModifyVsixManifest/ModifyVsixManifest.csproj
+++ b/ModifyVsixManifest/ModifyVsixManifest.csproj
@@ -1,0 +1,68 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C2D10BD8-726A-4A75-B7AD-18EB25ED768A}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ModifyVsixManifest</RootNamespace>
+    <AssemblyName>ModifyVsixManifest</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Mono.Options, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Options.4.4.0.0\lib\net4-client\Mono.Options.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AddVsixValueOperation.cs" />
+    <Compile Include="IVsixManifestOperation.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RemoveVsixValueOperation.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/ModifyVsixManifest/Program.cs
+++ b/ModifyVsixManifest/Program.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Packaging;
+using System.Xml.Linq;
+using Mono.Options;
+
+namespace ModifyVsixManifest
+{
+    internal class Program
+    {
+        public static void Main(string[] args)
+        {
+            string vsixName = null;
+            var operations = new List<IVsixManifestOperation>();
+            var parameters = new OptionSet()
+            {
+                @"Usage: {exename} --vsix=path\to\package.vsix [options]",
+                "",
+                "Options:",
+                { "vsix=", "The VSIX package to modify.", value => vsixName = value },
+                { "add-attribute=", "The XPath of the parent to the attribute, the attribute name, and the value to add, all separated by semicolons.", value => operations.Add(AddVsixValueOperation.FromSemicolonDelimited(value)) },
+                { "remove=", "The XPath of the value to remove.", path => operations.Add(new RemoveVsixValueOperation(path)) }
+            };
+
+            if (args.Length == 0)
+            {
+                parameters.WriteOptionDescriptions(Console.Out);
+                Environment.Exit(0);
+            }
+
+            try
+            {
+                parameters.Parse(args);
+            }
+            catch (OptionException)
+            {
+                parameters.WriteOptionDescriptions(Console.Out);
+                Environment.Exit(1);
+            }
+
+            using (var package = Package.Open(vsixName))
+            {
+                var part = package.GetPart(new Uri("/extension.vsixmanifest", UriKind.Relative));
+                using (var stream = part.GetStream(FileMode.Open))
+                {
+                    var document = XDocument.Load(stream);
+                    foreach (var operation in operations)
+                    {
+                        operation.Execute(document);
+                    }
+
+                    using (var ms = new MemoryStream())
+                    {
+                        document.Save(ms);
+                        stream.Seek(0, SeekOrigin.Begin);
+                        stream.SetLength(ms.Length);
+                        ms.Seek(0, SeekOrigin.Begin);
+                        ms.CopyTo(stream);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ModifyVsixManifest/Properties/AssemblyInfo.cs
+++ b/ModifyVsixManifest/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ModifyVsixManifest")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ModifyVsixManifest")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("c2d10bd8-726a-4a75-b7ad-18eb25ed768a")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/ModifyVsixManifest/RemoveVsixValueOperation.cs
+++ b/ModifyVsixManifest/RemoveVsixValueOperation.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.XPath;
+
+namespace ModifyVsixManifest
+{
+    internal class RemoveVsixValueOperation : IVsixManifestOperation
+    {
+        public string Path { get; }
+
+        public RemoveVsixValueOperation(string path)
+        {
+            Path = path;
+        }
+
+        public void Execute(XDocument document)
+        {
+            var navigator = document.CreateNavigator();
+            var namespaceManager = new XmlNamespaceManager(new NameTable());
+            namespaceManager.AddNamespace("x", document.Root.Name.NamespaceName);
+
+            // unfortunately evaluating
+            var enumerable = (IEnumerable<object>)document.XPathEvaluate(Path, namespaceManager);
+            var node = enumerable.FirstOrDefault() as XObject;
+            if (node is XElement)
+            {
+                ((XElement)node).Remove();
+            }
+            else if (node is XAttribute)
+            {
+                var att = (XAttribute)node;
+                var parent = att.Parent;
+                var newAttributes = parent.Attributes().Except(new[] { att });
+                parent.RemoveAttributes();
+                parent.Add(newAttributes);
+            }
+            else
+            {
+                throw new Exception("Unable to find element via XPath.");
+            }
+        }
+    }
+}

--- a/ModifyVsixManifest/packages.config
+++ b/ModifyVsixManifest/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Mono.Options" version="4.4.0.0" targetFramework="net452" />
+</packages>

--- a/RoslynTools.sln
+++ b/RoslynTools.sln
@@ -59,6 +59,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SignToolTests", "src\SignToolTests\SignToolTests.csproj", "{AB372697-8CAA-433F-AEC1-10A122FBB4EE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModifyVsixManifest", "ModifyVsixManifest\ModifyVsixManifest.csproj", "{C2D10BD8-726A-4A75-B7AD-18EB25ED768A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -73,6 +75,10 @@ Global
 		{AB372697-8CAA-433F-AEC1-10A122FBB4EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AB372697-8CAA-433F-AEC1-10A122FBB4EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AB372697-8CAA-433F-AEC1-10A122FBB4EE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C2D10BD8-726A-4A75-B7AD-18EB25ED768A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C2D10BD8-726A-4A75-B7AD-18EB25ED768A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C2D10BD8-726A-4A75-B7AD-18EB25ED768A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C2D10BD8-726A-4A75-B7AD-18EB25ED768A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -86,5 +92,6 @@ Global
 		{3DA711E1-055F-4352-A5E1-F9169C86A20F} = {1063E05B-16CB-434C-9F91-A1710B4AAAB8}
 		{C0E7FE5B-10C1-414A-B54F-DA182205053F} = {1063E05B-16CB-434C-9F91-A1710B4AAAB8}
 		{AB372697-8CAA-433F-AEC1-10A122FBB4EE} = {1063E05B-16CB-434C-9F91-A1710B4AAAB8}
+		{C2D10BD8-726A-4A75-B7AD-18EB25ED768A} = {1063E05B-16CB-434C-9F91-A1710B4AAAB8}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
The VSIX packages we currently build have an `Experimental="true"` attribute set in the manifest that we need to remove when doing insertions into the DevDiv build.  For those same insertions we also have to add a `InstalledByMSI="true"` attribute.  With this tool our build process will be modified like so:
- Build VSIX packages normally.
- Duplicate our insertion VSIX packages with a new name.  E.g., `copy Roslyn.VisualStudio.Setup.vsix Roslyn.VisualStudio.Setup.Insertion.vsix`.
- Run this tool to set the appropriate attributes: `ModifyVsixManifest.exe --vsix=Roslyn.VisualStudio.Setup.Insertion.vsix --remove=//x:PackageManifest/x:Installation/@Experimental --add-attribute=//x:PackageManifest/x:Installation;InstalledByMSI;true`.
- Sign both original and `.Insertion.vsix` packages.
- Then the `.Insertion.vsix` packages will be inserted.

Note 1: This tool is overly complex because it can be used to make nearly any modification to the `extension.vsixmanifest` file.  I deemed this better than a one-off tool that was too specific.

Note 2: Other Roslyn teams will also be using this to fix the VSIX attributes, namely compilers and test impact.
