### PR TITLE
POC for Orchestratable SignTool

### DIFF
--- a/sdks/RepoToolset/tools/Build.proj
+++ b/sdks/RepoToolset/tools/Build.proj
@@ -30,7 +30,6 @@
     PB_PublishBlobFeedKey  {''|string}                    Account key.
     
     PB_SigningOrchestrationConfig  {''|string}            Path to output Json for orchestrated-type signing (produce manifest that can be consumed later.)
-    PB_SigningOrchestrationMode    {''|'true'|'false'}    Set 'true' to have SignTool use manifests as provided above.
   -->
   <PropertyGroup>
     <RealSign>false</RealSign>
@@ -174,7 +173,7 @@
       Sign artifacts.
     -->
     <MSBuild Projects="Sign.proj"
-             Properties="$(_CommonProps);RealSign=$(RealSign);DirectoryBuildPropsPath=$(DirectoryBuildPropsPath);OutputConfigFile=$(PB_SigningOrchestrationConfig);OrchestrationMode=$(PB_SigningOrchestrationMode)"
+             Properties="$(_CommonProps);RealSign=$(RealSign);DirectoryBuildPropsPath=$(DirectoryBuildPropsPath);OutputConfigFile=$(PB_SigningOrchestrationConfig)"
              Targets="Sign"
              Condition="'$(Sign)' == 'true'"/>
 

--- a/sdks/RepoToolset/tools/Build.proj
+++ b/sdks/RepoToolset/tools/Build.proj
@@ -14,9 +14,11 @@
     Deploy            "true" to deploy assets (e.g. VSIXes)
     Test              "true" to run tests
     IntegrationTest   "true" to run integration tests
-    Sign              "true" to sign built binaries
     Pack              "true" to build NuGet packages and VS insertion manifests
+    Sign              "true" to sign built binaries
     SignType          "real" to send binaries to signing service, "test" to only validate signing configuration.
+    OrchestrationConfigFile 
+                      Path to output Json for orchestrated-type signing (produce manifest that can be consumed later.)
   -->
 
   <!-- 
@@ -171,7 +173,7 @@
       Sign artifacts.
     -->
     <MSBuild Projects="Sign.proj"
-             Properties="$(_CommonProps);RealSign=$(RealSign);DirectoryBuildPropsPath=$(DirectoryBuildPropsPath)"
+             Properties="$(_CommonProps);RealSign=$(RealSign);DirectoryBuildPropsPath=$(DirectoryBuildPropsPath);OrchestrationConfigFile=$(OrchestrationConfigFile)"
              Targets="Sign"
              Condition="'$(Sign)' == 'true'"/>
 

--- a/sdks/RepoToolset/tools/Build.proj
+++ b/sdks/RepoToolset/tools/Build.proj
@@ -17,8 +17,6 @@
     Pack              "true" to build NuGet packages and VS insertion manifests
     Sign              "true" to sign built binaries
     SignType          "real" to send binaries to signing service, "test" to only validate signing configuration.
-    OrchestrationConfigFile 
-                      Path to output Json for orchestrated-type signing (produce manifest that can be consumed later.)
   -->
 
   <!-- 
@@ -30,6 +28,9 @@
     PB_PublishType         {''|store1-store2-...-storeN}  List of stores where to publish assets to.
     PB_PublishBlobFeedUrl  {''|URL}                       Target feed URL.
     PB_PublishBlobFeedKey  {''|string}                    Account key.
+    
+    PB_SigningOrchestrationConfig  {''|string}            Path to output Json for orchestrated-type signing (produce manifest that can be consumed later.)
+    PB_SigningOrchestrationMode    {''|'true'|'false'}    Set 'true' to have SignTool use manifests as provided above.
   -->
   <PropertyGroup>
     <RealSign>false</RealSign>
@@ -173,7 +174,7 @@
       Sign artifacts.
     -->
     <MSBuild Projects="Sign.proj"
-             Properties="$(_CommonProps);RealSign=$(RealSign);DirectoryBuildPropsPath=$(DirectoryBuildPropsPath);OrchestrationConfigFile=$(OrchestrationConfigFile)"
+             Properties="$(_CommonProps);RealSign=$(RealSign);DirectoryBuildPropsPath=$(DirectoryBuildPropsPath);OutputConfigFile=$(PB_SigningOrchestrationConfig);OrchestrationMode=$(PB_SigningOrchestrationMode)"
              Targets="Sign"
              Condition="'$(Sign)' == 'true'"/>
 

--- a/sdks/RepoToolset/tools/Sign.proj
+++ b/sdks/RepoToolset/tools/Sign.proj
@@ -6,10 +6,9 @@
       RealSign                      "true" to send binaries to the signing service, "false" to only validate signing configuration.
 
     Optional parameters:
-      OrchestrationConfigFile       If specified, output a manifest similar to SignToolData.json but with checksums of all relevant files included 
-                                    for reassembly later when only zip archives are available.
-      OrchestrationMode             "true" if the input manifest is an orchestration manifest, false otherwise.  Will attempt to unpack all zips
-                                    provided and match on checksums for any missing files.
+      OutputConfigFile              If specified, output a manifest similar to SignToolData.json but with checksums of all relevant files included 
+                                    for reassembly later when only zip archives are available.  If this file is later used as the '-config' file, 
+                                    SignTool will attempt to unpack all zips provided and match on checksums for any missing files.
   -->
 
   <Import Project="$(DirectoryBuildPropsPath)" Condition="Exists('$(DirectoryBuildPropsPath)')"/>
@@ -25,8 +24,7 @@
     </Exec>
 
     <ItemGroup>
-      <SignToolArgs Condition="'$(OrchestrationMode)' == 'true'" Include='-orchestrationmode' />
-      <SignToolArgs Condition="'$(OrchestrationConfigFile)' != ''" Include='-orchestrationconfigfile "$(OrchestrationConfigFile)"' />      
+      <SignToolArgs Include='-outputconfig "$(OutputConfigFile)"' Condition="'$(OutputConfigFile)' != ''" />      
       <SignToolArgs Include='-nugetPackagesPath "$(NuGetPackageRoot)\"' />
       <SignToolArgs Include='-intermediateOutputPath "$(ArtifactsObjDir)\"' />
       <SignToolArgs Include='-config "$(SignToolDataPath)"' />

--- a/sdks/RepoToolset/tools/Sign.proj
+++ b/sdks/RepoToolset/tools/Sign.proj
@@ -4,6 +4,12 @@
     Required parameters:
       DirectoryBuildPropsPath       Path to the Directory.Build.props file in the repo root.
       RealSign                      "true" to send binaries to the signing service, "false" to only validate signing configuration.
+
+    Optional parameters:
+      OrchestrationConfigFile       If specified, output a manifest similar to SignToolData.json but with checksums of all relevant files included 
+                                    for reassembly later when only zip archives are available.
+      OrchestrationMode             "true" if the input manifest is an orchestration manifest, false otherwise.  Will attempt to unpack all zips
+                                    provided and match on checksums for any missing files.
   -->
 
   <Import Project="$(DirectoryBuildPropsPath)" Condition="Exists('$(DirectoryBuildPropsPath)')"/>
@@ -19,6 +25,8 @@
     </Exec>
 
     <ItemGroup>
+      <SignToolArgs Condition="'$(OrchestrationMode)' == 'true'" Include='-orchestrationmode' />
+      <SignToolArgs Condition="'$(OrchestrationConfigFile)' != ''" Include='-orchestrationconfigfile "$(OrchestrationConfigFile)"' />      
       <SignToolArgs Include='-nugetPackagesPath "$(NuGetPackageRoot)\"' />
       <SignToolArgs Include='-intermediateOutputPath "$(ArtifactsObjDir)\"' />
       <SignToolArgs Include='-config "$(SignToolDataPath)"' />
@@ -29,4 +37,5 @@
     
     <Exec Command="$(NuGetPackageRoot)roslyntools.microsoft.signtool\$(RoslynToolsMicrosoftSignToolVersion)\tools\SignTool.exe @(SignToolArgs, ' ')" />
   </Target>
+  
 </Project>

--- a/src/SignTool/SignTool/BatchSignInput.cs
+++ b/src/SignTool/SignTool/BatchSignInput.cs
@@ -125,8 +125,7 @@ namespace SignTool
             {
                 ContentUtil contentUtil = new ContentUtil();
 
-                // Get all Zip Archives in the manifest
-                // We'll use a non-immutable queue as we may need to add new zips to the list.
+                // Get all Zip Archives in the manifest recursively.
                 Queue<FileName> allZipsWeKnowAbout = new Queue<FileName>(ZipContainerNames);
 
                 while (allZipsWeKnowAbout.Count > 0)
@@ -168,7 +167,7 @@ namespace SignTool
                     if (matchFile == null)
                     {
                         success = false;
-                        missingFiles.AppendLine($"Unable to find {missingFileWithHashToFind.Name} with SHA256 hash '{missingFileWithHashToFind.SHA256Hash}'");
+                        missingFiles.AppendLine($"File: {missingFileWithHashToFind.Name} Hash: '{missingFileWithHashToFind.SHA256Hash}'");
                     }
                     else
                     {

--- a/src/SignTool/SignTool/BatchSignInput.cs
+++ b/src/SignTool/SignTool/BatchSignInput.cs
@@ -1,9 +1,13 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using SignTool.Json;
 
 namespace SignTool
 {
@@ -18,41 +22,46 @@ namespace SignTool
         internal string OutputPath { get; }
 
         /// <summary>
-        /// The ordered names of the files to be signed.  These are all relative paths off of the <see cref="OutputPath"/>
+        /// Uri, to be consumed by later steps, which describes where these files get published to.
+        /// </summary>
+        internal string PublishUri { get; }
+
+        /// <summary>
+        /// The ordered names of the files to be signed. These are all relative paths off of the <see cref="OutputPath"/>
         /// property.
         /// </summary>
         internal ImmutableArray<FileName> FileNames { get; }
 
         /// <summary>
-        /// These are binaries which are included in our zip containers but are already signed.  This list is used for 
-        /// validation purpsoes.  These are all flat names and cannot be relative paths.
+        /// These are binaries which are included in our zip containers but are already signed. This list is used for 
+        /// validation purposes. These are all flat names and cannot be relative paths.
         /// </summary>
-        internal ImmutableArray<string> ExternalFileNames { get;}
+        internal ImmutableArray<string> ExternalFileNames { get; }
 
         /// <summary>
-        /// Names of assemblies that need to be signed.  This is a subset of <see cref="FileNames"/>
+        /// Names of assemblies that need to be signed. This is a subset of <see cref="FileNames"/>
         /// </summary>
         internal ImmutableArray<FileName> AssemblyNames { get; }
 
         /// <summary>
-        /// Names of zip containers that need to be examined for signing.  This is a subset of <see cref="FileNames"/>
+        /// Names of zip containers that need to be examined for signing. This is a subset of <see cref="FileNames"/>
         /// </summary>
         internal ImmutableArray<FileName> ZipContainerNames { get; }
 
         /// <summary>
-        /// Names of other file types which aren't specifically handled by the tool.  This is a subset of <see cref="FileNames"/>
+        /// Names of other file types which aren't specifically handled by the tool. This is a subset of <see cref="FileNames"/>
         /// </summary>
         internal ImmutableArray<FileName> OtherNames { get; }
 
         /// <summary>
-        /// A map of all of the binaries that need to be signed to the actual signing data.
+        /// A map from all of the binaries that need to be signed to the actual signing data.
         /// </summary>
         internal ImmutableDictionary<FileName, FileSignInfo> FileSignInfoMap { get; }
 
-        internal BatchSignInput(string outputPath, Dictionary<string, SignInfo> fileSignDataMap, IEnumerable<string> externalFileNames)
+        internal BatchSignInput(string outputPath, Dictionary<string, SignInfo> fileSignDataMap, IEnumerable<string> externalFileNames, string publishUri)
         {
             OutputPath = outputPath;
-
+            PublishUri = publishUri;
             // Use order by to make the output of this tool as predictable as possible.
             var fileNames = fileSignDataMap.Keys;
             FileNames = fileNames.OrderBy(x => x).Select(x => new FileName(outputPath, x)).ToImmutableArray();
@@ -69,6 +78,111 @@ namespace SignTool
                 builder.Add(name, new FileSignInfo(name, data));
             }
             FileSignInfoMap = builder.ToImmutable();
+        }
+
+        internal BatchSignInput(string outputPath, Dictionary<FileSignDataEntry, SignInfo> fileSignDataMap, IEnumerable<string> externalFileNames, string publishUri)
+        {
+            OutputPath = outputPath;
+            PublishUri = publishUri;
+
+            List<FileName> fileNames = fileSignDataMap.Keys.Select(x => new FileName(outputPath, x.FilePath, x.SHA256Hash)).ToList();
+            ZipContainerNames = fileNames.Where(x => x.IsZipContainer).ToImmutableArray();
+            // If there's any files we can't find, recursively unpack the zip archives we just made a list of above.
+            UnpackMissingContent(ref fileNames);
+            // After this point, if the files are available execution should be as before.
+            // Use OrderBy to make the output of this tool as predictable as possible.
+            FileNames = fileNames.OrderBy(x => x.RelativePath).ToImmutableArray();
+            ExternalFileNames = externalFileNames.OrderBy(x => x).ToImmutableArray();
+            AssemblyNames = FileNames.Where(x => x.IsAssembly).ToImmutableArray();
+            OtherNames = FileNames.Where(x => !x.IsAssembly && !x.IsZipContainer).ToImmutableArray();
+
+            var builder = ImmutableDictionary.CreateBuilder<FileName, FileSignInfo>();
+            foreach (var name in FileNames)
+            {
+                var data = fileSignDataMap.Keys.Where(k => k.SHA256Hash == name.SHA256Hash).Single();
+                builder.Add(name, new FileSignInfo(name, fileSignDataMap[data]));
+            }
+            FileSignInfoMap = builder.ToImmutable();
+        }
+
+        private void UnpackMissingContent(ref List<FileName> candidateFileNames)
+        {
+            bool success = true;
+            string unpackingDirectory = Path.Combine(OutputPath, "UnpackedZipArchives");
+            StringBuilder missingFiles = new StringBuilder();
+            Directory.CreateDirectory(unpackingDirectory);
+
+            var unpackNeeded = (from file in candidateFileNames
+                                where !File.Exists(file.FullPath)
+                                select file).ToList();
+
+            // Nothing to do
+            if (unpackNeeded.Count() == 0)
+            {
+                return;
+            }
+            else
+            {
+                ContentUtil contentUtil = new ContentUtil();
+
+                // Get all Zip Archives in the manifest
+                // We'll use a non-immutable queue as we may need to add new zips to the list.
+                Queue<FileName> allZipsWeKnowAbout = new Queue<FileName>(ZipContainerNames);
+
+                while (allZipsWeKnowAbout.Count > 0)
+                {
+                    FileName zipFile = allZipsWeKnowAbout.Dequeue();
+                    string unpackFolder = Path.Combine(unpackingDirectory, zipFile.SHA256Hash);
+
+                    // Assumption:  If a zip with a given hash is already unpacked, it's probably OK.
+                    if (!Directory.Exists(unpackFolder))
+                    {
+                        Directory.CreateDirectory(unpackFolder);
+                        ZipFile.ExtractToDirectory(zipFile.FullPath, unpackFolder);
+                    }
+                    // Add any zips we just unzipped.
+                    foreach (string file in Directory.GetFiles(unpackFolder, "*", SearchOption.AllDirectories))
+                    {
+                        if (PathUtil.IsZipContainer(file))
+                        {
+                            string relativePath = (string)(new Uri(unpackingDirectory).MakeRelativeUri(new Uri(file))).OriginalString;
+                            allZipsWeKnowAbout.Enqueue(new FileName(unpackingDirectory, relativePath, contentUtil.GetChecksum(file)));
+                        }
+                    }
+                }
+                // Lazy : Disks are fast, just calculate ALL hashes.  Could optimize by only files we intend to sign
+                Dictionary<string, string> existingHashLookup = new Dictionary<string, string>();
+                foreach (string file in Directory.GetFiles(unpackingDirectory, "*", SearchOption.AllDirectories))
+                {
+                    existingHashLookup.Add(file, contentUtil.GetChecksum(file));
+                }
+
+                Dictionary<FileName, FileName> fileNameUpdates = new Dictionary<FileName, FileName>();
+                // At this point, we've unpacked every Zip we can possibly pull out into folders named for the zip's hash into 'unpackingDirectory'
+                foreach (FileName missingFileWithHashToFind in unpackNeeded)
+                {
+                    string matchFile = (from filePath in existingHashLookup.Keys
+                                        where Path.GetFileName(filePath).Equals(missingFileWithHashToFind.Name, StringComparison.OrdinalIgnoreCase)
+                                        where existingHashLookup[filePath] == missingFileWithHashToFind.SHA256Hash
+                                        select filePath).SingleOrDefault();
+                    if (matchFile == null)
+                    {
+                        success = false;
+                        missingFiles.AppendLine($"Unable to find {missingFileWithHashToFind.Name} with SHA256 hash '{missingFileWithHashToFind.SHA256Hash}'");
+                    }
+                    else
+                    {
+                        string relativePath = (string)(new Uri(OutputPath).MakeRelativeUri(new Uri(matchFile))).OriginalString.Replace('/', Path.DirectorySeparatorChar);
+                        FileName updatedFileName = new FileName(OutputPath, relativePath, missingFileWithHashToFind.SHA256Hash);
+                        candidateFileNames.Remove(missingFileWithHashToFind);
+                        candidateFileNames.Add(updatedFileName);
+                    }
+                }
+            }
+            if (!success)
+            {
+                throw new Exception($"Failure attempting to find one or more files:\n{missingFiles.ToString()}");
+            }
         }
     }
 }

--- a/src/SignTool/SignTool/BatchSignUtil.cs
+++ b/src/SignTool/SignTool/BatchSignUtil.cs
@@ -94,7 +94,7 @@ namespace SignTool
                     });
                 }
                 fileJsonWithInfo.SignList = newList.ToArray();
-
+                fileJsonWithInfo.Kind = "orchestration";
 
                 using (StreamWriter file = File.CreateText(outputPath))
                 {

--- a/src/SignTool/SignTool/ContentUtil.cs
+++ b/src/SignTool/SignTool/ContentUtil.cs
@@ -3,21 +3,18 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Security.Cryptography;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SignTool
 {
     internal sealed class ContentUtil
     {
         private readonly Dictionary<string, string> _filePathCache = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        private readonly MD5 _md5 = MD5.Create();
+        private readonly SHA256 _sha256 = SHA256.Create();
 
         internal string GetChecksum(Stream stream)
         {
-            var hash = _md5.ComputeHash(stream);
+            var hash = _sha256.ComputeHash(stream);
             return HashBytesToString(hash);
         }
 

--- a/src/SignTool/SignTool/FileName.cs
+++ b/src/SignTool/SignTool/FileName.cs
@@ -14,17 +14,19 @@ namespace SignTool
         internal string Name { get; }
         internal string FullPath { get; }
         internal string RelativePath { get; }
+        internal string SHA256Hash { get; }
 
         internal bool IsAssembly => PathUtil.IsAssembly(Name);
         internal bool IsVsix => PathUtil.IsVsix(Name);
         internal bool IsNupkg => PathUtil.IsVsix(Name);
         internal bool IsZipContainer => PathUtil.IsZipContainer(Name);
 
-        internal FileName(string rootBinaryPath, string relativePath)
+        internal FileName(string rootBinaryPath, string relativePath, string sha256Hash = null)
         {
             Name = Path.GetFileName(relativePath);
             FullPath = Path.Combine(rootBinaryPath, relativePath);
             RelativePath = relativePath;
+            SHA256Hash = sha256Hash;
         }
 
         public static bool operator ==(FileName left, FileName right) => left.FullPath == right.FullPath;

--- a/src/SignTool/SignTool/JsonTypes.cs
+++ b/src/SignTool/SignTool/JsonTypes.cs
@@ -1,16 +1,14 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 namespace SignTool.Json
 {
     internal sealed class FileJson
     {
+        [JsonProperty(PropertyName = "publishUrl")]
+        public string PublishUrl { get; set; }
+
         [JsonProperty(PropertyName = "sign")]
         public FileSignData[] SignList { get; set; }
 
@@ -23,18 +21,61 @@ namespace SignTool.Json
         }
     }
 
-    internal sealed class FileSignData
+    internal sealed class OrchestratedFileJson
     {
-        [JsonProperty(PropertyName = "certificate")]
+        [JsonProperty(PropertyName = "sign")]
+        public OrchestratedFileSignData[] SignList { get; set; }
+
+        [JsonProperty(PropertyName = "exclude")]
+        public string[] ExcludeList { get; set; }
+
+        public OrchestratedFileJson()
+        {
+        }
+    }
+
+    internal class FileSignDataBase
+    {
+        [JsonProperty(PropertyName = "certificate", Order = 1)]
         public string Certificate { get; set; }
 
-        [JsonProperty(PropertyName = "strongName")]
+        [JsonProperty(PropertyName = "strongName", Order = 2)]
         public string StrongName { get; set; }
+    }
 
-        [JsonProperty(PropertyName = "values")]
+
+    internal sealed class FileSignData : FileSignDataBase
+    {
+        [JsonProperty(PropertyName = "values", Order = 3)]
         public string[] FileList { get; set; }
 
         public FileSignData()
+        {
+        }
+    }
+
+    internal sealed class OrchestratedFileSignData : FileSignDataBase
+    {
+        [JsonProperty(PropertyName = "values", Order = 3)]
+        public FileSignDataEntry[] FileList { get; set; }
+
+        public OrchestratedFileSignData()
+        {
+        }
+    }
+
+    internal sealed class FileSignDataEntry
+    {
+        [JsonProperty(PropertyName = "filePath")]
+        public string FilePath { get; set; }
+
+        [JsonProperty(PropertyName = "sha256Hash")]
+        public string SHA256Hash { get; set; }
+
+        [JsonProperty(PropertyName = "publishtofeedurl")]
+        public string PublishToFeedUrl { get; set; }
+
+        public FileSignDataEntry()
         {
         }
     }

--- a/src/SignTool/SignTool/JsonTypes.cs
+++ b/src/SignTool/SignTool/JsonTypes.cs
@@ -6,6 +6,9 @@ namespace SignTool.Json
 {
     internal sealed class FileJson
     {
+        [JsonProperty(PropertyName = "kind")]
+        public string Kind { get; set; }
+
         [JsonProperty(PropertyName = "publishUrl")]
         public string PublishUrl { get; set; }
 
@@ -23,6 +26,9 @@ namespace SignTool.Json
 
     internal sealed class OrchestratedFileJson
     {
+        [JsonProperty(PropertyName = "kind")]
+        public string Kind { get; set; }
+
         [JsonProperty(PropertyName = "sign")]
         public OrchestratedFileSignData[] SignList { get; set; }
 

--- a/src/SignTool/SignTool/OrchestratedBatchSignInput.cs
+++ b/src/SignTool/SignTool/OrchestratedBatchSignInput.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using SignTool.Json;
+
+namespace SignTool
+{
+    /// <summary>
+    /// Represents a preprocessed version of all of the input to the batch signing process.
+    /// </summary>
+    internal sealed class OrchestratedBatchSignInput
+    {
+        /// <summary>
+        /// The path where the binaries are built to: e:\path\to\source\Binaries\Debug
+        /// </summary>
+        internal string OutputPath { get; }
+
+        /// <summary>
+        /// The path where the binaries are built to: e:\path\to\source\Binaries\Debug
+        /// </summary>
+        internal string PublishUri { get; }
+
+        /// <summary>
+        /// The ordered names of the files to be signed. These are all relative paths off of the <see cref="OutputPath"/>
+        /// property.
+        /// </summary>
+        internal ImmutableArray<FileName> FileNames { get; }
+
+        /// <summary>
+        /// These are binaries which are included in our zip containers but are already signed. This list is used for 
+        /// validation purposes. These are all flat names and cannot be relative paths.
+        /// </summary>
+        internal ImmutableArray<string> ExternalFileNames { get;}
+
+        /// <summary>
+        /// Names of assemblies that need to be signed. This is a subset of <see cref="FileNames"/>
+        /// </summary>
+        internal ImmutableArray<FileName> AssemblyNames { get; }
+
+        /// <summary>
+        /// Names of zip containers that need to be examined for signing. This is a subset of <see cref="FileNames"/>
+        /// </summary>
+        internal ImmutableArray<FileName> ZipContainerNames { get; }
+
+        /// <summary>
+        /// Names of other file types which aren't specifically handled by the tool. This is a subset of <see cref="FileNames"/>
+        /// </summary>
+        internal ImmutableArray<FileName> OtherNames { get; }
+
+        /// <summary>
+        /// A map from all of the binaries that need to be signed to the actual signing data.
+        /// </summary>
+        internal ImmutableDictionary<FileName, FileSignInfo> FileSignInfoMap { get; }
+
+        internal OrchestratedBatchSignInput(string outputPath, Dictionary<string, SignInfo> fileSignDataMap, IEnumerable<string> externalFileNames, string publishUri)
+        {
+            OutputPath = outputPath;
+            PublishUri = publishUri;
+            // Use order by to make the output of this tool as predictable as possible.
+            var fileNames = fileSignDataMap.Keys;
+            FileNames = fileNames.OrderBy(x => x).Select(x => new FileName(outputPath, x)).ToImmutableArray();
+            ExternalFileNames = externalFileNames.OrderBy(x => x).ToImmutableArray();
+
+            AssemblyNames = FileNames.Where(x => x.IsAssembly).ToImmutableArray();
+            ZipContainerNames = FileNames.Where(x => x.IsZipContainer).ToImmutableArray();
+            OtherNames = FileNames.Where(x => !x.IsAssembly && !x.IsZipContainer).ToImmutableArray();
+
+            var builder = ImmutableDictionary.CreateBuilder<FileName, FileSignInfo>();
+            foreach (var name in FileNames)
+            {
+                var data = fileSignDataMap[name.RelativePath];
+                builder.Add(name, new FileSignInfo(name, data));
+            }
+            FileSignInfoMap = builder.ToImmutable();
+        }
+    }
+}
+

--- a/src/SignTool/SignTool/PathUtil.cs
+++ b/src/SignTool/SignTool/PathUtil.cs
@@ -9,8 +9,8 @@ namespace SignTool
 {
     internal static class PathUtil
     {
-        internal static bool IsVsix(string fileName) => Path.GetExtension(fileName) == ".vsix";
-        internal static bool IsNupkg(string fileName) => Path.GetExtension(fileName) == ".nupkg";
+        internal static bool IsVsix(string fileName) => Path.GetExtension(fileName).Equals(".vsix", StringComparison.OrdinalIgnoreCase);
+        internal static bool IsNupkg(string fileName) => Path.GetExtension(fileName).Equals(".nupkg", StringComparison.OrdinalIgnoreCase);
 
         internal static bool IsZipContainer(string fileName) =>
             IsVsix(fileName) ||

--- a/src/SignTool/SignTool/Program.cs
+++ b/src/SignTool/SignTool/Program.cs
@@ -231,7 +231,6 @@ orchestrationConfigFile: Run tool to produce an orchestration json file.  This w
             string outputConfigFile = null;
             var test = false;
             var testSign = false;
-            var orchestrationMode = false;
 
             var i = 0;
 
@@ -246,10 +245,6 @@ orchestrationConfigFile: Run tool to produce an orchestration json file.  This w
                         break;
                     case "-testsign":
                         testSign = true;
-                        i++;
-                        break;
-                    case "-orchestrationmode":
-                        orchestrationMode = true;
                         i++;
                         break;
                     case "-intermediateoutputpath":
@@ -287,12 +282,6 @@ orchestrationConfigFile: Run tool to produce an orchestration json file.  This w
                         Console.Error.WriteLine($"Unrecognized option {current}");
                         return false;
                 }
-            }
-
-            if (orchestrationMode && !string.IsNullOrEmpty(outputConfigFile))
-            {
-                Console.WriteLine("Please specify either -orchestrationmode (signing multiple json manifests with SHA256 entries) or a value for -outputconfig to generate such a manifest, but not both.");
-                return false;
             }
 
             if (i + 1 != args.Length)

--- a/src/SignTool/SignTool/Program.cs
+++ b/src/SignTool/SignTool/Program.cs
@@ -205,13 +205,12 @@ namespace SignTool
 
 test: Run tool without actually modifying any state.
 testSign: The binaries will be test signed. The default is to real sign.
-orchestrationmode:  Support comma-separated list of one or more config files in the format outputted using the 'orchestrationConfigFile' argument.
 outputPath: Directory containing the binaries.
 intermediateOutputPath: Directory containing intermediate output.  Default is (outputpath\..\Obj).
 nugetPackagesPath: Path containing downloaded NuGet packages.
 msbuildPath: Path to MSBuild.exe to use as signing mechanism.
 config: Path to SignToolData.json. Default: build\config\SignToolData.json.
-orchestrationConfigFile: Run tool to produce an orchestration json file.  This will contain SHA256 hashes of files for verification to consume later.  Cannot be used with -orchestrationmode
+outputConfig: Run tool to produce an orchestration json file with specified name.  This will contain SHA256 hashes of files for verification to consume later.
 ";
             Console.WriteLine(usage);
         }

--- a/src/SignTool/SignTool/Program.cs
+++ b/src/SignTool/SignTool/Program.cs
@@ -2,14 +2,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
 using Newtonsoft.Json;
+using SignTool.Json;
 
 namespace SignTool
 {
@@ -20,8 +18,7 @@ namespace SignTool
 
         internal static int Main(string[] args)
         {
-            SignToolArgs signToolArgs;
-            if (!ParseCommandLineArguments(StandardHost.Instance, args, out signToolArgs))
+            if (!ParseCommandLineArguments(StandardHost.Instance, args, out SignToolArgs signToolArgs))
             {
                 PrintUsage();
                 return ExitFailure;
@@ -33,9 +30,17 @@ namespace SignTool
                 return ExitFailure;
             }
 
+            BatchSignInput batchData;
             var signTool = SignToolFactory.Create(signToolArgs);
-            var batchData = ReadConfigFile(signToolArgs.OutputPath, signToolArgs.ConfigFile);
-            var util = new BatchSignUtil(signTool, batchData);
+            if (signToolArgs.OrchestrationMode)
+            {
+                batchData = ReadOrchestrationConfigFile(signToolArgs.OutputPath, signToolArgs.ConfigFile);
+            }
+            else
+            {
+                batchData = ReadConfigFile(signToolArgs.OutputPath, signToolArgs.ConfigFile);
+            }
+            var util = new BatchSignUtil(signTool, batchData, signToolArgs.OrchestrationManifestPath);
             try
             {
                 return util.Go(Console.Out) ? ExitSuccess : ExitFailure;
@@ -52,12 +57,10 @@ namespace SignTool
         {
             using (var file = File.OpenText(configFile))
             {
-                BatchSignInput batchData;
-                if (!TryReadConfigFile(Console.Out, file, outputPath, out batchData))
+                if (!TryReadConfigFile(Console.Out, file, outputPath, out BatchSignInput batchData))
                 {
                     Environment.Exit(ExitFailure);
                 }
-
                 return batchData;
             }
         }
@@ -91,13 +94,64 @@ namespace SignTool
                 return false;
             }
 
-            batchData = new BatchSignInput(outputPath, map, fileJson.ExcludeList ?? Array.Empty<string>());
+            batchData = new BatchSignInput(outputPath, map, fileJson.ExcludeList ?? Array.Empty<string>(), fileJson.PublishUrl ?? "unset");
             return true;
         }
 
+        internal static BatchSignInput ReadOrchestrationConfigFile(string outputPath, string configFile)
+        {
+            using (var file = File.OpenText(configFile))
+            {
+                if (!TryReadOrchestrationConfigFile(Console.Out, file, outputPath, out BatchSignInput batchData))
+                {
+                    Environment.Exit(ExitFailure);
+                }
+                return batchData;
+            }
+        }
+
+        internal static bool TryReadOrchestrationConfigFile(TextWriter output, TextReader configReader, string outputPath, out BatchSignInput batchData)
+        {
+            var serializer = new JsonSerializer();
+            var fileJson = (Json.OrchestratedFileJson)serializer.Deserialize(configReader, typeof(Json.OrchestratedFileJson));
+            var map = new Dictionary<FileSignDataEntry, SignInfo>();
+            // For now, a given json file will be assumed to serialize to one place and we'll throw otherwise
+            string publishUrl = (from OrchestratedFileSignData entry in fileJson.SignList
+                                 from FileSignDataEntry fileToSign in entry.FileList
+                                 select fileToSign.PublishToFeedUrl).Distinct().Single();
+            var allGood = true;
+            foreach (var item in fileJson.SignList)
+            {
+                var data = new SignInfo(certificate: item.Certificate, strongName: item.StrongName);
+                
+                foreach (FileSignDataEntry entry in item.FileList)
+                {
+                    if (map.ContainsKey(entry))
+                    {
+                        Console.WriteLine($"Duplicate signing info entry for: {entry.FilePath}");
+                        allGood = false;
+                    }
+                    else
+                    {
+                        map.Add(entry, data);
+                    }
+                }
+            }
+
+            if (!allGood)
+            {
+                batchData = null;
+                return false;
+            }
+
+            batchData = new BatchSignInput(outputPath, map, fileJson.ExcludeList ?? Array.Empty<string>(), publishUrl );
+            return true;
+        }
+
+
         /// <summary>
-        /// The files to sign section supports globbing. The only caveat is that globs must expand to match at least a 
-        /// single file else an error occurs. This function will expand those globas as necessary.
+        /// The 'files to sign' section supports globbing. The only caveat is that globs must expand to match at least a 
+        /// single file else an error occurs. This function will expand those globs as necessary.
         /// </summary>
         private static List<string> ExpandFileList(string outputPath, IEnumerable<string> relativeFileNames, ref bool allGood)
         {
@@ -143,11 +197,13 @@ namespace SignTool
 
 test: Run tool without actually modifying any state.
 testSign: The binaries will be test signed. The default is to real sign.
+orchestrationmode:  Support comma-separated list of one or more config files in the format outputted using the 'orchestrationConfigFile' argument.
 outputPath: Directory containing the binaries.
 intermediateOutputPath: Directory containing intermediate output.  Default is (outputpath\..\Obj).
 nugetPackagesPath: Path containing downloaded NuGet packages.
 msbuildPath: Path to MSBuild.exe to use as signing mechanism.
-config: Path to SignToolData.json. Default build\config\SignToolData.json.
+config: Path to SignToolData.json. Default: build\config\SignToolData.json.
+orchestrationConfigFile: Run tool to produce an orchestration json file.  This will contain SHA256 hashes of files for verification to consume later.  Cannot be used with -orchestrationmode
 ";
             Console.WriteLine(usage);
         }
@@ -164,8 +220,10 @@ config: Path to SignToolData.json. Default build\config\SignToolData.json.
             string msbuildPath = null;
             string nugetPackagesPath = null;
             string configFile = null;
+            string orchestrationConfigFile = null;
             var test = false;
             var testSign = false;
+            var orchestrationMode = false;
 
             var i = 0;
 
@@ -180,6 +238,10 @@ config: Path to SignToolData.json. Default build\config\SignToolData.json.
                         break;
                     case "-testsign":
                         testSign = true;
+                        i++;
+                        break;
+                    case "-orchestrationmode":
+                        orchestrationMode = true;
                         i++;
                         break;
                     case "-intermediateoutputpath":
@@ -206,10 +268,23 @@ config: Path to SignToolData.json. Default build\config\SignToolData.json.
                             return false;
                         }
                         break;
+                    case "-orchestrationconfigfile":
+                        if (!ParsePathOption(args, ref i, current, out orchestrationConfigFile))
+                        {
+                            return false;
+                        }
+                        orchestrationConfigFile = orchestrationConfigFile.TrimEnd('\"').TrimStart('\"');
+                        break;
                     default:
                         Console.Error.WriteLine($"Unrecognized option {current}");
                         return false;
                 }
+            }
+
+            if (orchestrationMode && !string.IsNullOrEmpty(orchestrationConfigFile))
+            {
+                Console.WriteLine("Please specify either -orchestrationmode (for signing multiple json manifests w/ SHA256 entries) or a value for -orchestrationconfigfile to generate such a manifest, but not both.");
+                return false;
             }
 
             if (i + 1 != args.Length)
@@ -256,7 +331,9 @@ config: Path to SignToolData.json. Default build\config\SignToolData.json.
                 appPath: AppContext.BaseDirectory,
                 configFile: configFile,
                 test: test,
-                testSign: testSign);
+                testSign: testSign,
+                orchestrationManifestPath: orchestrationConfigFile,
+                orchestrationMode: orchestrationMode);
             return true;
         }
 
@@ -287,7 +364,6 @@ config: Path to SignToolData.json. Default build\config\SignToolData.json.
 
                 current = Path.GetDirectoryName(current);
             }
-
             return null;
         }
     }

--- a/src/SignTool/SignTool/SignToolArgs.cs
+++ b/src/SignTool/SignTool/SignToolArgs.cs
@@ -9,7 +9,6 @@ namespace SignTool
         internal string MSBuildPath { get; }
         internal string ConfigFile { get; }
         internal bool Test { get; }
-        internal bool OrchestrationMode { get; }
         internal bool TestSign { get; }
         internal string OrchestrationManifestPath { get; }
 
@@ -22,7 +21,6 @@ namespace SignTool
             string configFile,
             bool test,
             bool testSign,
-            bool orchestrationMode,
             string orchestrationManifestPath
             )
         {
@@ -35,7 +33,6 @@ namespace SignTool
             Test = test;
             TestSign = testSign;
             OrchestrationManifestPath = orchestrationManifestPath;
-            OrchestrationMode = orchestrationMode;
         }
     }
 }

--- a/src/SignTool/SignTool/SignToolArgs.cs
+++ b/src/SignTool/SignTool/SignToolArgs.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace SignTool
 {
     internal struct SignToolArgs
@@ -15,7 +9,9 @@ namespace SignTool
         internal string MSBuildPath { get; }
         internal string ConfigFile { get; }
         internal bool Test { get; }
+        internal bool OrchestrationMode { get; }
         internal bool TestSign { get; }
+        internal string OrchestrationManifestPath { get; }
 
         internal SignToolArgs(
             string outputPath,
@@ -25,7 +21,10 @@ namespace SignTool
             string nugetPackagesPath,
             string configFile,
             bool test,
-            bool testSign)
+            bool testSign,
+            bool orchestrationMode,
+            string orchestrationManifestPath
+            )
         {
             OutputPath = outputPath;
             IntermediateOutputPath = intermediateOutputPath;
@@ -35,6 +34,8 @@ namespace SignTool
             ConfigFile = configFile;
             Test = test;
             TestSign = testSign;
+            OrchestrationManifestPath = orchestrationManifestPath;
+            OrchestrationMode = orchestrationMode;
         }
     }
 }

--- a/src/SignTool/SignTool/ZipData.cs
+++ b/src/SignTool/SignTool/ZipData.cs
@@ -1,11 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SignTool
 {


### PR DESCRIPTION
Not yet ready to merge but it's taken longer than I'd like to get something that works, so I'd like to get some feedback from @jaredpar and @tmat if possible.

Still need to test with a "real" build definition but this will require the supported functionality be turned on in a build of the Roslyn Repo Toolset.

How this is expected to work:

1) Run as normal but with argument -OrchestrationConfigFile **_Path to output file_**.  This will make a file similar to the existing SignToolData.Json but with some more info (theoretically enough to do the signing later).  For instance, running this on the symreader repo yields something like this:

```
{
  "kind": "orchestration",
  "sign": [
    {
      "certificate": "MicrosoftSHA1Win8WinBlue",
      "strongName": "MsSharedLib72",
      "values": [
        {
          "filePath": "bin/Microsoft.DiaSymReader/net20/Microsoft.DiaSymReader.dll",
          "sha256Hash": "72D86688EE6A5F7A85387766A8876F747E8A41C7D030933482A25297659CE264",
          "publishtofeedurl": "https://dotnet.myget.org/F/symreader/api/v3/index.json"
        }
      ]
    },
    {
      "certificate": "WindowsPhone623",
      "strongName": "MsSharedLib72",
      "values": [
        {
          "filePath": "bin/Microsoft.DiaSymReader/netstandard1.1/Microsoft.DiaSymReader.dll",
          "sha256Hash": "1123BCD4CF2E3E2B34CF2A49B1FD22BEAD32902EE793DBCA85E1DEE0D9C688EE",
          "publishtofeedurl": "https://dotnet.myget.org/F/symreader/api/v3/index.json"
        }
      ]
    },
    {
      "certificate": null,
      "strongName": null,
      "values": [
        {
          "filePath": "packages\\Microsoft.DiaSymReader.1.3.0-ci.nupkg",
          "sha256Hash": "A110FE52C49551E2693E54F4DD019C7B8538F1CFABE99B5C2D0B6222BF688181",
          "publishtofeedurl": "https://dotnet.myget.org/F/symreader/api/v3/index.json"
        }
      ]
    }
  ],
  "exclude": []
}
```
from this original file: https://github.com/dotnet/symreader/blob/master/build/SignToolData.json

2)  Later on, bring down the contents of the previous run's OutputPath and run as normal except passing in the new JSON file and the argument OrchestrationMode to trigger using the new format.
Signtool will then try to find every file (using SHA256 to match) listed in all archives provided.  If the files are loose on disk, it leaves them alone;  if they are only inside archives, it will recursively unpack archives to find them.

3) (Theoretical at this point) SignTool execution continues as normal.



