### PR TITLE
Add an option to build via dotnet cli

### DIFF
--- a/src/SignTool/SignTool/SignTool.SignToolBase.cs
+++ b/src/SignTool/SignTool/SignTool.SignToolBase.cs
@@ -18,6 +18,7 @@ namespace SignTool
             private readonly SignToolArgs _args;
 
             internal string MSBuildPath => _args.MSBuildPath;
+            internal string DotnetToolPath => _args.DotnetPath;
             internal string OutputPath => _args.OutputPath;
             internal string IntermediateOutputPath => _args.IntermediateOutputPath;
             internal string NuGetPackagesPath => _args.NuGetPackagesPath;
@@ -37,20 +38,32 @@ namespace SignTool
             public void Sign(IEnumerable<FileSignInfo> filesToSign)
             {
                 var buildFilePath = Path.Combine(AppPath, "build.proj");
-                var commandLine = new StringBuilder();
-
-                commandLine.Append(@"/v:m ");
-                commandLine.Append($@"""{buildFilePath}"" ");
-                Console.WriteLine($"msbuild.exe {commandLine.ToString()}");
-
+                
                 var content = GenerateBuildFileContent(filesToSign);
                 File.WriteAllText(buildFilePath, content);
                 Console.WriteLine("Generated project file");
                 Console.WriteLine(content);
 
+                string fileName;
+                var commandLine = new StringBuilder();
+
+                if (MSBuildPath != null)
+                {
+                    fileName = MSBuildPath;
+                    commandLine.Append("/v:m ");
+                }
+                else
+                {
+                    fileName = DotnetToolPath;
+                    commandLine.Append("msbuild ");
+                }
+
+                commandLine.Append($@"""{buildFilePath}"" ");
+                Console.WriteLine($"{fileName} {commandLine.ToString()}");
+
                 var startInfo = new ProcessStartInfo()
                 {
-                    FileName = MSBuildPath,
+                    FileName = fileName,
                     Arguments = commandLine.ToString(),
                     UseShellExecute = false,
                     RedirectStandardOutput = true,

--- a/src/SignTool/SignTool/SignToolArgs.cs
+++ b/src/SignTool/SignTool/SignToolArgs.cs
@@ -13,6 +13,7 @@ namespace SignTool
         internal string NuGetPackagesPath { get; }
         internal string AppPath { get; }
         internal string MSBuildPath { get; }
+        internal string DotnetPath { get; }
         internal string ConfigFile { get; }
         internal bool Test { get; }
 
@@ -21,6 +22,7 @@ namespace SignTool
             string intermediateOutputPath,
             string appPath,
             string msbuildPath,
+            string dotnetPath,
             string nugetPackagesPath,
             string configFile,
             bool test)
@@ -29,6 +31,7 @@ namespace SignTool
             IntermediateOutputPath = intermediateOutputPath;
             AppPath = appPath;
             MSBuildPath = msbuildPath;
+            DotnetPath = dotnetPath;
             NuGetPackagesPath = nugetPackagesPath;
             ConfigFile = configFile;
             Test = test;


### PR DESCRIPTION
Enables repos using dotnet cli based builds to avoid dependency on MSBuild.exe (msbuild functionality is available thru ```dotnet msbuild```).