### PR TITLE
Update package feed to new sleet feed

### DIFF
--- a/sdks/RepoToolset/tools/Tools.proj
+++ b/sdks/RepoToolset/tools/Tools.proj
@@ -10,7 +10,7 @@
     <_RestoreSources Include="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json"/>
     <_RestoreSources Include="https://dotnet.myget.org/F/symreader-converter/api/v3/index.json"
                      Condition="'$(UsingToolPdbConverter)' == 'true' and $(MicrosoftDiaSymReaderPdb2PdbVersion.Contains('-'))"/>
-    <_RestoreSources Include="https://dotnetfeed.blob.core.windows.net/dotnet-core/packages/index.json"
+    <_RestoreSources Include="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json"
                      Condition="'$(UsingPipeBuildPublishing)' == 'true'" />
   </ItemGroup>
   <PropertyGroup>


### PR DESCRIPTION
The packages/index.json feed was deprecated a bit back, which is why we were getting failures restoring the feed tasks package in the orchestrated build.