### PR TITLE
Allow artifacts directory to be overridden

### DIFF
--- a/sdks/RepoToolset/RepoToolset.csproj
+++ b/sdks/RepoToolset/RepoToolset.csproj
@@ -9,6 +9,10 @@
     <NuspecProperties>version=$(Version);licenseUrl=$(PackageLicenseUrl);repoUrl=$(RepositoryUrl);copyright=$(Copyright);ArtifactsBinDir=$(ArtifactsBinDir)</NuspecProperties>
   </PropertyGroup>
   <ItemGroup>
+    <!-- Show .*proj files in solution explorer, which are excluded by default -->
+    <None Include="tools\*.*proj" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="$(RepoRoot)src\BuildTasks\RoslynTools.BuildTasks.csproj" />
   </ItemGroup>
 </Project>

--- a/sdks/RepoToolset/tools/Directory.Build.props
+++ b/sdks/RepoToolset/tools/Directory.Build.props
@@ -1,4 +1,5 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project>
-  
+  <!-- This is an empty Directory.Build.props file to prevent the Directory.Build.props file from the repo from being used
+       when building Build.proj if the repo toolset targets are imported directly from the repo -->
 </Project>

--- a/sdks/RepoToolset/tools/Directory.Build.props
+++ b/sdks/RepoToolset/tools/Directory.Build.props
@@ -1,0 +1,4 @@
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
+  
+</Project>

--- a/sdks/RepoToolset/tools/Directory.Build.targets
+++ b/sdks/RepoToolset/tools/Directory.Build.targets
@@ -1,0 +1,4 @@
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
+
+</Project>

--- a/sdks/RepoToolset/tools/Directory.Build.targets
+++ b/sdks/RepoToolset/tools/Directory.Build.targets
@@ -1,4 +1,5 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project>
-
+  <!-- This is an empty Directory.Build.targets file to prevent the Directory.Build.targets file from the repo from being used
+       when building Build.proj if the repo toolset targets are imported directly from the repo -->
 </Project>

--- a/sdks/RepoToolset/tools/RepoLayout.props
+++ b/sdks/RepoToolset/tools/RepoLayout.props
@@ -19,7 +19,7 @@
   <PropertyGroup>
     <DotNetTool>$(DotNetRoot)dotnet</DotNetTool>
     <DotNetTool Condition="'$(OS)' == 'Windows_NT'">$(DotNetTool).exe</DotNetTool>
-    <ArtifactsDir>$(RepoRoot)artifacts\</ArtifactsDir>
+    <ArtifactsDir Condition="'$(ArtifactsDir)' == ''">$(RepoRoot)artifacts\</ArtifactsDir>
     <ArtifactsToolsetDir>$(ArtifactsDir)toolset\</ArtifactsToolsetDir>
     <ArtifactsConfigurationDir>$(ArtifactsDir)$(Configuration)\</ArtifactsConfigurationDir>
     <ArtifactsBinDir>$(ArtifactsConfigurationDir)bin\</ArtifactsBinDir>


### PR DESCRIPTION
- Allow `ArtifactsDir` to be overridden.  This will let MSBuild build itself, and then use the built version of MSBuild to build itself again to
a different (stage 2) artifacts directory
- Add empty Directory.Build files in repo toolset targets folder.  This prevents Directory.Build.props and Directory.Build.targets being picked up when building Build.proj.
This allows you to set the `RepoToolsetDir` in another repo to a local repo for roslyn-tools to test out local changes.
- Show `.*proj` files (for example Build.proj) in solution explorer