### PR TITLE
Report words used across files

### DIFF
--- a/src/Words/App.config
+++ b/src/Words/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+    </startup>
+</configuration>

--- a/src/Words/Program.cs
+++ b/src/Words/Program.cs
@@ -1,0 +1,159 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+internal delegate void Handler(Location location, string word);
+
+internal sealed class Location
+{
+    internal readonly string Path;
+    internal readonly int Line;
+    internal readonly int Column;
+
+    internal Location(string path, int line, int column)
+    {
+        Path = path;
+        Line = line;
+        Column = column;
+    }
+}
+
+internal struct CountAndLocation
+{
+    internal readonly int Count;
+    internal readonly Location Location;
+
+    internal CountAndLocation(int count, Location location)
+    {
+        Count = count;
+        Location = location;
+    }
+}
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        if (args.Length != 1)
+        {
+            Console.WriteLine("Usage: Words <source-path>");
+            return;
+        }
+
+        var path = Path.GetFullPath(args[0]);
+        var words = new Dictionary<string, CountAndLocation> ();
+        ReadFiles(
+            path,
+            path.Length + 1,
+            new[] { ".cs", ".vb" },
+            (location, word) =>
+            {
+                if (word.Length < 3)
+                {
+                    return;
+                }
+                word = word.ToLower();
+                CountAndLocation value;
+                value = words.TryGetValue(word, out value) ?
+                    new CountAndLocation(value.Count + 1, Merge(value.Location, location)) :
+                    new CountAndLocation(1, location);
+                words[word] = value;
+            });
+
+        var list = words.ToArray();
+        Array.Sort(list, (pair1, pair2) => pair1.Key.CompareTo(pair2.Key));
+        WriteResults(list);
+    }
+
+    // If the file is the same, keep the file but drop the (line, column).
+    // If the file is different, drop the location.
+    private static Location Merge(Location a, Location b)
+    {
+        return (a != null && a.Path == b.Path) ? new Location(a.Path, 0, 0) : null;
+    }
+
+    private static void WriteResults(KeyValuePair<string, CountAndLocation>[] results)
+    {
+        foreach (var item in results)
+        {
+            var word = item.Key;
+            var count = item.Value.Count;
+            var location = item.Value.Location;
+            Console.Write("{0} {1}", word, count);
+            if (location != null)
+            {
+                Console.Write("\t\t\t{0}", location.Path);
+                if (location.Line != 0)
+                {
+                    Console.Write(" ({0}, {1})", location.Line, location.Column);
+                }
+            }
+            Console.WriteLine();
+        }
+    }
+
+    private static void ReadFiles(string path, int pathLength, string[] extensions, Handler handler)
+    {
+        foreach (var file in Directory.GetFiles(path))
+        {
+            var extension = Path.GetExtension(file);
+            if (extensions.Contains(extension))
+            {
+                var text = File.ReadAllText(file);
+                ReadWords(file.Substring(pathLength), text, handler);
+            }
+        }
+
+        foreach (var dir in Directory.GetDirectories(path))
+        {
+            ReadFiles(dir, pathLength, extensions, handler);
+        }
+    }
+
+    private static void ReadWords(string path, string text, Handler handler)
+    {
+        int line = 1;
+        int column = 0;
+        int i = 0;
+        int n = text.Length;
+        while (i < n)
+        {
+            char c = text[i++];
+            switch (c)
+            {
+                case '\n':
+                    line++;
+                    column = 0;
+                    continue;
+                case '\r':
+                    column = 0;
+                    continue;
+            }
+            column++;
+            if (!char.IsLetter(c))
+            {
+                continue;
+            }
+            int start = i - 1;
+            while (i < n)
+            {
+                c = text[i];
+                if (!char.IsLetter(c))
+                {
+                    break;
+                }
+                if (char.IsUpper(c))
+                {
+                    break;
+                }
+                i++;
+            }
+            int length = i - start;
+            handler(new Location(path, line, column), text.Substring(start, length));
+            column += length - 1;
+        }
+    }
+}

--- a/src/Words/Words.csproj
+++ b/src/Words/Words.csproj
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\build\Targets\VSL.Settings.targets" />
+  <PropertyGroup>
+    <NonShipping>True</NonShipping>
+    <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net46</TargetFramework>
+    <RuntimeIdentifiers>win7</RuntimeIdentifiers>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+  <Import Project="..\..\build\Targets\VSL.Imports.targets" />
+</Project>

--- a/src/Words/Words.csproj
+++ b/src/Words/Words.csproj
@@ -1,19 +1,37 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\build\Targets\VSL.Settings.targets" />
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <NonShipping>True</NonShipping>
-    <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{9A19103F-16F7-4668-BE54-9A1E7A4F7556}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net46</TargetFramework>
-    <RuntimeIdentifiers>win7</RuntimeIdentifiers>
+    <RootNamespace></RootNamespace>
+    <AssemblyName>Words</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <SignAssembly>false</SignAssembly>
+    <Deterministic>true</Deterministic>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -21,5 +39,8 @@
   <ItemGroup>
     <Compile Include="Program.cs" />
   </ItemGroup>
-  <Import Project="..\..\build\Targets\VSL.Imports.targets" />
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/Words/Words.sln
+++ b/src/Words/Words.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26906.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Words", "Words.csproj", "{2408E75D-A824-45B7-B7B6-68915C764462}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2408E75D-A824-45B7-B7B6-68915C764462}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2408E75D-A824-45B7-B7B6-68915C764462}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2408E75D-A824-45B7-B7B6-68915C764462}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2408E75D-A824-45B7-B7B6-68915C764462}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {7FC8C9D0-7EEA-410F-B4F1-6BA52EE18E71}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Command-line tool to report a sorted list of words used across files in a source directory.
If the word is only used in one file, the file path is included, and if the word is only used once, the (line, column) are included.

Used as a simple mechanism for catching typos.