### PR TITLE
Fixing the official build version to not longer go over 65535

### DIFF
--- a/sdks/RepoToolset/tools/Version.props
+++ b/sdks/RepoToolset/tools/Version.props
@@ -36,8 +36,18 @@
   <Choose>
     <When Condition="'$(OfficialBuild)' == 'true'">
       <PropertyGroup>
-        <_BuildNumberFiveDigitDateStamp>$([MSBuild]::Subtract($(BUILD_BUILDNUMBER.Split('.')[0].Substring(3).Trim()), 8800))</_BuildNumberFiveDigitDateStamp>
-        <_BuildNumberBuildOfTheDayPadded>$(BUILD_BUILDNUMBER.Split('.')[1].PadLeft(2,'0'))</_BuildNumberBuildOfTheDayPadded>
+        <!-- Split the build parts out from the BuildNumber which is given to us by MicroBuild in the format of yyyymmdd.nn
+         where BuildNumberFiveDigitDateStamp is mmmdd (such as 60615) and BuildNumberBuildOfTheDay is nn (which represents the nth build
+         started that day). So the first build of the day, 20160615.1, will produce something similar to BuildNumberFiveDigitDateStamp: 60615,
+         BuildNumberBuildOfTheDayPadded: 01;and the 12th build of the day, 20160615.12, will produce BuildNumberFiveDigitDateStamp: 60615, BuildNumberBuildOfTheDay: 12
+
+         Additionally, in order ensure the value fits in the 16-bit PE header fields, we will only take the last five digits of the BuildNumber, so
+         in the case of 20160615, we will set BuildNumberFiveDigitDateStamp to 60615. Further, if this would result in a number like 71201 or 81201, we
+         decrement the year and add 12 to the month to extend the time. -->
+        <_BuildNumberFiveDigitDateStamp>$([MSBuild]::Subtract($(BuildNumber.Split($([System.Convert]::ToString(`.`).ToCharArray())).GetValue($([System.Convert]::ToInt32(0)))), 20100000))</_BuildNumberFiveDigitDateStamp>
+        <_BuildNumberFiveDigitDateStampYearsToOffset>$([System.Math]::Max($([System.Convert]::ToInt32($([MSBuild]::Subtract($([MSBuild]::Divide($(BuildNumberFiveDigitDateStamp), 10000)), 6)))), $([System.Convert]::ToInt32(0))))</_BuildNumberFiveDigitDateStampYearsToOffset>
+        <_BuildNumberFiveDigitDateStamp>$([MSBuild]::Subtract($([System.Convert]::ToInt32($(BuildNumberFiveDigitDateStamp))), $([MSBuild]::Multiply($(_BuildNumberFiveDigitDateStampYearsToOffset), 8800))))</_BuildNumberFiveDigitDateStamp>
+        <_BuildNumberBuildOfTheDayPadded>$(BuildNumber.Split($([System.Convert]::ToString(`.`).ToCharArray())).GetValue($([System.Convert]::ToInt32(1))).PadLeft($([System.Convert]::ToInt32(2)), $([System.Convert]::ToChar(`0`))))</_BuildNumberBuildOfTheDayPadded>
         <Version>$(VersionBase)</Version>
         <Version Condition="'$(PreReleaseVersionLabel)' != ''">$(Version)-$(PreReleaseVersionLabel)-$(_BuildNumberFiveDigitDateStamp)-$(_BuildNumberBuildOfTheDayPadded)</Version>
         <FileVersion>$(VersionBase).$(_BuildNumberFiveDigitDateStamp)</FileVersion>


### PR DESCRIPTION
FYI. @jaredpar, @jasonmalinowski, @tmat 

Port of https://github.com/dotnet/roslyn/pull/23999