### PR TITLE
Update SourceLink generating targets to new design

### DIFF
--- a/sdks/RepoToolset/tools/Imports.targets
+++ b/sdks/RepoToolset/tools/Imports.targets
@@ -20,6 +20,7 @@
   <Import Project="GenerateInternalsVisibleTo.targets" />
   <Import Project="GenerateResxSource.targets" />
   <Import Project="Workarounds.targets"/>
+  <Import Project="RepositoryInfo.targets"/>
 
   <Import Project="SourceLink.targets" Condition="'$(EnableSourceLink)' == 'true' and '$(GitHeadSha)' != ''"/>
   <Import Project="XUnit.targets" Condition="'$(UsingToolXUnit)' == 'true'"/>

--- a/sdks/RepoToolset/tools/ProjectDefaults.props
+++ b/sdks/RepoToolset/tools/ProjectDefaults.props
@@ -40,17 +40,6 @@
     <DebugType>portable</DebugType>
     <DebugType Condition="'$(OfficialBuild)' != 'true' and '$(BuildingForLiveUnitTesting)' != 'true'">embedded</DebugType>
 
-    <!--
-      The source root path used for deterministic normalization of source paths.
-      
-      If set the value is used in PathMap to instruct the compiler to normalize source paths 
-      emitted to the binary and PDB and as a root for Source Link mapping.
-      If set must end with a directory separator.
-      
-      If unset the PathMap need to be set explicitly to facilitate full determinism.
-    -->
-    <DeterministicSourceRoot Condition="'$(CIBuild)' == 'true'">/_/</DeterministicSourceRoot>
-
     <EnableSourceLink Condition="'$(CIBuild)' == 'true'">true</EnableSourceLink>
   </PropertyGroup>
 
@@ -137,7 +126,7 @@
     <When Condition="'$(Language)' == 'F#'">
       <PropertyGroup>
         <!-- F# compiler doesn't support PathMap (see https://github.com/Microsoft/visualfsharp/issues/3812) -->
-        <DeterministicSourceRoot></DeterministicSourceRoot>
+        <DeterministicSourcePaths>false</DeterministicSourcePaths>
       </PropertyGroup>
     </When>
   </Choose>

--- a/sdks/RepoToolset/tools/RepositoryInfo.targets
+++ b/sdks/RepoToolset/tools/RepositoryInfo.targets
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
+
+  <UsingTask TaskName="RoslynTools.BuildTasks.MapSourceRoots" AssemblyFile="$(RoslynToolsBuildTasksAssembly)"/>
+
+  <PropertyGroup>
+    <InitializeSourceRootDependsOn>$(InitializeSourceRootDependsOn);_InitializeSourceRootFromSourceControl</InitializeSourceRootDependsOn>
+  </PropertyGroup>
+
+  <!-- To be replaced by a Microsoft.Build.Tasks.Git and SourceLink.GitHub packages. -->
+  <Target Name="_InitializeSourceRootFromSourceControl">
+    <Error Text="GitHeadSha has invalid value: '$(GitHeadSha)'" Condition="'$(GitHeadSha.Length)' != '40'" />
+
+    <PropertyGroup>
+      <_RepositoryRawUrl>$(RepositoryRawUrl)</_RepositoryRawUrl>
+      <_RepositoryRawUrl Condition="'$(_RepositoryRawUrl)' == '' and $(RepositoryUrl.StartsWith('https://github.com/'))">https://raw.githubusercontent.com/$(RepositoryUrl.SubString(19))</_RepositoryRawUrl>
+      <_RepositoryRawUrl Condition="'$(_RepositoryRawUrl)' == '' and $(RepositoryUrl.StartsWith('http://github.com/'))">https://raw.githubusercontent.com/$(RepositoryUrl.SubString(18))</_RepositoryRawUrl>
+    </PropertyGroup>
+
+    <Error Text="RepositoryRawUrl is empty and RepositoryUrl is not a well-known public repository URL: '$(RepositoryUrl)'" Condition="'$(_RepositoryRawUrl)' == ''" />
+   
+    <!-- Older source packages use RawUrl that doesn't include '/*' suffix instead of SourceLinkUrl -->
+    <ItemGroup>
+      <SourceRoot Update="@(SourceRoot)">
+        <SourceLinkUrl Condition="'%(SourceRoot.SourceLinkUrl)' == '' and '%(SourceRoot.RawUrl)' != ''">%(SourceRoot.RawUrl)/*</SourceLinkUrl>
+      </SourceRoot>
+    </ItemGroup>
+
+    <ItemGroup>
+      <SourceRoot Include="$([System.IO.Path]::GetFullPath('$(RepoRoot)'))">
+        <SourceControl>Git</SourceControl>
+        <SourceLinkUrl>$(_RepositoryRawUrl.TrimEnd('/'))/$(GitHeadSha)/*</SourceLinkUrl>
+      </SourceRoot>
+    </ItemGroup>
+  </Target>
+
+  <!--
+    ==========
+    SourceRoot
+    ==========
+    
+    All source files of the project are expected to be located under one of the directories specified by SourceRoot item group.
+    Include the final backslash in the path.
+  -->
+
+  <!-- Virtual with base call before overridden implementation. -->
+  <Target Name="InitializeSourceRoot"
+          DependsOnTargets="$(InitializeSourceRootDependsOn)">
+    <ItemGroup>
+      <_InvalidSourceRoot Include="@(SourceRoot)" Condition="!HasTrailingSlash('%(SourceRoot.Identity)')" />
+    </ItemGroup>
+
+    <Error Text="SourceRoot paths are required to end with a slash or backslash: @(_InvalidSourceRoot, ', ')"
+           Condition="'@(_InvalidSourceRoot)' != ''" />
+
+    <!--
+      Assign top-level source roots a deterministic path (MappedPath metadata).
+    -->
+    
+    <ItemGroup Condition="'@(_MappedSourceRoot)' != ''">
+      <_MappedSourceRoot Remove="@(_MappedSourceRoot)" />
+    </ItemGroup>
+
+    <MapSourceRoots SourceRoots="@(SourceRoot)" Condition="'$(DeterministicSourcePaths)' == 'true'">
+      <Output TaskParameter="MappedSourceRoots" ItemName="_MappedSourceRoot" />
+    </MapSourceRoots>
+
+    <ItemGroup Condition="'$(DeterministicSourcePaths)' == 'true'">
+      <SourceRoot Remove="@(SourceRoot)" />
+      <SourceRoot Include="@(_MappedSourceRoot)" />
+    </ItemGroup>
+  </Target>
+
+  <!-- 
+    =======
+    PathMap
+    =======
+    
+    If DeterministicSourcePaths is true adds mapping for all source roots to PathMap.
+    
+    This target requires SourceRoot to be initialized in order to calculate the PathMap.
+    If SourceRoot is empty an error is reported if DeterministicSourcePaths has been explicitly set to true by the project.
+    If DeterministicSourcePaths has been set to true in Common.props the target is skipped, to avoid breaking existing projects.
+  -->
+
+  <PropertyGroup>
+    <!-- 
+      Unless specified otherwise enable deterministic source root (PathMap) when building deterministically on CI server, but not for local builds.
+      In order for the debugger to find source files when debugging a locally built binary the PDB must contain original, unmapped local paths.
+    -->
+    <_DeterministicSourcePathsOriginal>$(DeterministicSourcePaths)</_DeterministicSourcePathsOriginal>
+    <DeterministicSourcePaths Condition="'$(DeterministicSourcePaths)' == '' and '$(Deterministic)' == 'true' and '$(CIBuild)' != ''">true</DeterministicSourcePaths>
+  </PropertyGroup>
+
+  <Target Name="_SetPathMapFromSourceRoots"
+          DependsOnTargets="InitializeSourceRoot"
+          BeforeTargets="CoreCompile"
+          Condition="'$(DeterministicSourcePaths)' == 'true'">
+   
+    <ItemGroup>
+      <_TopLevelSourceRoot Include="@(SourceRoot)" Condition="'%(SourceRoot.NestedRoot)' == ''"/>
+    </ItemGroup>
+
+    <Error Text="SourceRoot must contain top-level source roots when DeterministicSourcePaths is true"
+           Condition="'@(_TopLevelSourceRoot)' == '' and '$(_DeterministicSourcePathsOriginal)' == 'true'" />
+    
+    <PropertyGroup Condition="'@(_TopLevelSourceRoot)' != ''">
+      <!-- TODO: Report error/warning if /pathmap doesn't cover all emitted source paths: https://github.com/dotnet/roslyn/issues/23969 -->
+      
+      <!-- TODO: PathMap should accept and ignore empty mapping: https://github.com/dotnet/roslyn/issues/23523-->
+      <PathMap Condition="'$(PathMap)' != ''">$(PathMap),</PathMap>
+      
+      <!--
+        TODO: quote the paths to avoid misinterpreting ',' and '=' in them as separators, 
+        but quoting doesn't currently work (see https://github.com/dotnet/roslyn/issues/22835).
+      -->
+      <PathMap>$(PathMap)@(_TopLevelSourceRoot->'%(Identity)=%(MappedPath)', ',')</PathMap>
+    </PropertyGroup>
+  </Target>
+
+</Project>

--- a/sdks/RepoToolset/tools/SourceLink.targets
+++ b/sdks/RepoToolset/tools/SourceLink.targets
@@ -2,6 +2,8 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project>
 
+  <UsingTask TaskName="RoslynTools.BuildTasks.GenerateSourceLinkFile" AssemblyFile="$(RoslynToolsBuildTasksAssembly)"/>
+  
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
@@ -9,73 +11,24 @@
   <PropertyGroup>
     <SourceLink Condition="'$(DebugType)' != 'none'">$(IntermediateOutputPath)$(MSBuildProjectName).sourcelink.json</SourceLink>
   </PropertyGroup>
-
-  <Target Name="_CalculateSourceLinkRoots">
-    <Error Text="GitHeadSha has invalid value: '$(GitHeadSha)'" Condition="'$(GitHeadSha.Length)' != '40'" />
-
-    <PropertyGroup>
-      <_RepositoryRawUrl>$(RepositoryRawUrl)</_RepositoryRawUrl>
-      <_RepositoryRawUrl Condition="'$(_RepositoryRawUrl)' == '' and $(RepositoryUrl.StartsWith('https://github.com/'))">https://raw.githubusercontent.com/$(RepositoryUrl.SubString(19))</_RepositoryRawUrl>
-      <_RepositoryRawUrl Condition="'$(_RepositoryRawUrl)' == '' and $(RepositoryUrl.StartsWith('http://github.com/'))">https://raw.githubusercontent.com/$(RepositoryUrl.SubString(18))</_RepositoryRawUrl>
-    </PropertyGroup>
-
-    <Error Text="RepositoryRawUrl is empty and RepositoryUrl is not a well-known public repository URL: '$(RepositoryUrl)'" Condition="'$(_RepositoryRawUrl)' == ''" />
-   
+    
     <!-- 
-      Map explicitly specified source roots first, so they are not overridden by the RepoRoot mapping.
-      Scenario: Source packages restored in packages directory below RepoRoot should be mapped 
-      to their respective RawUrls, not to the RepoRoot URL.
-    -->
-    <ItemGroup>
-      <_SourceLinkRoot Include="@(SourceRoot)">
-        <Path Condition="'$(DeterministicSourceRoot)' == ''">%(SourceRoot.Identity)</Path>
-        <Path Condition="'$(DeterministicSourceRoot)' != ''">/_%(SourceRoot.UniqueName)/</Path>
-      </_SourceLinkRoot>
-    </ItemGroup>
-
-    <ItemGroup>
-      <_SourceLinkRoot Include="$(RepoRoot)">
-        <RawUrl>$(_RepositoryRawUrl.TrimEnd('/'))/$(GitHeadSha)</RawUrl>
-        <Path Condition="'$(DeterministicSourceRoot)' == ''">$([System.IO.Path]::GetFullPath('$(RepoRoot)'))</Path>
-        <Path Condition="'$(DeterministicSourceRoot)' != ''">$(DeterministicSourceRoot)</Path>
-      </_SourceLinkRoot>
-    </ItemGroup>
+    Fills in SourceLinkUrl metadata on SourceRoot items that don't have it yet.
+  -->
+  <Target Name="InitializeSourceLinkUrl"
+          DependsOnTargets="InitializeSourceRoot;$(InitializeSourceLinkUrlDependsOn)">
   </Target>
 
-  <Target Name="_CalculateSourceLinkMappings"
-          Inputs="*%(_SourceLinkRoot.Identity)"
-          Outputs="*%(_SourceLinkRoot.Identity)">
-    
-    <Error Text="SourceRoot.Identity must end with a slash or backslash: '%(_SourceLinkRoot.Path)'" Condition="!HasTrailingSlash('%(_SourceLinkRoot.Path)')"/>
-    
-    <PropertyGroup>
-      <_JsonEscapedPath>%(_SourceLinkRoot.Path)</_JsonEscapedPath>
-      <_JsonEscapedPath>$(_JsonEscapedPath.Replace('\', '\\').Replace('"', '\"'))</_JsonEscapedPath>
-      
-      <_JsonEscapedUrl>%(_SourceLinkRoot.RawUrl)</_JsonEscapedUrl>
-      <_JsonEscapedUrl>$(_JsonEscapedUrl.TrimEnd('/').Replace('\', '\\').Replace('"', '\"'))</_JsonEscapedUrl>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <_SourceLinkMapping Include='"$(_JsonEscapedPath)*":"$(_JsonEscapedUrl)/*"' />
-    </ItemGroup>
-  </Target>
-
-  <Target Name="GenerateSourceLinkFile"
-          Outputs="$(SourceLink)"
-          DependsOnTargets="PrepareForBuild;_CalculateSourceLinkRoots;_CalculateSourceLinkMappings"
+  <!-- 
+    Generates source link file.
+  -->
+  <Target Name="_GenerateSourceLinkFile"
+          DependsOnTargets="InitializeSourceLinkUrl"
           BeforeTargets="CoreCompile"
+          Outputs="$(SourceLink)"
           Condition="'$(SourceLink)' != ''">
 
-    <PropertyGroup>
-      <_Value>@(_SourceLinkMapping, ',')</_Value>
-    </PropertyGroup>
-    
-    <WriteLinesToFile
-      File="$(SourceLink)" 
-      Lines='{"documents":{$(_Value)}}'
-      Overwrite="true">
-    </WriteLinesToFile>
+    <GenerateSourceLinkFile SourceRoots="@(SourceRoot)" OutputFile="$(SourceLink)" />
 
     <ItemGroup>
       <FileWrites Include="$(SourceLink)" />

--- a/sdks/RepoToolset/tools/Workarounds.targets
+++ b/sdks/RepoToolset/tools/Workarounds.targets
@@ -96,24 +96,4 @@
   <PropertyGroup Condition="'$(DebugType)' == 'portable'">
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
-
-  <!-- 
-    Override PathMap if DeterministicSourceRoot is set.
-  -->
-  <Target Name="_SetPathMap"
-          BeforeTargets="CoreCompile"
-          Condition="'$(DeterministicSourceRoot)' != ''">
-
-    <!-- 
-      We should quote the paths to avoid misinterpreting ',' and '=' in them as separators, 
-      but quoting doesn't currently work (see https://github.com/dotnet/roslyn/issues/22835).
-    -->
-    <PropertyGroup>
-      <PathMap>$(RepoRoot)=$(DeterministicSourceRoot)</PathMap>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'@(SourceRoot)' != ''">
-      <PathMap>$(PathMap),@(SourceRoot->'%(Identity)=/_%(UniqueName)/', ',')</PathMap>
-    </PropertyGroup>
-  </Target>
 </Project>

--- a/src/BuildTasks/GenerateSourceLinkFile.cs
+++ b/src/BuildTasks/GenerateSourceLinkFile.cs
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace RoslynTools.BuildTasks
+{
+    // TODO: move to Microsoft.Build.Tasks
+    public class GenerateSourceLinkFile : Task
+    {
+        [Required]
+        public ITaskItem[] SourceRoots { get; set; }
+
+        [Required]
+        public string OutputFile { get; set; }
+
+        public override bool Execute()
+        {
+            if (string.IsNullOrEmpty(OutputFile))
+            {
+                Log.LogError("OutputFile not specified");
+                return false;
+            }
+
+            if (SourceRoots.Length == 0)
+            {
+                Log.LogError("No SourceRoots specified");
+                return false;
+            }
+
+            string JsonEscape(string str)
+                => str.Replace(@"\", @"\\").Replace("\"", "\\\"");
+
+            var result = new StringBuilder();
+            result.Append("{\"documents\":{");
+
+            bool success = true;
+            bool first = true;
+            foreach (var root in SourceRoots)
+            {
+                string mappedPath = root.GetMetadata("MappedPath");
+                bool isMapped = !string.IsNullOrEmpty(mappedPath);
+                string localPath = isMapped ? mappedPath : root.ItemSpec;
+
+                if (!localPath.EndsWithSeparator())
+                {
+                    Log.LogError($"{(isMapped ? "SourceLink.MappedPath" : "SourceLink")} must end with a directory separator: '{localPath}'");
+                    success = false;
+                    continue;
+                }
+
+                if (localPath.Contains('*'))
+                {
+                    Log.LogError($"{(isMapped ? "SourceLink.MappedPath" : "SourceLink")} must not contain wildcard '*': '{localPath}'");
+                    success = false;
+                    continue;
+                }
+
+                var url = root.GetMetadata("SourceLinkUrl");
+                if (string.IsNullOrEmpty(url))
+                {
+                    Log.LogError($"SourceRoot.SourceLinkUrl is empty: '{root.ItemSpec}'");
+                    success = false;
+                    continue;
+                }
+
+                if (url.Count(c => c == '*') != 1)
+                {
+                    Log.LogError($"SourceRoot.SourceLinkUrl must contain a single wildcard '*': '{url}'");
+                    success = false;
+                    continue;
+                }
+
+                if (first)
+                {
+                    first = false;
+                }
+                else
+                {
+                    result.Append(',');
+                }
+
+                result.Append('"');
+                result.Append(JsonEscape(localPath));
+                result.Append('*');
+                result.Append('"');
+                result.Append(':');
+                result.Append('"');
+                result.Append(JsonEscape(url));
+                result.Append('"');
+            }
+
+            result.Append("}}");
+
+            if (!success)
+            {
+                return false;
+            }
+
+            try
+            {
+                File.WriteAllText(OutputFile, result.ToString());
+            }
+            catch (Exception e)
+            {
+                Log.LogError($"Error writing to source link file '{OutputFile}': {e.Message}");
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/BuildTasks/MapSourceRoots.cs
+++ b/src/BuildTasks/MapSourceRoots.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace RoslynTools.BuildTasks
+{
+    // TODO: move to Microsoft.Build.Tasks
+    public sealed class MapSourceRoots : Task
+    {
+        [Required]
+        public ITaskItem[] SourceRoots { get; set; }
+
+        [Output]
+        public ITaskItem[] MappedSourceRoots { get; set; }
+
+        public override bool Execute()
+        {
+            var topLevelMappedPaths = new Dictionary<string, string>();
+            bool success = true;
+            int i = 0;
+
+            void SetTopLevelMappedPaths(bool sourceControl)
+            {
+                foreach (var root in SourceRoots)
+                {
+                    if (!string.IsNullOrEmpty(root.GetMetadata("SourceControl")) == sourceControl)
+                    {
+                        string nestedRoot = root.GetMetadata("NestedRoot");
+                        if (string.IsNullOrEmpty(nestedRoot))
+                        {
+                            if (topLevelMappedPaths.ContainsKey(root.ItemSpec))
+                            {
+                                Log.LogError($"SourceRoot contains a duplicate: '{root.ItemSpec}'");
+                                success = false;
+                            }
+                            else
+                            {
+                                var mappedPath = "/_" + (i == 0 ? "" : i.ToString()) + "/";
+                                topLevelMappedPaths.Add(root.ItemSpec, mappedPath);
+                                root.SetMetadata("MappedPath", mappedPath);
+                                i++;
+                            }
+                        }
+                    }
+                }
+
+            }
+
+            // assign mapped paths to process source control roots first:
+            SetTopLevelMappedPaths(sourceControl: true);
+
+            // then assign mapped paths to other source control roots:
+            SetTopLevelMappedPaths(sourceControl: false);
+
+            // finally, calculate mapped paths of nested roots:
+            foreach (var root in SourceRoots)
+            {
+                string nestedRoot = root.GetMetadata("NestedRoot");
+                if (!string.IsNullOrEmpty(nestedRoot))
+                {
+                    string containingRoot = root.GetMetadata("ContainingRoot");
+                    if (containingRoot != null && topLevelMappedPaths.TryGetValue(containingRoot, out var mappedTopLevelPath))
+                    {
+                        root.SetMetadata("MappedPath", Path.Combine(mappedTopLevelPath, nestedRoot.Replace('\\', '/')).EndWithSeparator('/'));
+                    }
+                    else
+                    {
+                        Log.LogError($"SourceRoot.ContainingRoot not found in SourceRoot items: '{containingRoot}'");
+                        success = false;
+                    }
+                }
+            }
+
+            if (success)
+            {
+                MappedSourceRoots = SourceRoots;
+            }
+
+            return success;
+        }
+    }
+}

--- a/src/BuildTasks/PathUtilities.cs
+++ b/src/BuildTasks/PathUtilities.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.IO;
+
+namespace RoslynTools.BuildTasks
+{
+    internal static class PathUtilities
+    {
+        public static bool EndsWithSeparator(this string path)
+        {
+            char last = path[path.Length - 1];
+            return last == Path.DirectorySeparatorChar || last == Path.AltDirectorySeparatorChar;
+        }
+
+        public static string EndWithSeparator(this string path)
+            => path.EndsWithSeparator() ? path : path + Path.DirectorySeparatorChar;
+
+        public static string EndWithSeparator(this string path, char separator)
+            => path.EndsWithSeparator() ? path : path + separator;
+    }
+}


### PR DESCRIPTION
Implements SourceRoot handling as prototyped in https://github.com/tmat/repository-info.

See also https://github.com/tmat/repository-info/blob/master/docs/Readme.md.