### PR TITLE
add auto-generated IVT file to F#'s CompileBefore collection

### DIFF
--- a/src/RepoToolset/GenerateInternalsVisibleTo.targets
+++ b/src/RepoToolset/GenerateInternalsVisibleTo.targets
@@ -39,7 +39,8 @@
     <WriteCodeFragment AssemblyAttributes="@(_InternalsVisibleToAttribute)"
                        Language="$(Language)"
                        OutputFile="$(GeneratedInternalsVisibleToFile)">
-      <Output TaskParameter="OutputFile" ItemName="Compile" />
+      <Output TaskParameter="OutputFile" ItemName="CompileBefore" Condition="'$(Language)' == 'F#'" />
+      <Output TaskParameter="OutputFile" ItemName="Compile" Condition="'$(Language)' != 'F#'" />
       <Output TaskParameter="OutputFile" ItemName="FileWrites" />
     </WriteCodeFragment>
   </Target>


### PR DESCRIPTION
This ensures that the IVT files are included before the remaining code files which ensures that a program's entry point is never overwritten.