### PR TITLE
Updating _TestRunnerCommand so we don't get an error on Linux.

### DIFF
--- a/src/RepoToolset/XUnit.targets
+++ b/src/RepoToolset/XUnit.targets
@@ -43,14 +43,14 @@
 
     <PropertyGroup Condition="'$(_RunOnCore)' == 'true'">
       <!-- TODO: xUnit doesn't support -html on CoreCLR currently (see https://github.com/xunit/xunit/issues/977) -->
-      <_TestRunnerCommand>"$(DotNetTool)" exec --depsfile "$(_CoreDepsPath)" --runtimeconfig "$(_CoreRuntimeConfigPath)" "$(NuGetPackageRoot)xunit.runner.console\$(XUnitVersion)\tools\netcoreapp1.0\xunit.console.dll" "$(TargetPath)" -noautoreporters -xml "$(_TestResultsXmlPath) $(XUnitRunnerAdditionalArguments)"</_TestRunnerCommand>
+      <_TestRunnerCommand>"$(DotNetTool)" exec --depsfile "$(_CoreDepsPath)" --runtimeconfig "$(_CoreRuntimeConfigPath)" "$(NuGetPackageRoot)xunit.runner.console/$(XUnitVersion)/tools/netcoreapp1.0/xunit.console.dll" "$(TargetPath)" -noautoreporters -xml "$(_TestResultsXmlPath)" $(XUnitRunnerAdditionalArguments)</_TestRunnerCommand>
       <_TestResultsDisplayPath>$(_TestStdOutPath)</_TestResultsDisplayPath>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(_RunOnCore)' != 'true'">
       <_XUnitConsoleExe>xunit.console.exe</_XUnitConsoleExe>
       <_XUnitConsoleExe Condition="'$(_TestArchitecture)' == 'x86'">xunit.console.x86.exe</_XUnitConsoleExe>
-      <_TestRunnerCommand>"$(NuGetPackageRoot)xunit.runner.console\$(XUnitVersion)\tools\net452\$(_XUnitConsoleExe)" "$(TargetPath)" -noshadow -xml "$(_TestResultsXmlPath)" -html "$(_TestResultsHtmlPath) $(XUnitRunnerAdditionalArguments)"</_TestRunnerCommand>
+      <_TestRunnerCommand>"$(NuGetPackageRoot)xunit.runner.console\$(XUnitVersion)\tools\net452\$(_XUnitConsoleExe)" "$(TargetPath)" -noshadow -xml "$(_TestResultsXmlPath)" -html "$(_TestResultsHtmlPath)" $(XUnitRunnerAdditionalArguments)</_TestRunnerCommand>
       <_TestResultsDisplayPath>$(_TestResultsHtmlPath)</_TestResultsDisplayPath>
     </PropertyGroup>
 


### PR DESCRIPTION
FYI. @tmat 

Error was: dotnet exec needs a managed .dll or .exe extension. The application specified was '/home/tagoo/.nuget/packages/xunit.runner.console\2.3.0\tools\netcoreapp1.0\xunit.console.dll'