### PR TITLE
SignTool: Use LocateVS to find msbuild when not specified

### DIFF
--- a/build/Scripts/Windows/Build.ps1
+++ b/build/Scripts/Windows/Build.ps1
@@ -8,7 +8,7 @@ Param(
   [string] $msbuildVersion = "15.0",
   [string] $nugetVersion = "3.6.0-beta1",
   [switch] $official,
-  [string] $publishedPackageVersion = "0.3.1-beta",
+  [string] $publishedPackageVersion = "0.3.2-beta",
   [switch] $realSign,
   [string] $signToolVersion = "0.2.4-beta",
   [switch] $skipBuild,

--- a/src/NuGet/SignTool.nuspec
+++ b/src/NuGet/SignTool.nuspec
@@ -20,6 +20,9 @@
     <file src="SignTool\Newtonsoft.Json.dll" target="tools" />
     <file src="SignTool\System.Collections.Immutable.dll" target="tools" />
     <file src="SignTool\System.Reflection.Metadata.dll" target="tools" />
+    <file src="SignTool\LocateVS.dll" target="tools" />
+    <file src="SignTool\Microsoft.VisualStudio.Setup.Configuration.Interop.dll" target="tools" />    
+    <file src="SignTool\x86\Microsoft.VisualStudio.Setup.Configuration.Native.dll" target="tools\x86" />
     <file src="$thirdPartyNoticesPath$" target="" />
   </files>
 </package>

--- a/src/SignTool/SignTool/Program.cs
+++ b/src/SignTool/SignTool/Program.cs
@@ -22,7 +22,7 @@ namespace SignTool
                 Environment.Exit(1);
             }
 
-            if (!File.Exists(signToolArgs.MSBuildPath))
+            if (!signToolArgs.Test && !File.Exists(signToolArgs.MSBuildPath))
             {
                 Console.WriteLine($"Unable to locate MSBuild at the path '{signToolArgs.MSBuildPath}'.");
                 Environment.Exit(1);
@@ -160,7 +160,7 @@ config: Path to SignToolData.json. Default build\config\SignToolData.json.
             outputPath = args[i];
 
             // Get defaults for all of the optional values that weren't specified
-            if (msbuildPath == null)
+            if (msbuildPath == null && !test)
             {
                 var vsInstallDir = LocateVS.Instance.GetInstallPath("15.0", new[] { "Microsoft.Component.MSBuild" });
                 msbuildPath = Path.Combine(vsInstallDir, "MSBuild", "15.0", "Bin", "msbuild.exe");

--- a/src/SignTool/SignTool/Program.cs
+++ b/src/SignTool/SignTool/Program.cs
@@ -22,20 +22,11 @@ namespace SignTool
                 Environment.Exit(1);
             }
 
-            if (signToolArgs.MSBuildPath != null && !File.Exists(signToolArgs.MSBuildPath))
+            if (!File.Exists(signToolArgs.MSBuildPath))
             {
                 Console.WriteLine($"Unable to locate MSBuild at the path '{signToolArgs.MSBuildPath}'.");
                 Environment.Exit(1);
             }
-
-            if (signToolArgs.DotnetPath != null && !File.Exists(signToolArgs.DotnetPath))
-            {
-                Console.WriteLine($"Unable to locate dotnet at the path '{signToolArgs.DotnetPath}'.");
-                Environment.Exit(1);
-            }
-
-            // A default msbuild path was set.
-            Debug.Assert(signToolArgs.MSBuildPath != null || signToolArgs.DotnetPath != null);
 
             var signTool = SignToolFactory.Create(signToolArgs);
             var batchData = ReadConfigFile(signToolArgs.OutputPath, signToolArgs.ConfigFile);
@@ -115,7 +106,6 @@ config: Path to SignToolData.json. Default build\config\SignToolData.json.
             string intermediateOutputPath = null;
             string outputPath = null;
             string msbuildPath = null;
-            string dotnetPath = null;
             string nugetPackagesPath = null;
             string configFile = null;
             var test = false;
@@ -139,12 +129,6 @@ config: Path to SignToolData.json. Default build\config\SignToolData.json.
                         break;
                     case "-msbuildpath":
                         if (!ParsePathOption(args, ref i, current, out msbuildPath))
-                        {
-                            return false;
-                        }
-                        break;
-                    case "-dotnetpath":
-                        if (!ParsePathOption(args, ref i, current, out dotnetPath))
                         {
                             return false;
                         }
@@ -176,9 +160,10 @@ config: Path to SignToolData.json. Default build\config\SignToolData.json.
             outputPath = args[i];
 
             // Get defaults for all of the optional values that weren't specified
-            if (msbuildPath == null && dotnetPath == null)
+            if (msbuildPath == null)
             {
-                msbuildPath = Path.Combine(host.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), @"MSBuild\14.0\bin\MSBuild.exe");
+                var vsInstallDir = LocateVS.Instance.GetInstallPath("15.0", new[] { "Microsoft.Component.MSBuild" });
+                msbuildPath = Path.Combine(vsInstallDir, "MSBuild", "15.0", "Bin", "msbuild.exe");
             }
 
             intermediateOutputPath = intermediateOutputPath ?? Path.Combine(Path.GetDirectoryName(outputPath), "Obj");
@@ -206,7 +191,6 @@ config: Path to SignToolData.json. Default build\config\SignToolData.json.
             signToolArgs = new SignToolArgs(
                 outputPath: outputPath,
                 msbuildPath: msbuildPath,
-                dotnetPath: dotnetPath,
                 intermediateOutputPath: intermediateOutputPath,
                 nugetPackagesPath: nugetPackagesPath,
                 appPath: AppContext.BaseDirectory,

--- a/src/SignTool/SignTool/SignTool.SignToolBase.cs
+++ b/src/SignTool/SignTool/SignTool.SignToolBase.cs
@@ -45,7 +45,11 @@ namespace SignTool
 
                 string fileName = MSBuildPath;
                 var commandLine = $@"/v:m ""{buildFilePath}""";
-                Console.WriteLine($"{fileName} {commandLine}");
+
+                if (!_args.Test)
+                {
+                    Console.WriteLine($"{fileName} {commandLine}");
+                }
 
                 var startInfo = new ProcessStartInfo()
                 {

--- a/src/SignTool/SignTool/SignTool.SignToolBase.cs
+++ b/src/SignTool/SignTool/SignTool.SignToolBase.cs
@@ -18,7 +18,6 @@ namespace SignTool
             private readonly SignToolArgs _args;
 
             internal string MSBuildPath => _args.MSBuildPath;
-            internal string DotnetToolPath => _args.DotnetPath;
             internal string OutputPath => _args.OutputPath;
             internal string IntermediateOutputPath => _args.IntermediateOutputPath;
             internal string NuGetPackagesPath => _args.NuGetPackagesPath;
@@ -44,27 +43,14 @@ namespace SignTool
                 Console.WriteLine("Generated project file");
                 Console.WriteLine(content);
 
-                string fileName;
-                var commandLine = new StringBuilder();
-
-                if (MSBuildPath != null)
-                {
-                    fileName = MSBuildPath;
-                    commandLine.Append("/v:m ");
-                }
-                else
-                {
-                    fileName = DotnetToolPath;
-                    commandLine.Append("msbuild ");
-                }
-
-                commandLine.Append($@"""{buildFilePath}"" ");
-                Console.WriteLine($"{fileName} {commandLine.ToString()}");
+                string fileName = MSBuildPath;
+                var commandLine = $@"/v:m ""{buildFilePath}""";
+                Console.WriteLine($"{fileName} {commandLine}");
 
                 var startInfo = new ProcessStartInfo()
                 {
                     FileName = fileName,
-                    Arguments = commandLine.ToString(),
+                    Arguments = commandLine,
                     UseShellExecute = false,
                     RedirectStandardOutput = true,
                     WorkingDirectory = AppPath,

--- a/src/SignTool/SignTool/SignToolArgs.cs
+++ b/src/SignTool/SignTool/SignToolArgs.cs
@@ -13,7 +13,6 @@ namespace SignTool
         internal string NuGetPackagesPath { get; }
         internal string AppPath { get; }
         internal string MSBuildPath { get; }
-        internal string DotnetPath { get; }
         internal string ConfigFile { get; }
         internal bool Test { get; }
 
@@ -22,7 +21,6 @@ namespace SignTool
             string intermediateOutputPath,
             string appPath,
             string msbuildPath,
-            string dotnetPath,
             string nugetPackagesPath,
             string configFile,
             bool test)
@@ -31,7 +29,6 @@ namespace SignTool
             IntermediateOutputPath = intermediateOutputPath;
             AppPath = appPath;
             MSBuildPath = msbuildPath;
-            DotnetPath = dotnetPath;
             NuGetPackagesPath = nugetPackagesPath;
             ConfigFile = configFile;
             Test = test;

--- a/src/SignTool/SignTool/project.json
+++ b/src/SignTool/SignTool/project.json
@@ -1,13 +1,16 @@
 ﻿{
   "dependencies": {
     "Newtonsoft.Json": "9.0.1",
+    "RoslynTools.Microsoft.LocateVS": "0.2.4-beta",
     "System.Collections.Immutable": "1.2.0",
-    "System.Reflection.Metadata": "1.4.1-beta-24322-03"
+    "System.Reflection.Metadata": "1.4.1-beta-24322-03",
+    "Microsoft.VisualStudio.Setup.Configuration.Interop": "1.3.269-rc",
+    "Microsoft.VisualStudio.Setup.Configuration.Native.AnyCPU": "1.3.269-rc"
   },
   "frameworks": {
-    "net46": { }
+    "net46": {}
   },
   "runtimes": {
-    "win": { }
+    "win": {}
   }
 }

--- a/src/SignTool/SignToolTests/SignTool.UnitTests.xunit.runner.json
+++ b/src/SignTool/SignToolTests/SignTool.UnitTests.xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "shadowCopy": false
+}

--- a/src/SignTool/SignToolTests/SignToolTests.csproj
+++ b/src/SignTool/SignToolTests/SignToolTests.csproj
@@ -14,6 +14,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
+    <None Include="SignTool.UnitTests.xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SignTool\SignTool.csproj">


### PR DESCRIPTION
Removes -dotnetPath command line arg, since the microbuild real signing task won't be portable anytime soon.

