### PR TITLE
adding PostCompileBinaryModification so the ApplyOptimizations task runs

### DIFF
--- a/src/RepoToolset/OptimizationData.targets
+++ b/src/RepoToolset/OptimizationData.targets
@@ -8,6 +8,21 @@
     <_OptimizationDataFile>$([System.IO.Path]::GetFullPath('$(IbcOptimizationDataDir)$(TargetName).pgo'))</_OptimizationDataFile>
   </PropertyGroup>
 
+
+  <Target Name="PostCompileBinaryModification"
+          AfterTargets="CoreCompile"
+          DependsOnTargets="ApplyOptimizations"
+          Inputs="@(IntermediateAssembly)"
+          Outputs="@(IntermediateAssembly);$(PostCompileBinaryModificationSentinelFile)">
+
+    <!-- Write out a sentinel timestamp file to prevent unnecessary work in incremental builds. -->
+    <Touch AlwaysCreate="true" Files="$(PostCompileBinaryModificationSentinelFile)" />
+
+    <ItemGroup>
+      <FileWrites Include="$(PostCompileBinaryModificationSentinelFile)" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="ApplyOptimizations"
           Condition="Exists('$(_OptimizationDataFile)')"
           Inputs="@(IntermediateAssembly)"
@@ -22,7 +37,7 @@
     </PropertyGroup>
 
     <Message Text="IBCMerge tool will be run in an official build with arguments: $(_IbcMergeCommandLineArgs)" Condition="'$(_RunIbc)' != 'true'" Importance="normal"/>
-    
+
     <Exec Command='"$(_IbcMergePath)" $(_IbcMergeCommandLineArgs)' ConsoleToMSBuild="true" Condition="'$(_RunIbc)' == 'true'">
       <Output TaskParameter="ConsoleOutput" PropertyName="IbcMergeOutput" />
     </Exec>

--- a/src/RepoToolset/OptimizationData.targets
+++ b/src/RepoToolset/OptimizationData.targets
@@ -8,7 +8,8 @@
     <_OptimizationDataFile>$([System.IO.Path]::GetFullPath('$(IbcOptimizationDataDir)$(TargetName).pgo'))</_OptimizationDataFile>
   </PropertyGroup>
 
-
+  <!-- We need to write out this sentinel file so that when ApplyOptimizations runs and compares the intermediate assemby location
+       against itself the PostCompileBinaryModificationSentinelFile will have a newer timestamp allowing the target to be run.  -->
   <Target Name="PostCompileBinaryModification"
           AfterTargets="CoreCompile"
           DependsOnTargets="ApplyOptimizations"


### PR DESCRIPTION
unless we write out a sentinel file the `ApplyOptimizations` task will never run.

![image](https://user-images.githubusercontent.com/9797472/31782801-02df9700-b4b1-11e7-8862-68aa79956462.png)
