### PR TITLE
Make GetBuildVersion target optional to avoid conflict with Nerdbank.GitVersioning

### DIFF
--- a/sdks/RepoToolset/tools/GetBuildVersion.targets
+++ b/sdks/RepoToolset/tools/GetBuildVersion.targets
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
+  
+  <!-- Returns the current build version. Used in .vsixmanifests to substitute our build version into them.
+      This target is defined in its own file so that it can be conditionally defined.  This is so it is
+      possible to avoid conflicts with https://github.com/AArnott/Nerdbank.GitVersioning, which also
+      defines a GetBuildVersion target.
+  -->
+  <Target Name="GetBuildVersion" Outputs="$(VsixVersion)" />
+
+</Project>

--- a/sdks/RepoToolset/tools/VisualStudio.targets
+++ b/sdks/RepoToolset/tools/VisualStudio.targets
@@ -243,7 +243,15 @@
     <GetVsixSourceItemsDependsOn>$(GetVsixSourceItemsDependsOn);_GetVsixTemplateItems</GetVsixSourceItemsDependsOn>
   </PropertyGroup>
 
-  <!-- Returns the current build version. Used in .vsixmanifests to substitute our build version into them -->
-  <Target Name="GetBuildVersion" Outputs="$(VsixVersion)" />
+  <!-- Conditionally import a .targets file with the GetBuildVersion target in it.
+      This target is defined in its own file so that it can be conditionally defined.  This is so it is
+      possible to avoid conflicts with https://github.com/AArnott/Nerdbank.GitVersioning, which also
+      defines a GetBuildVersion target.
+  -->
+
+  <PropertyGroup>
+    <DefineGetBuildVersionTargetForVsix Condition="'$(DefineGetBuildVersionTargetForVsix)' == ''">true</DefineGetBuildVersionTargetForVsix>
+  </PropertyGroup>
+  <Import Project="GetBuildVersion.targets" Condition="'$(DefineGetBuildVersionTargetForVsix)' == 'true'"/>
 
 </Project>


### PR DESCRIPTION
The [Nerdbank.GitVersioning](https://github.com/AArnott/Nerdbank.GitVersioning) package defines a `GetBuildVersion` target: https://github.com/AArnott/Nerdbank.GitVersioning/blob/d398833fcdcb857fe44c3e8287f25b4058921181/src/Nerdbank.GitVersioning.NuGet/build/Nerdbank.GitVersioning.targets#L62

This conflicts with the `GetBuildVersion` target which repo toolset defines if `UsingToolVSSDK` is set to true.  The result is that if you try to enable the VS SDK in a project, then Nerdbank.GitVersioning will stop working.

This PR adds a workaround for this: you can set the `DefineGetBuildVersionTargetForVsix` to false to prevent repo toolset's version of this target from being defined.

I ran into this while [porting MSBuild to use repo toolset](https://github.com/Microsoft/msbuild/issues/2706).

FYI @AArnott