### PR TITLE
Remove incorrect condition

### DIFF
--- a/sdks/RepoToolset/tools/Build.proj
+++ b/sdks/RepoToolset/tools/Build.proj
@@ -211,7 +211,7 @@
     <MSBuild Projects="VisualStudio.Insertion.proj"
              Properties="@(_CommonProps)"
              Targets="Pack"
-             Condition="'$(Pack)' == 'true' and '$(UsingToolVSSDK)' == 'true'"/>
+             Condition="'$(Pack)' == 'true'"/>
 
     <MSBuild Projects="PipeBuild.Publish.proj"
              Properties="@(_CommonProps);ExpectedFeedUrl=$(PB_PublishBlobFeedUrl);AccountKey=$(PB_PublishBlobFeedKey)"


### PR DESCRIPTION
Since we no longer import versions.props in build.proj ```$(UsingToolVSSDK)``` is not available. ```VisualStudio.Insertion.proj``` is a no-op for non-VSSDK repos anyways, so the condition was unnecessary.