### PR TITLE
Support single level directory glob in sign tool

### DIFF
--- a/src/NuGet/SignTool.nuspec
+++ b/src/NuGet/SignTool.nuspec
@@ -22,7 +22,8 @@
     <file src="SignTool\System.Reflection.Metadata.dll" target="tools" />
     <file src="SignTool\LocateVS.dll" target="tools" />
     <file src="SignTool\Microsoft.VisualStudio.Setup.Configuration.Interop.dll" target="tools" />    
-    <file src="SignTool\x86\Microsoft.VisualStudio.Setup.Configuration.Native.dll" target="tools\x86" />
+    <file src="SignTool\x86\*" target="tools\x86" />
+    <file src="SignTool\x64\*" target="tools\x64" />
     <file src="$thirdPartyNoticesPath$" target="" />
   </files>
 </package>

--- a/src/SignTool/README.md
+++ b/src/SignTool/README.md
@@ -36,7 +36,7 @@ The properties have the following semantics:
 
 - certificate: name of the authenticode certificate to use for signing.  Valid values include Microsoft402, WindowsPhone623, MicrosoftSHA1Win8WinBlue and VsixSHA2.  More are likely available.  This value must be specified.
 - strongName: name of the key to use when strong naming the binary.  This can be `null` for values which do not require strong name signing such as VSIX files. 
-- values: array of paths, relative to the binaries directory, which will be signed in this manner. 
+- values: array of paths, relative to the binaries directory, which will be signed in this manner.  These paths can include `*` globbing for directory names (helps support localization). 
 
 The exclude section is only relevant when VSIX values are being signed.  It's not uncommon to include files in a VSIX which are not built by the repo producing the VSIX.  Such files should not be included in signing (responsibility of the repo that produced them).  
 
@@ -46,6 +46,7 @@ Example configuration files:
 
 - [Roslyn](https://github.com/dotnet/roslyn/blob/master/build/config/SignToolData.json)
 - [DiaSym Reader](https://github.com/dotnet/symreader/blob/master/build/Signing/SignToolData.json)
+- [SDK](https://github.com/dotnet/sdk/blob/master/build/Signing/SignToolConfig.json)
 
 ## Arguments
 
@@ -61,3 +62,4 @@ The only required argument is `outputPath` and `-config`.  The rest will be infe
 - `-msbuildPath`: Path to the MSBuild.exe binary used to run the actual signing process on Microbuild.  The default is to use MSBuid 14.0 standard installation.
 - `-nugetPackagesPath`: Defaults to `~\.nuget\packages`.  Needed to specify the `<Import>` statements for Microbuild.
 - `-intermediateOutputPath`: Defaults to `<outputPath>\Obj`.  
+

--- a/src/SignTool/SignTool/PathUtil.cs
+++ b/src/SignTool/SignTool/PathUtil.cs
@@ -4,23 +4,78 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Security.Cryptography;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SignTool
 {
     internal static class PathUtil
     {
-        internal static bool IsVsix(string fileName)
-        {
-            return Path.GetExtension(fileName) == ".vsix";
-        }
+        internal static bool IsVsix(string fileName) => Path.GetExtension(fileName) == ".vsix";
 
         internal static bool IsAssembly(string fileName)
         {
             var ext = Path.GetExtension(fileName);
             return ext == ".exe" || ext == ".dll";
         }
+
+        internal static bool IsAnyDirectorySeparator(char c) => c == '\\' || c == '/';
+
+        internal static List<string> ExpandDirectoryGlob(string globPath)
+        {
+            var all = ExpandDirectoryGlobCore(globPath);
+            return all
+                .Where(File.Exists)
+                .Distinct()
+                .OrderByDescending(x => x)
+                .ToList();
+        }
+
+        internal static IEnumerable<string> ExpandDirectoryGlobCore(string globPath)
+        {
+            var firstStarIndex = globPath.IndexOf('*');
+            if (firstStarIndex <= 2 || 
+                firstStarIndex + 1 == globPath.Length ||
+                !IsAnyDirectorySeparator(globPath[firstStarIndex - 1]))
+            {
+                throw CreateBadGlobException();
+            }
+
+            var baseDir = globPath.Substring(0, length: firstStarIndex - 1);
+
+            var nextCharIndex = firstStarIndex + 1;
+            var nextChar = globPath[nextCharIndex];
+            if (IsAnyDirectorySeparator(nextChar))
+            {
+                if (nextCharIndex + 1 >= globPath.Length)
+                {
+                    throw CreateBadGlobException();
+                }
+
+                var childPath = globPath.Substring(nextCharIndex + 1);
+                return ExpandGlobDirectorySingle(baseDir, childPath);
+            }
+
+            throw CreateBadGlobException();
+        }
+
+        private static IEnumerable<string> ExpandGlobDirectorySingle(string baseDir, string childPath)
+        {
+            foreach (var dir in Directory.EnumerateDirectories(baseDir))
+            {
+                var fullPath = Path.Combine(dir, childPath);
+                if (fullPath.IndexOf('*') > 0)
+                {
+                    foreach (var expandedPath in ExpandDirectoryGlobCore(fullPath))
+                    {
+                        yield return expandedPath;
+                    }
+                }
+                else
+                {
+                    yield return fullPath;
+                }
+            }
+        }
+
+        private static Exception CreateBadGlobException() => new Exception("Globbing is only supported as a * directory names in their entirety");
     }
 }


### PR DESCRIPTION
This will make it simpler to sign resource files with the batch signing tool.  No longer need
to enumerate every single resource DLL. Instead can do the following

```
ArtifactTool\*\ArtifactTool.resource.dll
```