### PR TITLE
remove use of 'roslyn' from option names as they can refer to several…

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/RoslynInsertionToolCommandline.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/RoslynInsertionToolCommandline.cs
@@ -31,11 +31,11 @@ partial class RoslynInsertionToolCommandline
         var options = new RoslynInsertionToolOptions()
             .WithUsername(settings.UserName)
             .WithVSTSUrl(settings.VSTSUrl)
-            .WithGithubBuildQueueName(settings.GithubBuildQueueName)
-            .WithGithubBuildConfig(settings.GithubBuildConfig)
+            .WithBuildQueueName(settings.BuildQueueName)
+            .WithBuildConfig(settings.BuildConfig)
             .WithEnlistmentPath(settings.EnlistmentPath)
             .WithTFSProjectName(settings.TFSProjectName)
-            .WithGithubBuildDropPath(settings.GithubBuildDropPath)
+            .WithBuildDropPath(settings.BuildDropPath)
             .WithNewBranchName(settings.NewBranchName)
             .WithEmailServerName(settings.EmailServerName)
             .WithMailRecipient(settings.MailRecipient)
@@ -86,14 +86,14 @@ partial class RoslynInsertionToolCommandline
                 visualStudioBranchName => options = options.WithVisualStudioBranchName(visualStudioBranchName)
             },
             {
-                "gbn=|githubranchname=",
-                "The github branch we are inserting *from*.",
-                githubBranchName => options = options.WithGitHubBranchName(githubBranchName)
+                "bn=|branchname=",
+                "The branch we are inserting *from*.",
+                branchName => options = options.WithbranchName(branchName)
             },
             {
-                "gbq=|githubbuildqueue=",
-                $"The name of the build queue producing signed bits you wish to insert. Defaults to \"{options.GithubBuildQueueName}\".",
-                githubBuildQueueName => options = options.WithGithubBuildQueueName(githubBuildQueueName)
+                "bq=|buildqueue=",
+                $"The name of the build queue producing signed bits you wish to insert. Defaults to \"{options.BuildQueueName}\".",
+                buildQueueName => options = options.WithBuildQueueName(buildQueueName)
             },
             {
                 "vstsurl=",
@@ -111,9 +111,9 @@ partial class RoslynInsertionToolCommandline
                 newBranchName => options = options.WithNewBranchName(newBranchName)
             },
             {
-                "gdp=|githubdroppath=",
-                $"Location where the signed binaries are dropped. Will use this path in combination with **githubranchname** to find signed binaries, unless the path ends with ```Binaries\\Debug``` or ```Binaries\\Release``` (for local testing purposes only). Defaults to \"{options.GithubBuildDropPath}\".",
-                roslynDropPath => options = options.WithGithubBuildDropPath(roslynDropPath)
+                "dp=|droppath=",
+                $"Location where the signed binaries are dropped. Will use this path in combination with **branchname** to find signed binaries, unless the path ends with ```Binaries\\Debug``` or ```Binaries\\Release``` (for local testing purposes only). Defaults to \"{options.BuildDropPath}\".",
+                dropPath => options = options.WithBuildDropPath(dropPath)
             },
             {
                 "sb=|specificbuild=",

--- a/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/RoslynInsertionToolCommandline.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/RoslynInsertionToolCommandline.cs
@@ -31,11 +31,11 @@ partial class RoslynInsertionToolCommandline
         var options = new RoslynInsertionToolOptions()
             .WithUsername(settings.UserName)
             .WithVSTSUrl(settings.VSTSUrl)
-            .WithRoslynBuildQueueName(settings.RoslynBuildQueueName)
-            .WithRoslynBuildConfig(settings.RoslynBuildConfig)
+            .WithGithubBuildQueueName(settings.GithubBuildQueueName)
+            .WithGithubBuildConfig(settings.GithubBuildConfig)
             .WithEnlistmentPath(settings.EnlistmentPath)
             .WithTFSProjectName(settings.TFSProjectName)
-            .WithRoslynDropPath(settings.RoslynDropPath)
+            .WithGithubBuildDropPath(settings.GithubBuildDropPath)
             .WithNewBranchName(settings.NewBranchName)
             .WithEmailServerName(settings.EmailServerName)
             .WithMailRecipient(settings.MailRecipient)
@@ -86,14 +86,14 @@ partial class RoslynInsertionToolCommandline
                 visualStudioBranchName => options = options.WithVisualStudioBranchName(visualStudioBranchName)
             },
             {
-                "rbn=|roslynbranchname=",
-                "The Roslyn branch we are inserting *from*.",
-                roslynBranchName => options = options.WithRoslynBranchName(roslynBranchName)
+                "gbn=|githubranchname=",
+                "The github branch we are inserting *from*.",
+                githubBranchName => options = options.WithGitHubBranchName(githubBranchName)
             },
             {
-                "rbq=|roslynbuildqueue=",
-                $"The name of the build queue producing signed bits you wish to insert. Defaults to \"{options.RoslynBuildQueueName}\".",
-                roslynBuildQueueName => options = options.WithRoslynBuildQueueName(roslynBuildQueueName)
+                "gbq=|githubbuildqueue=",
+                $"The name of the build queue producing signed bits you wish to insert. Defaults to \"{options.GithubBuildQueueName}\".",
+                githubBuildQueueName => options = options.WithGithubBuildQueueName(githubBuildQueueName)
             },
             {
                 "vstsurl=",
@@ -111,9 +111,9 @@ partial class RoslynInsertionToolCommandline
                 newBranchName => options = options.WithNewBranchName(newBranchName)
             },
             {
-                "rdp=|roslyndroppath=",
-                $"Location where the signed binaries are dropped. Will use this path in combination with **roslynbuildname** to find signed binaries, unless the path ends with ```Binaries\\Debug``` or ```Binaries\\Release``` (for local testing purposes only). Defaults to \"{options.RoslynDropPath}\".",
-                roslynDropPath => options = options.WithRoslynDropPath(roslynDropPath)
+                "gdp=|githubdroppath=",
+                $"Location where the signed binaries are dropped. Will use this path in combination with **githubranchname** to find signed binaries, unless the path ends with ```Binaries\\Debug``` or ```Binaries\\Release``` (for local testing purposes only). Defaults to \"{options.GithubBuildDropPath}\".",
+                roslynDropPath => options = options.WithGithubBuildDropPath(roslynDropPath)
             },
             {
                 "sb=|specificbuild=",

--- a/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/Settings.Designer.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/Settings.Designer.cs
@@ -53,9 +53,9 @@ namespace Roslyn.Insertion {
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("\\\\cpvsbuild\\drops\\Roslyn")]
-        public string RoslynDropPath {
+        public string GithubBuildDropPath {
             get {
-                return ((string)(this["RoslynDropPath"]));
+                return ((string)(this["GithubBuildDropPath"]));
             }
         }
 
@@ -89,18 +89,18 @@ namespace Roslyn.Insertion {
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("Roslyn-Signed")]
-        public string RoslynBuildQueueName {
+        public string GithubBuildQueueName {
             get {
-                return ((string)(this["RoslynBuildQueueName"]));
+                return ((string)(this["GithubBuildQueueName"]));
             }
         }
 
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("Release")]
-        public string RoslynBuildConfig {
+        public string GithubBuildConfig {
             get {
-                return ((string)(this["RoslynBuildConfig"]));
+                return ((string)(this["GithubBuildConfig"]));
             }
         }
 

--- a/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/Settings.Designer.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/Settings.Designer.cs
@@ -53,7 +53,7 @@ namespace Roslyn.Insertion {
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("\\\\cpvsbuild\\drops\\Roslyn")]
-        public string GithubBuildDropPath {
+        public string BuildDropPath {
             get {
                 return ((string)(this["GithubBuildDropPath"]));
             }
@@ -89,7 +89,7 @@ namespace Roslyn.Insertion {
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("Roslyn-Signed")]
-        public string GithubBuildQueueName {
+        public string BuildQueueName {
             get {
                 return ((string)(this["GithubBuildQueueName"]));
             }
@@ -98,7 +98,7 @@ namespace Roslyn.Insertion {
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("Release")]
-        public string GithubBuildConfig {
+        public string BuildConfig {
             get {
                 return ((string)(this["GithubBuildConfig"]));
             }

--- a/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/Settings.settings
+++ b/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/Settings.settings
@@ -11,7 +11,7 @@
     <Setting Name="TFSProjectName" Type="System.String" Scope="Application">
       <Value Profile="(Default)">DevDiv</Value>
     </Setting>
-    <Setting Name="RoslynDropPath" Type="System.String" Scope="Application">
+    <Setting Name="GithubBuildDropPath" Type="System.String" Scope="Application">
       <Value Profile="(Default)">\\cpvsbuild\drops\Roslyn</Value>
     </Setting>
     <Setting Name="NewBranchName" Type="System.String" Scope="Application">
@@ -23,10 +23,10 @@
     <Setting Name="EmailServerName" Type="System.String" Scope="Application">
       <Value Profile="(Default)">smtphost</Value>
     </Setting>
-    <Setting Name="RoslynBuildQueueName" Type="System.String" Scope="Application">
+    <Setting Name="GithubBuildQueueName" Type="System.String" Scope="Application">
       <Value Profile="(Default)">Roslyn-Signed</Value>
     </Setting>
-    <Setting Name="RoslynBuildConfig" Type="System.String" Scope="Application">
+    <Setting Name="GithubBuildConfig" Type="System.String" Scope="Application">
       <Value Profile="(Default)">Release</Value>
     </Setting>
     <Setting Name="EnlistmentPath" Type="System.String" Scope="Application">

--- a/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/Settings.settings
+++ b/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/Settings.settings
@@ -11,7 +11,7 @@
     <Setting Name="TFSProjectName" Type="System.String" Scope="Application">
       <Value Profile="(Default)">DevDiv</Value>
     </Setting>
-    <Setting Name="GithubBuildDropPath" Type="System.String" Scope="Application">
+    <Setting Name="BuildDropPath" Type="System.String" Scope="Application">
       <Value Profile="(Default)">\\cpvsbuild\drops\Roslyn</Value>
     </Setting>
     <Setting Name="NewBranchName" Type="System.String" Scope="Application">
@@ -23,10 +23,10 @@
     <Setting Name="EmailServerName" Type="System.String" Scope="Application">
       <Value Profile="(Default)">smtphost</Value>
     </Setting>
-    <Setting Name="GithubBuildQueueName" Type="System.String" Scope="Application">
+    <Setting Name="BuildQueueName" Type="System.String" Scope="Application">
       <Value Profile="(Default)">Roslyn-Signed</Value>
     </Setting>
-    <Setting Name="GithubBuildConfig" Type="System.String" Scope="Application">
+    <Setting Name="BuildConfig" Type="System.String" Scope="Application">
       <Value Profile="(Default)">Release</Value>
     </Setting>
     <Setting Name="EnlistmentPath" Type="System.String" Scope="Application">

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.AssemblyVersions.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.AssemblyVersions.cs
@@ -9,11 +9,11 @@ namespace Roslyn.Insertion
 {
     static partial class RoslynInsertionTool
     {
-        private static void UpdateAssemblyVersions(BuildVersion roslynBuildVersion)
+        private static void UpdateAssemblyVersions(BuildVersion buildVersion)
         {
             var versionsUpdater = new VersionsUpdater(Log, GetAbsolutePathForEnlistment(), WarningMessages);
 
-            foreach (var nameAndVersion in ReadAssemblyVersions(GetDevDivInsertionFilePath(roslynBuildVersion, "DependentAssemblyVersions.csv")))
+            foreach (var nameAndVersion in ReadAssemblyVersions(GetDevDivInsertionFilePath(buildVersion, "DependentAssemblyVersions.csv")))
             {
                 versionsUpdater.UpdateComponentVersion(nameAndVersion.Key, nameAndVersion.Value);
             }

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.Packages.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.Packages.cs
@@ -27,7 +27,7 @@ namespace Roslyn.Insertion
         /// </summary>
         private static bool UpdatePackages(
             List<string> newPackageFiles,
-            BuildVersion roslynBuildVersion,
+            BuildVersion buildVersion,
             CoreXT coreXT,
             string packagesDir,
             CancellationToken cancellationToken)
@@ -63,7 +63,7 @@ namespace Roslyn.Insertion
                     continue;
                 }
 
-                UpdatePackage(previousPackageVersion, roslynBuildVersion, coreXT, package);
+                UpdatePackage(previousPackageVersion, buildVersion, coreXT, package);
             }
 
             return shouldRetainBuild;
@@ -71,7 +71,7 @@ namespace Roslyn.Insertion
 
         private static void UpdatePackage(
             SemanticVersion previousPackageVersion,
-            BuildVersion roslynBuildVersion,
+            BuildVersion buildVersion,
             CoreXT coreXT,
             PackageInfo package)
         {
@@ -89,12 +89,12 @@ namespace Roslyn.Insertion
 
             if (package.IsRoslyn)
             {
-                var buildVersion = package.Version.GetSuffixBuildVersion();
+                var packageBuildVersion = package.Version.GetSuffixBuildVersion();
 
-                if (buildVersion.Build != roslynBuildVersion.FiveDigitBuildNumber ||
-                    buildVersion.Revision != roslynBuildVersion.Revision)
+                if (packageBuildVersion.Build != buildVersion.FiveDigitBuildNumber ||
+                    packageBuildVersion.Revision != buildVersion.Revision)
                 {
-                    throw new InvalidOperationException($"Roslyn package version '{package.Version}' inconsistent with build version '{roslynBuildVersion}'");
+                    throw new InvalidOperationException($"Package version for '{package.PackageName}:{package.Version}' inconsistent with build version '{buildVersion}'");
                 }
             }
 

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.UpdateFiles.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.UpdateFiles.cs
@@ -24,17 +24,17 @@ namespace Roslyn.Insertion
         internal static string GetBuildDirectory(BuildVersion version)
         {
             // used for local testing:
-            if (Options.GithubBuildDropPath.EndsWith(@"Binaries\Debug", StringComparison.OrdinalIgnoreCase) ||
-                Options.GithubBuildDropPath.EndsWith(@"Binaries\Release", StringComparison.OrdinalIgnoreCase))
+            if (Options.BuildDropPath.EndsWith(@"Binaries\Debug", StringComparison.OrdinalIgnoreCase) ||
+                Options.BuildDropPath.EndsWith(@"Binaries\Release", StringComparison.OrdinalIgnoreCase))
             {
-                return Options.GithubBuildDropPath;
+                return Options.BuildDropPath;
             }
 
             return Path.Combine(
-                Options.GithubBuildDropPath,
-                Options.GithubBuildQueueName,
-                Path.GetFileName(Options.GithubBranchName), // The folder under GithubBranchName is just the last component of the name
-                Options.GithubBuildConfig,
+                Options.BuildDropPath,
+                Options.BuildQueueName,
+                Path.GetFileName(Options.BranchName), // The folder under BranchName is just the last component of the name
+                Options.BuildConfig,
                 version.ToString());
         }
 

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.UpdateFiles.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.UpdateFiles.cs
@@ -33,7 +33,7 @@ namespace Roslyn.Insertion
             return Path.Combine(
                 Options.GithubBuildDropPath,
                 Options.GithubBuildQueueName,
-                Path.GetFileName(Options.GithubBranchName), // The folder under Roslyn-Signed is just the last component of the name
+                Path.GetFileName(Options.GithubBranchName), // The folder under GithubBranchName is just the last component of the name
                 Options.GithubBuildConfig,
                 version.ToString());
         }

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.UpdateFiles.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.UpdateFiles.cs
@@ -24,17 +24,17 @@ namespace Roslyn.Insertion
         internal static string GetBuildDirectory(BuildVersion version)
         {
             // used for local testing:
-            if (Options.RoslynDropPath.EndsWith(@"Binaries\Debug", StringComparison.OrdinalIgnoreCase) ||
-                Options.RoslynDropPath.EndsWith(@"Binaries\Release", StringComparison.OrdinalIgnoreCase))
+            if (Options.GithubBuildDropPath.EndsWith(@"Binaries\Debug", StringComparison.OrdinalIgnoreCase) ||
+                Options.GithubBuildDropPath.EndsWith(@"Binaries\Release", StringComparison.OrdinalIgnoreCase))
             {
-                return Options.RoslynDropPath;
+                return Options.GithubBuildDropPath;
             }
 
             return Path.Combine(
-                Options.RoslynDropPath,
-                Options.RoslynBuildQueueName,
-                Path.GetFileName(Options.RoslynBranchName), // The folder under Roslyn-Signed is just the last component of the name
-                Options.RoslynBuildConfig,
+                Options.GithubBuildDropPath,
+                Options.GithubBuildQueueName,
+                Path.GetFileName(Options.GithubBranchName), // The folder under Roslyn-Signed is just the last component of the name
+                Options.GithubBuildConfig,
                 version.ToString());
         }
 

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
@@ -54,9 +54,9 @@ namespace Roslyn.Insertion
         private static async Task<Build> GetLatestPassedBuildAsync(CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            Log.Trace($"Getting latest passing build from {Options.TFSProjectName} where name is {Options.GithubBuildQueueName}");
+            Log.Trace($"Getting latest passing build from {Options.TFSProjectName} where name is {Options.BuildQueueName}");
             var buildClient = ProjectCollection.GetClient<BuildHttpClient>();
-            var definitions = await buildClient.GetDefinitionsAsync(project: Options.TFSProjectName, name: Options.GithubBuildQueueName);
+            var definitions = await buildClient.GetDefinitionsAsync(project: Options.TFSProjectName, name: Options.BuildQueueName);
             var builds = await GetBuildsFromTFSAsync(buildClient, definitions, cancellationToken, BuildResult.Succeeded);
             return (from build in builds
                     orderby build.FinishTime descending
@@ -65,8 +65,8 @@ namespace Roslyn.Insertion
 
         private static async Task<IEnumerable<Build>> GetBuildsFromTFSAsync(BuildHttpClient buildClient, List<BuildDefinitionReference> definitions, CancellationToken cancellationToken, BuildResult? resultFilter = default(BuildResult))
         {
-            IEnumerable<Build> builds = await GetBuildsFromTFSByBranchAsync(buildClient, definitions, Options.GithubBranchName, resultFilter, cancellationToken);
-            builds = builds.Concat(await GetBuildsFromTFSByBranchAsync(buildClient, definitions, "refs/heads/" + Options.GithubBranchName, resultFilter, cancellationToken));
+            IEnumerable<Build> builds = await GetBuildsFromTFSByBranchAsync(buildClient, definitions, Options.BranchName, resultFilter, cancellationToken);
+            builds = builds.Concat(await GetBuildsFromTFSByBranchAsync(buildClient, definitions, "refs/heads/" + Options.BranchName, resultFilter, cancellationToken));
             return builds;
         }
 
@@ -93,12 +93,12 @@ namespace Roslyn.Insertion
             }
             catch (Exception ex)
             {
-                throw new IOException($"Unable to get latest build for '{Options.GithubBuildQueueName}' from project '{Options.TFSProjectName}' in '{Options.VSTSUri}': {ex.Message}");
+                throw new IOException($"Unable to get latest build for '{Options.BuildQueueName}' from project '{Options.TFSProjectName}' in '{Options.VSTSUri}': {ex.Message}");
             }
 
             if (newestBuild == null)
             {
-                throw new IOException($"Unable to get latest build for '{Options.GithubBuildQueueName}' from project '{Options.TFSProjectName}' in '{Options.VSTSUri}'");
+                throw new IOException($"Unable to get latest build for '{Options.BuildQueueName}' from project '{Options.TFSProjectName}' in '{Options.VSTSUri}'");
             }
 
             // ********************* Get New Build Version****************************
@@ -191,12 +191,12 @@ namespace Roslyn.Insertion
         private static async Task<Build> GetSpecificBuildAsync(BuildVersion version, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            Log.Trace($"Getting latest passing build from {Options.TFSProjectName} where name is {Options.GithubBuildQueueName}");
+            Log.Trace($"Getting latest passing build from {Options.TFSProjectName} where name is {Options.BuildQueueName}");
             var buildClient = ProjectCollection.GetClient<BuildHttpClient>();
-            var definitions = await buildClient.GetDefinitionsAsync(project: Options.TFSProjectName, name: Options.GithubBuildQueueName);
+            var definitions = await buildClient.GetDefinitionsAsync(project: Options.TFSProjectName, name: Options.BuildQueueName);
             var builds = await GetBuildsFromTFSAsync(buildClient, definitions, cancellationToken);
             return (from build in builds
-                    where version == BuildVersion.FromTfsBuildNumber(build.BuildNumber, Options.GithubBuildQueueName)
+                    where version == BuildVersion.FromTfsBuildNumber(build.BuildNumber, Options.BuildQueueName)
                     orderby build.FinishTime descending
                     select build).FirstOrDefault();
         }

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
@@ -54,9 +54,9 @@ namespace Roslyn.Insertion
         private static async Task<Build> GetLatestPassedBuildAsync(CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            Log.Trace($"Getting latest passing build from {Options.TFSProjectName} where name is {Options.RoslynBuildQueueName}");
+            Log.Trace($"Getting latest passing build from {Options.TFSProjectName} where name is {Options.GithubBuildQueueName}");
             var buildClient = ProjectCollection.GetClient<BuildHttpClient>();
-            var definitions = await buildClient.GetDefinitionsAsync(project: Options.TFSProjectName, name: Options.RoslynBuildQueueName);
+            var definitions = await buildClient.GetDefinitionsAsync(project: Options.TFSProjectName, name: Options.GithubBuildQueueName);
             var builds = await GetBuildsFromTFSAsync(buildClient, definitions, cancellationToken, BuildResult.Succeeded);
             return (from build in builds
                     orderby build.FinishTime descending
@@ -65,8 +65,8 @@ namespace Roslyn.Insertion
 
         private static async Task<IEnumerable<Build>> GetBuildsFromTFSAsync(BuildHttpClient buildClient, List<BuildDefinitionReference> definitions, CancellationToken cancellationToken, BuildResult? resultFilter = default(BuildResult))
         {
-            IEnumerable<Build> builds = await GetBuildsFromTFSByBranchAsync(buildClient, definitions, Options.RoslynBranchName, resultFilter, cancellationToken);
-            builds = builds.Concat(await GetBuildsFromTFSByBranchAsync(buildClient, definitions, "refs/heads/" + Options.RoslynBranchName, resultFilter, cancellationToken));
+            IEnumerable<Build> builds = await GetBuildsFromTFSByBranchAsync(buildClient, definitions, Options.GithubBranchName, resultFilter, cancellationToken);
+            builds = builds.Concat(await GetBuildsFromTFSByBranchAsync(buildClient, definitions, "refs/heads/" + Options.GithubBranchName, resultFilter, cancellationToken));
             return builds;
         }
 
@@ -93,12 +93,12 @@ namespace Roslyn.Insertion
             }
             catch (Exception ex)
             {
-                throw new IOException($"Unable to get latest build for '{Options.RoslynBuildQueueName}' from project '{Options.TFSProjectName}' in '{Options.VSTSUri}': {ex.Message}");
+                throw new IOException($"Unable to get latest build for '{Options.GithubBuildQueueName}' from project '{Options.TFSProjectName}' in '{Options.VSTSUri}': {ex.Message}");
             }
 
             if (newestBuild == null)
             {
-                throw new IOException($"Unable to get latest build for '{Options.RoslynBuildQueueName}' from project '{Options.TFSProjectName}' in '{Options.VSTSUri}'");
+                throw new IOException($"Unable to get latest build for '{Options.GithubBuildQueueName}' from project '{Options.TFSProjectName}' in '{Options.VSTSUri}'");
             }
 
             // ********************* Get New Build Version****************************
@@ -191,12 +191,12 @@ namespace Roslyn.Insertion
         private static async Task<Build> GetSpecificBuildAsync(BuildVersion version, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            Log.Trace($"Getting latest passing build from {Options.TFSProjectName} where name is {Options.RoslynBuildQueueName}");
+            Log.Trace($"Getting latest passing build from {Options.TFSProjectName} where name is {Options.GithubBuildQueueName}");
             var buildClient = ProjectCollection.GetClient<BuildHttpClient>();
-            var definitions = await buildClient.GetDefinitionsAsync(project: Options.TFSProjectName, name: Options.RoslynBuildQueueName);
+            var definitions = await buildClient.GetDefinitionsAsync(project: Options.TFSProjectName, name: Options.GithubBuildQueueName);
             var builds = await GetBuildsFromTFSAsync(buildClient, definitions, cancellationToken);
             return (from build in builds
-                    where version == BuildVersion.FromTfsBuildNumber(build.BuildNumber, Options.RoslynBuildQueueName)
+                    where version == BuildVersion.FromTfsBuildNumber(build.BuildNumber, Options.GithubBuildQueueName)
                     orderby build.FinishTime descending
                     select build).FirstOrDefault();
         }

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
@@ -64,7 +64,7 @@ namespace Roslyn.Insertion
                 // ********************** Get Last Insertion *****************************
                 cancellationToken.ThrowIfCancellationRequested();
 
-                BuildVersion roslynBuildVersion;
+                BuildVersion buildVersion;
                 Build newestBuild;
                 bool retainBuild = false;
                 // Get the version from TFS build queue, e.g. Roslyn-Master-Signed-Release.
@@ -73,12 +73,12 @@ namespace Roslyn.Insertion
                 if (string.IsNullOrEmpty(Options.SpecificBuild))
                 {
                     newestBuild = await GetLatestBuildAsync(cancellationToken);
-                    roslynBuildVersion = BuildVersion.FromTfsBuildNumber(newestBuild.BuildNumber, Options.GithubBuildQueueName);
+                    buildVersion = BuildVersion.FromTfsBuildNumber(newestBuild.BuildNumber, Options.BuildQueueName);
                 }
                 else
                 {
-                    roslynBuildVersion = BuildVersion.FromString(Options.SpecificBuild);
-                    newestBuild = await GetSpecificBuildAsync(roslynBuildVersion, cancellationToken);
+                    buildVersion = BuildVersion.FromString(Options.SpecificBuild);
+                    newestBuild = await GetSpecificBuildAsync(buildVersion, cancellationToken);
                 }
 
                 // ****************** Get Latest and Create Branch ***********************
@@ -98,9 +98,9 @@ namespace Roslyn.Insertion
                     Log.Info($"Updating Nuget Packages");
                     retainBuild |= UpdatePackages(
                         newPackageFiles,
-                        roslynBuildVersion,
+                        buildVersion,
                         coreXT,
-                        GetDevDivPackagesDirPath(roslynBuildVersion),
+                        GetDevDivPackagesDirPath(buildVersion),
                         cancellationToken);
 
                     // ************ Update .corext\Configs\default.config ********************
@@ -113,7 +113,7 @@ namespace Roslyn.Insertion
                     Log.Info($"Update paths to CoreFX libraries");
                     if (!await TryUpdateFileAsync(
                         Path.Combine("ProductData", "ContractAssemblies.props"),
-                        roslynBuildVersion,
+                        buildVersion,
                         onlyCopyIfFileDoesNotExistAtDestination: false,
                         cancellationToken: cancellationToken))
                     {
@@ -123,7 +123,7 @@ namespace Roslyn.Insertion
                     // ************** Update assembly versions ************************
                     cancellationToken.ThrowIfCancellationRequested();
                     Log.Info($"Updating assembly versions");
-                    UpdateAssemblyVersions(roslynBuildVersion);
+                    UpdateAssemblyVersions(buildVersion);
 
                     // if we got this far then we definitely need to retain this build
                     retainBuild = true;
@@ -132,7 +132,7 @@ namespace Roslyn.Insertion
                 // *********** Update toolset ********************
                 if (Options.InsertToolset)
                 {
-                    UpdateToolsetPackage(roslynBuildVersion, cancellationToken);
+                    UpdateToolsetPackage(buildVersion, cancellationToken);
                     retainBuild = true;
                 }
 
@@ -193,8 +193,8 @@ namespace Roslyn.Insertion
                     Log.Info($"Create Pull Request");
                     try
                     {
-                        PushChanges(branch, roslynBuildVersion, cancellationToken);
-                        pullRequest = await CreatePullRequestAsync(branch.FriendlyName, $"Updating {Options.InsertionName} to {roslynBuildVersion}", cancellationToken);
+                        PushChanges(branch, buildVersion, cancellationToken);
+                        pullRequest = await CreatePullRequestAsync(branch.FriendlyName, $"Updating {Options.InsertionName} to {buildVersion}", cancellationToken);
                         shouldRollBackGitChanges = false;
                     }
                     catch (EmptyCommitException ecx)
@@ -313,12 +313,12 @@ namespace Roslyn.Insertion
         }
 
         private static void UpdateToolsetPackage(
-            BuildVersion roslynBuildVersion,
+            BuildVersion buildVersion,
             CancellationToken cancellationToken)
         {
             Log.Info("Updating toolset compiler package");
 
-            var packagesDir = GetDevDivPackagesDirPath(roslynBuildVersion);
+            var packagesDir = GetDevDivPackagesDirPath(buildVersion);
             var toolsetPackagePath = Directory.EnumerateFiles(packagesDir,
                 $"{PackageInfo.RoslynToolsetPackageName}*.nupkg",
                 SearchOption.AllDirectories).Single();
@@ -332,7 +332,7 @@ namespace Roslyn.Insertion
                 throw new Exception("Toolset package is not installed in this enlistment");
             }
 
-            UpdatePackage(previousPackageVersion, roslynBuildVersion, coreXT, package);
+            UpdatePackage(previousPackageVersion, buildVersion, coreXT, package);
 
             // Update .corext/Configs/default.config
             cancellationToken.ThrowIfCancellationRequested();
@@ -393,7 +393,7 @@ namespace Roslyn.Insertion
                 {
                     if (pullRequest != null)
                     {
-                        mailMessage.Subject = $"{Options.InsertionName} insertion from {Options.GithubBuildQueueName}/{Options.GithubBranchName}/{Options.GithubBuildConfig} into {Options.VisualStudioBranchName} SUCCEEDED";
+                        mailMessage.Subject = $"{Options.InsertionName} insertion from {Options.BuildQueueName}/{Options.BranchName}/{Options.BuildConfig} into {Options.VisualStudioBranchName} SUCCEEDED";
                         mailMessage.SubjectEncoding = Encoding.UTF8;
                         mailMessage.IsBodyHtml = true;
                         mailMessage.Body = GetHTMLSuccessMessage(pullRequest, newPackageFiles);
@@ -403,7 +403,7 @@ namespace Roslyn.Insertion
                     {
                         var insertionStatus = isInsertionCancelled ? "CANCELLED" : "FAILED";
 
-                        mailMessage.Subject = $"{Options.InsertionName} insertion from {Options.GithubBuildQueueName}/{Options.GithubBranchName}/{Options.GithubBuildConfig} into {Options.VisualStudioBranchName} {insertionStatus}";
+                        mailMessage.Subject = $"{Options.InsertionName} insertion from {Options.BuildQueueName}/{Options.BranchName}/{Options.BuildConfig} into {Options.VisualStudioBranchName} {insertionStatus}";
                         mailMessage.SubjectEncoding = Encoding.UTF8;
                         mailMessage.Body = $"Review attached log for details";
                     }

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
@@ -73,7 +73,7 @@ namespace Roslyn.Insertion
                 if (string.IsNullOrEmpty(Options.SpecificBuild))
                 {
                     newestBuild = await GetLatestBuildAsync(cancellationToken);
-                    roslynBuildVersion = BuildVersion.FromTfsBuildNumber(newestBuild.BuildNumber, Options.RoslynBuildQueueName);
+                    roslynBuildVersion = BuildVersion.FromTfsBuildNumber(newestBuild.BuildNumber, Options.GithubBuildQueueName);
                 }
                 else
                 {
@@ -393,7 +393,7 @@ namespace Roslyn.Insertion
                 {
                     if (pullRequest != null)
                     {
-                        mailMessage.Subject = $"{Options.InsertionName} insertion from {Options.RoslynBuildQueueName}/{Options.RoslynBranchName}/{Options.RoslynBuildConfig} into {Options.VisualStudioBranchName} SUCCEEDED";
+                        mailMessage.Subject = $"{Options.InsertionName} insertion from {Options.GithubBuildQueueName}/{Options.GithubBranchName}/{Options.GithubBuildConfig} into {Options.VisualStudioBranchName} SUCCEEDED";
                         mailMessage.SubjectEncoding = Encoding.UTF8;
                         mailMessage.IsBodyHtml = true;
                         mailMessage.Body = GetHTMLSuccessMessage(pullRequest, newPackageFiles);
@@ -403,7 +403,7 @@ namespace Roslyn.Insertion
                     {
                         var insertionStatus = isInsertionCancelled ? "CANCELLED" : "FAILED";
 
-                        mailMessage.Subject = $"{Options.InsertionName} insertion from {Options.RoslynBuildQueueName}/{Options.RoslynBranchName}/{Options.RoslynBuildConfig} into {Options.VisualStudioBranchName} {insertionStatus}";
+                        mailMessage.Subject = $"{Options.InsertionName} insertion from {Options.GithubBuildQueueName}/{Options.GithubBranchName}/{Options.GithubBuildConfig} into {Options.VisualStudioBranchName} {insertionStatus}";
                         mailMessage.SubjectEncoding = Encoding.UTF8;
                         mailMessage.Body = $"Review attached log for details";
                     }

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionToolOptions.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionToolOptions.cs
@@ -13,13 +13,13 @@ namespace Roslyn.Insertion
             string username,
             string password,
             string visualStudioBranchName,
-            string githubBuildQueueName,
-            string githubBranchName,
-            string githubBuildConfig,
+            string buildQueueName,
+            string branchName,
+            string buildConfig,
             string vstsUri,
             string tfsProjectName,
             string newBranchName,
-            string githubBuildDropPath,
+            string buildDropPath,
             string specificbuild,
             string emailServerName,
             string mailRecipient,
@@ -39,13 +39,13 @@ namespace Roslyn.Insertion
             Username = username;
             Password = password;
             VisualStudioBranchName = visualStudioBranchName;
-            GithubBuildQueueName = githubBuildQueueName;
-            GithubBranchName = githubBranchName;
-            GithubBuildConfig = githubBuildConfig;
+            BuildQueueName = buildQueueName;
+            BranchName = branchName;
+            BuildConfig = buildConfig;
             VSTSUri = vstsUri;
             TFSProjectName = tfsProjectName;
             NewBranchName = newBranchName;
-            GithubBuildDropPath = githubBuildDropPath;
+            BuildDropPath = buildDropPath;
             SpecificBuild = specificbuild;
             EmailServerName = emailServerName;
             MailRecipient = mailRecipient;
@@ -69,13 +69,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                githubBuildQueueName: GithubBuildQueueName,
-                githubBranchName: GithubBranchName,
-                githubBuildConfig: GithubBuildConfig,
+                buildQueueName: BuildQueueName,
+                branchName: BranchName,
+                buildConfig: BuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                githubBuildDropPath: GithubBuildDropPath,
+                buildDropPath: BuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -99,13 +99,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                githubBuildQueueName: GithubBuildQueueName,
-                githubBranchName: GithubBranchName,
-                githubBuildConfig: GithubBuildConfig,
+                buildQueueName: BuildQueueName,
+                branchName: BranchName,
+                buildConfig: BuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                githubBuildDropPath: GithubBuildDropPath,
+                buildDropPath: BuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -129,13 +129,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                githubBuildQueueName: GithubBuildQueueName,
-                githubBranchName: GithubBranchName,
-                githubBuildConfig: GithubBuildConfig,
+                buildQueueName: BuildQueueName,
+                branchName: BranchName,
+                buildConfig: BuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                githubBuildDropPath: GithubBuildDropPath,
+                buildDropPath: BuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -154,18 +154,18 @@ namespace Roslyn.Insertion
 
         public RoslynInsertionToolOptions WithQueueValidationBuild(bool queueValidationBuild)
         {
-            return new RoslynInsertionToolOptions(
+             return new RoslynInsertionToolOptions(
                 enlistmentPath: EnlistmentPath,
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                githubBuildQueueName: GithubBuildQueueName,
-                githubBranchName: GithubBranchName,
-                githubBuildConfig: GithubBuildConfig,
+                buildQueueName: BuildQueueName,
+                branchName: BranchName,
+                buildConfig: BuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                githubBuildDropPath: GithubBuildDropPath,
+                buildDropPath: BuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -189,13 +189,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                githubBuildQueueName: GithubBuildQueueName,
-                githubBranchName: GithubBranchName,
-                githubBuildConfig: GithubBuildConfig,
+                buildQueueName: BuildQueueName,
+                branchName: BranchName,
+                buildConfig: BuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                githubBuildDropPath: GithubBuildDropPath,
+                buildDropPath: BuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -218,13 +218,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                githubBuildQueueName: GithubBuildQueueName,
-                githubBranchName: GithubBranchName,
-                githubBuildConfig: GithubBuildConfig,
+                buildQueueName: BuildQueueName,
+                branchName: BranchName,
+                buildConfig: BuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                githubBuildDropPath: GithubBuildDropPath,
+                buildDropPath: BuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -246,13 +246,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                githubBuildQueueName: GithubBuildQueueName,
-                githubBranchName: GithubBranchName,
-                githubBuildConfig: GithubBuildConfig,
+                buildQueueName: BuildQueueName,
+                branchName: BranchName,
+                buildConfig: BuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                githubBuildDropPath: GithubBuildDropPath,
+                buildDropPath: BuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -275,13 +275,13 @@ namespace Roslyn.Insertion
                 username: username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                githubBuildQueueName: GithubBuildQueueName,
-                githubBranchName: GithubBranchName,
-                githubBuildConfig: GithubBuildConfig,
+                buildQueueName: BuildQueueName,
+                branchName: BranchName,
+                buildConfig: BuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                githubBuildDropPath: GithubBuildDropPath,
+                buildDropPath: BuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -305,13 +305,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: password,
                 visualStudioBranchName: VisualStudioBranchName,
-                githubBuildQueueName: GithubBuildQueueName,
-                githubBranchName: GithubBranchName,
-                githubBuildConfig: GithubBuildConfig,
+                buildQueueName: BuildQueueName,
+                branchName: BranchName,
+                buildConfig: BuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                githubBuildDropPath: GithubBuildDropPath,
+                buildDropPath: BuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -335,13 +335,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: visualStudioBranchName,
-                githubBuildQueueName: GithubBuildQueueName,
-                githubBranchName: GithubBranchName,
-                githubBuildConfig: GithubBuildConfig,
+                buildQueueName: BuildQueueName,
+                branchName: BranchName,
+                buildConfig: BuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                githubBuildDropPath: GithubBuildDropPath,
+                buildDropPath: BuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -358,20 +358,20 @@ namespace Roslyn.Insertion
                 partitionsToBuild: PartitionsToBuild);
         }
 
-        public RoslynInsertionToolOptions WithGithubBuildQueueName(string githubBuildQueueName)
+        public RoslynInsertionToolOptions WithBuildQueueName(string buildQueueName)
         {
             return new RoslynInsertionToolOptions(
                 enlistmentPath: EnlistmentPath,
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                githubBuildQueueName: githubBuildQueueName,
-                githubBranchName: GithubBranchName,
-                githubBuildConfig: GithubBuildConfig,
+                buildQueueName: buildQueueName,
+                branchName: BranchName,
+                buildConfig: BuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                githubBuildDropPath: GithubBuildDropPath,
+                buildDropPath: BuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -388,20 +388,20 @@ namespace Roslyn.Insertion
                 partitionsToBuild: PartitionsToBuild);
         }
 
-        public RoslynInsertionToolOptions WithGitHubBranchName(string githubBranchName)
+        public RoslynInsertionToolOptions WithbranchName(string branchName)
         {
             return new RoslynInsertionToolOptions(
                 enlistmentPath: EnlistmentPath,
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                githubBuildQueueName: GithubBuildQueueName,
-                githubBranchName: githubBranchName,
-                githubBuildConfig: GithubBuildConfig,
+                buildQueueName: BuildQueueName,
+                branchName: branchName,
+                buildConfig: BuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                githubBuildDropPath: GithubBuildDropPath,
+                buildDropPath: BuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -418,20 +418,20 @@ namespace Roslyn.Insertion
                 partitionsToBuild: PartitionsToBuild);
         }
 
-        public RoslynInsertionToolOptions WithGithubBuildConfig(string githubBuildConfig)
+        public RoslynInsertionToolOptions WithBuildConfig(string buildConfig)
         {
             return new RoslynInsertionToolOptions(
                 enlistmentPath: EnlistmentPath,
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                githubBuildQueueName: GithubBuildQueueName,
-                githubBranchName: GithubBranchName,
-                githubBuildConfig: githubBuildConfig,
+                buildQueueName: BuildQueueName,
+                branchName: BranchName,
+                buildConfig: buildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                githubBuildDropPath: GithubBuildDropPath,
+                buildDropPath: BuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -455,13 +455,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                githubBuildQueueName: GithubBuildQueueName,
-                githubBranchName: GithubBranchName,
-                githubBuildConfig: GithubBuildConfig,
+                buildQueueName: BuildQueueName,
+                branchName: BranchName,
+                buildConfig: BuildConfig,
                 vstsUri: vstsUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                githubBuildDropPath: GithubBuildDropPath,
+                buildDropPath: BuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -485,13 +485,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                githubBuildQueueName: GithubBuildQueueName,
-                githubBranchName: GithubBranchName,
-                githubBuildConfig: GithubBuildConfig,
+                buildQueueName: BuildQueueName,
+                branchName: BranchName,
+                buildConfig: BuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: tfsProjectName,
                 newBranchName: NewBranchName,
-                githubBuildDropPath: GithubBuildDropPath,
+                buildDropPath: BuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -515,13 +515,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                githubBuildQueueName: GithubBuildQueueName,
-                githubBranchName: GithubBranchName,
-                githubBuildConfig: GithubBuildConfig,
+                buildQueueName: BuildQueueName,
+                branchName: BranchName,
+                buildConfig: BuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: newBranchName,
-                githubBuildDropPath: GithubBuildDropPath,
+                buildDropPath: BuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -538,20 +538,20 @@ namespace Roslyn.Insertion
                 partitionsToBuild: PartitionsToBuild);
         }
 
-        public RoslynInsertionToolOptions WithGithubBuildDropPath(string githubBuildDropPath)
+        public RoslynInsertionToolOptions WithBuildDropPath(string buildDropPath)
         {
             return new RoslynInsertionToolOptions(
                 enlistmentPath: EnlistmentPath,
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                githubBuildQueueName: GithubBuildQueueName,
-                githubBranchName: GithubBranchName,
-                githubBuildConfig: GithubBuildConfig,
+                buildQueueName: BuildQueueName,
+                branchName: BranchName,
+                buildConfig: BuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                githubBuildDropPath: githubBuildDropPath,
+                buildDropPath: buildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -575,13 +575,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                githubBuildQueueName: GithubBuildQueueName,
-                githubBranchName: GithubBranchName,
-                githubBuildConfig: GithubBuildConfig,
+                buildQueueName: BuildQueueName,
+                branchName: BranchName,
+                buildConfig: BuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                githubBuildDropPath: GithubBuildDropPath,
+                buildDropPath: BuildDropPath,
                 specificbuild: specificbuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -605,13 +605,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                githubBuildQueueName: GithubBuildQueueName,
-                githubBranchName: GithubBranchName,
-                githubBuildConfig: GithubBuildConfig,
+                buildQueueName: BuildQueueName,
+                branchName: BranchName,
+                buildConfig: BuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                githubBuildDropPath: GithubBuildDropPath,
+                buildDropPath: BuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: emailServerName,
                 mailRecipient: MailRecipient,
@@ -635,13 +635,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                githubBuildQueueName: GithubBuildQueueName,
-                githubBranchName: GithubBranchName,
-                githubBuildConfig: GithubBuildConfig,
+                buildQueueName: BuildQueueName,
+                branchName: BranchName,
+                buildConfig: BuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                githubBuildDropPath: GithubBuildDropPath,
+                buildDropPath: BuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: mailRecipient,
@@ -665,13 +665,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                githubBuildQueueName: GithubBuildQueueName,
-                githubBranchName: GithubBranchName,
-                githubBuildConfig: GithubBuildConfig,
+                buildQueueName: BuildQueueName,
+                branchName: BranchName,
+                buildConfig: BuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                githubBuildDropPath: GithubBuildDropPath,
+                buildDropPath: BuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -695,13 +695,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                githubBuildQueueName: GithubBuildQueueName,
-                githubBranchName: GithubBranchName,
-                githubBuildConfig: GithubBuildConfig,
+                buildQueueName: BuildQueueName,
+                branchName: BranchName,
+                buildConfig: BuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                githubBuildDropPath: GithubBuildDropPath,
+                buildDropPath: BuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -725,13 +725,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                githubBuildQueueName: GithubBuildQueueName,
-                githubBranchName: GithubBranchName,
-                githubBuildConfig: GithubBuildConfig,
+                buildQueueName: BuildQueueName,
+                branchName: BranchName,
+                buildConfig: BuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                githubBuildDropPath: GithubBuildDropPath,
+                buildDropPath: BuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -755,13 +755,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                githubBuildQueueName: GithubBuildQueueName,
-                githubBranchName: GithubBranchName,
-                githubBuildConfig: GithubBuildConfig,
+                buildQueueName: BuildQueueName,
+                branchName: BranchName,
+                buildConfig: BuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                githubBuildDropPath: GithubBuildDropPath,
+                buildDropPath: BuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -785,13 +785,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                githubBuildQueueName: GithubBuildQueueName,
-                githubBranchName: GithubBranchName,
-                githubBuildConfig: GithubBuildConfig,
+                buildQueueName: BuildQueueName,
+                branchName: BranchName,
+                buildConfig: BuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                githubBuildDropPath: GithubBuildDropPath,
+                buildDropPath: BuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -816,11 +816,11 @@ namespace Roslyn.Insertion
 
         public string VisualStudioBranchName { get; }
 
-        public string GithubBuildQueueName { get; }
+        public string BuildQueueName { get; }
 
-        public string GithubBranchName { get; }
+        public string BranchName { get; }
 
-        public string GithubBuildConfig { get; }
+        public string BuildConfig { get; }
 
         public string VSTSUri { get; }
 
@@ -828,7 +828,7 @@ namespace Roslyn.Insertion
 
         public string NewBranchName { get; }
 
-        public string GithubBuildDropPath { get; }
+        public string BuildDropPath { get; }
 
         public string SpecificBuild { get; }
 
@@ -863,12 +863,12 @@ namespace Roslyn.Insertion
             !string.IsNullOrEmpty(Username) &&
             !string.IsNullOrEmpty(Password) &&
             !string.IsNullOrEmpty(VisualStudioBranchName) &&
-            !string.IsNullOrEmpty(GithubBuildQueueName) &&
-            !string.IsNullOrEmpty(GithubBranchName) &&
-            !string.IsNullOrEmpty(GithubBuildConfig) &&
+            !string.IsNullOrEmpty(BuildQueueName) &&
+            !string.IsNullOrEmpty(BranchName) &&
+            !string.IsNullOrEmpty(BuildConfig) &&
             !string.IsNullOrEmpty(VSTSUri) &&
             !string.IsNullOrEmpty(TFSProjectName) &&
-            !string.IsNullOrEmpty(GithubBuildDropPath);
+            !string.IsNullOrEmpty(BuildDropPath);
 
         public string ValidationErrors
         {
@@ -895,19 +895,19 @@ namespace Roslyn.Insertion
                     builder.AppendLine($"{nameof(VisualStudioBranchName).ToLowerInvariant()} is required");
                 }
 
-                if (string.IsNullOrEmpty(GithubBuildQueueName))
+                if (string.IsNullOrEmpty(BuildQueueName))
                 {
-                    builder.AppendLine($"{nameof(GithubBuildQueueName).ToLowerInvariant()} is required");
+                    builder.AppendLine($"{nameof(BuildQueueName).ToLowerInvariant()} is required");
                 }
 
-                if (string.IsNullOrEmpty(GithubBranchName))
+                if (string.IsNullOrEmpty(BranchName))
                 {
-                    builder.AppendLine($"{nameof(GithubBranchName).ToLowerInvariant()} is required");
+                    builder.AppendLine($"{nameof(BranchName).ToLowerInvariant()} is required");
                 }
 
-                if (string.IsNullOrEmpty(GithubBuildConfig))
+                if (string.IsNullOrEmpty(BuildConfig))
                 {
-                    builder.AppendLine($"{nameof(GithubBuildConfig).ToLowerInvariant()} is required");
+                    builder.AppendLine($"{nameof(BuildConfig).ToLowerInvariant()} is required");
                 }
 
                 if (string.IsNullOrEmpty(VSTSUri))
@@ -920,9 +920,9 @@ namespace Roslyn.Insertion
                     builder.AppendLine($"{nameof(TFSProjectName).ToLowerInvariant()} is required");
                 }
 
-                if (string.IsNullOrEmpty(GithubBuildDropPath))
+                if (string.IsNullOrEmpty(BuildDropPath))
                 {
-                    builder.AppendLine($"{nameof(GithubBuildDropPath).ToLowerInvariant()} is required");
+                    builder.AppendLine($"{nameof(BuildDropPath).ToLowerInvariant()} is required");
                 }
 
                 return builder.ToString();

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionToolOptions.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionToolOptions.cs
@@ -13,13 +13,13 @@ namespace Roslyn.Insertion
             string username,
             string password,
             string visualStudioBranchName,
-            string roslynBuildQueueName,
-            string roslynBranchName,
-            string roslynBuildConfig,
+            string githubBuildQueueName,
+            string githubBranchName,
+            string githubBuildConfig,
             string vstsUri,
             string tfsProjectName,
             string newBranchName,
-            string roslynDropPath,
+            string githubBuildDropPath,
             string specificbuild,
             string emailServerName,
             string mailRecipient,
@@ -39,13 +39,13 @@ namespace Roslyn.Insertion
             Username = username;
             Password = password;
             VisualStudioBranchName = visualStudioBranchName;
-            RoslynBuildQueueName = roslynBuildQueueName;
-            RoslynBranchName = roslynBranchName;
-            RoslynBuildConfig = roslynBuildConfig;
+            GithubBuildQueueName = githubBuildQueueName;
+            GithubBranchName = githubBranchName;
+            GithubBuildConfig = githubBuildConfig;
             VSTSUri = vstsUri;
             TFSProjectName = tfsProjectName;
             NewBranchName = newBranchName;
-            RoslynDropPath = roslynDropPath;
+            GithubBuildDropPath = githubBuildDropPath;
             SpecificBuild = specificbuild;
             EmailServerName = emailServerName;
             MailRecipient = mailRecipient;
@@ -69,13 +69,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                roslynBuildQueueName: RoslynBuildQueueName,
-                roslynBranchName: RoslynBranchName,
-                roslynBuildConfig: RoslynBuildConfig,
+                githubBuildQueueName: GithubBuildQueueName,
+                githubBranchName: GithubBranchName,
+                githubBuildConfig: GithubBuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                roslynDropPath: RoslynDropPath,
+                githubBuildDropPath: GithubBuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -99,13 +99,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                roslynBuildQueueName: RoslynBuildQueueName,
-                roslynBranchName: RoslynBranchName,
-                roslynBuildConfig: RoslynBuildConfig,
+                githubBuildQueueName: GithubBuildQueueName,
+                githubBranchName: GithubBranchName,
+                githubBuildConfig: GithubBuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                roslynDropPath: RoslynDropPath,
+                githubBuildDropPath: GithubBuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -129,13 +129,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                roslynBuildQueueName: RoslynBuildQueueName,
-                roslynBranchName: RoslynBranchName,
-                roslynBuildConfig: RoslynBuildConfig,
+                githubBuildQueueName: GithubBuildQueueName,
+                githubBranchName: GithubBranchName,
+                githubBuildConfig: GithubBuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                roslynDropPath: RoslynDropPath,
+                githubBuildDropPath: GithubBuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -159,13 +159,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                roslynBuildQueueName: RoslynBuildQueueName,
-                roslynBranchName: RoslynBranchName,
-                roslynBuildConfig: RoslynBuildConfig,
+                githubBuildQueueName: GithubBuildQueueName,
+                githubBranchName: GithubBranchName,
+                githubBuildConfig: GithubBuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                roslynDropPath: RoslynDropPath,
+                githubBuildDropPath: GithubBuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -189,13 +189,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                roslynBuildQueueName: RoslynBuildQueueName,
-                roslynBranchName: RoslynBranchName,
-                roslynBuildConfig: RoslynBuildConfig,
+                githubBuildQueueName: GithubBuildQueueName,
+                githubBranchName: GithubBranchName,
+                githubBuildConfig: GithubBuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                roslynDropPath: RoslynDropPath,
+                githubBuildDropPath: GithubBuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -218,13 +218,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                roslynBuildQueueName: RoslynBuildQueueName,
-                roslynBranchName: RoslynBranchName,
-                roslynBuildConfig: RoslynBuildConfig,
+                githubBuildQueueName: GithubBuildQueueName,
+                githubBranchName: GithubBranchName,
+                githubBuildConfig: GithubBuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                roslynDropPath: RoslynDropPath,
+                githubBuildDropPath: GithubBuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -246,13 +246,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                roslynBuildQueueName: RoslynBuildQueueName,
-                roslynBranchName: RoslynBranchName,
-                roslynBuildConfig: RoslynBuildConfig,
+                githubBuildQueueName: GithubBuildQueueName,
+                githubBranchName: GithubBranchName,
+                githubBuildConfig: GithubBuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                roslynDropPath: RoslynDropPath,
+                githubBuildDropPath: GithubBuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -275,13 +275,13 @@ namespace Roslyn.Insertion
                 username: username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                roslynBuildQueueName: RoslynBuildQueueName,
-                roslynBranchName: RoslynBranchName,
-                roslynBuildConfig: RoslynBuildConfig,
+                githubBuildQueueName: GithubBuildQueueName,
+                githubBranchName: GithubBranchName,
+                githubBuildConfig: GithubBuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                roslynDropPath: RoslynDropPath,
+                githubBuildDropPath: GithubBuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -305,13 +305,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: password,
                 visualStudioBranchName: VisualStudioBranchName,
-                roslynBuildQueueName: RoslynBuildQueueName,
-                roslynBranchName: RoslynBranchName,
-                roslynBuildConfig: RoslynBuildConfig,
+                githubBuildQueueName: GithubBuildQueueName,
+                githubBranchName: GithubBranchName,
+                githubBuildConfig: GithubBuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                roslynDropPath: RoslynDropPath,
+                githubBuildDropPath: GithubBuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -335,13 +335,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: visualStudioBranchName,
-                roslynBuildQueueName: RoslynBuildQueueName,
-                roslynBranchName: RoslynBranchName,
-                roslynBuildConfig: RoslynBuildConfig,
+                githubBuildQueueName: GithubBuildQueueName,
+                githubBranchName: GithubBranchName,
+                githubBuildConfig: GithubBuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                roslynDropPath: RoslynDropPath,
+                githubBuildDropPath: GithubBuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -358,20 +358,20 @@ namespace Roslyn.Insertion
                 partitionsToBuild: PartitionsToBuild);
         }
 
-        public RoslynInsertionToolOptions WithRoslynBuildQueueName(string roslynBuildQueueName)
+        public RoslynInsertionToolOptions WithGithubBuildQueueName(string githubBuildQueueName)
         {
             return new RoslynInsertionToolOptions(
                 enlistmentPath: EnlistmentPath,
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                roslynBuildQueueName: roslynBuildQueueName,
-                roslynBranchName: RoslynBranchName,
-                roslynBuildConfig: RoslynBuildConfig,
+                githubBuildQueueName: githubBuildQueueName,
+                githubBranchName: GithubBranchName,
+                githubBuildConfig: GithubBuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                roslynDropPath: RoslynDropPath,
+                githubBuildDropPath: GithubBuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -388,20 +388,20 @@ namespace Roslyn.Insertion
                 partitionsToBuild: PartitionsToBuild);
         }
 
-        public RoslynInsertionToolOptions WithRoslynBranchName(string roslynBranchName)
+        public RoslynInsertionToolOptions WithGitHubBranchName(string githubBranchName)
         {
             return new RoslynInsertionToolOptions(
                 enlistmentPath: EnlistmentPath,
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                roslynBuildQueueName: RoslynBuildQueueName,
-                roslynBranchName: roslynBranchName,
-                roslynBuildConfig: RoslynBuildConfig,
+                githubBuildQueueName: GithubBuildQueueName,
+                githubBranchName: githubBranchName,
+                githubBuildConfig: GithubBuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                roslynDropPath: RoslynDropPath,
+                githubBuildDropPath: GithubBuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -418,20 +418,20 @@ namespace Roslyn.Insertion
                 partitionsToBuild: PartitionsToBuild);
         }
 
-        public RoslynInsertionToolOptions WithRoslynBuildConfig(string roslynBuildConfig)
+        public RoslynInsertionToolOptions WithGithubBuildConfig(string githubBuildConfig)
         {
             return new RoslynInsertionToolOptions(
                 enlistmentPath: EnlistmentPath,
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                roslynBuildQueueName: RoslynBuildQueueName,
-                roslynBranchName: RoslynBranchName,
-                roslynBuildConfig: roslynBuildConfig,
+                githubBuildQueueName: GithubBuildQueueName,
+                githubBranchName: GithubBranchName,
+                githubBuildConfig: githubBuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                roslynDropPath: RoslynDropPath,
+                githubBuildDropPath: GithubBuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -455,13 +455,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                roslynBuildQueueName: RoslynBuildQueueName,
-                roslynBranchName: RoslynBranchName,
-                roslynBuildConfig: RoslynBuildConfig,
+                githubBuildQueueName: GithubBuildQueueName,
+                githubBranchName: GithubBranchName,
+                githubBuildConfig: GithubBuildConfig,
                 vstsUri: vstsUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                roslynDropPath: RoslynDropPath,
+                githubBuildDropPath: GithubBuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -485,13 +485,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                roslynBuildQueueName: RoslynBuildQueueName,
-                roslynBranchName: RoslynBranchName,
-                roslynBuildConfig: RoslynBuildConfig,
+                githubBuildQueueName: GithubBuildQueueName,
+                githubBranchName: GithubBranchName,
+                githubBuildConfig: GithubBuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: tfsProjectName,
                 newBranchName: NewBranchName,
-                roslynDropPath: RoslynDropPath,
+                githubBuildDropPath: GithubBuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -515,13 +515,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                roslynBuildQueueName: RoslynBuildQueueName,
-                roslynBranchName: RoslynBranchName,
-                roslynBuildConfig: RoslynBuildConfig,
+                githubBuildQueueName: GithubBuildQueueName,
+                githubBranchName: GithubBranchName,
+                githubBuildConfig: GithubBuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: newBranchName,
-                roslynDropPath: RoslynDropPath,
+                githubBuildDropPath: GithubBuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -538,20 +538,20 @@ namespace Roslyn.Insertion
                 partitionsToBuild: PartitionsToBuild);
         }
 
-        public RoslynInsertionToolOptions WithRoslynDropPath(string roslynDropPath)
+        public RoslynInsertionToolOptions WithGithubBuildDropPath(string githubBuildDropPath)
         {
             return new RoslynInsertionToolOptions(
                 enlistmentPath: EnlistmentPath,
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                roslynBuildQueueName: RoslynBuildQueueName,
-                roslynBranchName: RoslynBranchName,
-                roslynBuildConfig: RoslynBuildConfig,
+                githubBuildQueueName: GithubBuildQueueName,
+                githubBranchName: GithubBranchName,
+                githubBuildConfig: GithubBuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                roslynDropPath: roslynDropPath,
+                githubBuildDropPath: githubBuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -575,13 +575,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                roslynBuildQueueName: RoslynBuildQueueName,
-                roslynBranchName: RoslynBranchName,
-                roslynBuildConfig: RoslynBuildConfig,
+                githubBuildQueueName: GithubBuildQueueName,
+                githubBranchName: GithubBranchName,
+                githubBuildConfig: GithubBuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                roslynDropPath: RoslynDropPath,
+                githubBuildDropPath: GithubBuildDropPath,
                 specificbuild: specificbuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -605,13 +605,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                roslynBuildQueueName: RoslynBuildQueueName,
-                roslynBranchName: RoslynBranchName,
-                roslynBuildConfig: RoslynBuildConfig,
+                githubBuildQueueName: GithubBuildQueueName,
+                githubBranchName: GithubBranchName,
+                githubBuildConfig: GithubBuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                roslynDropPath: RoslynDropPath,
+                githubBuildDropPath: GithubBuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: emailServerName,
                 mailRecipient: MailRecipient,
@@ -635,13 +635,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                roslynBuildQueueName: RoslynBuildQueueName,
-                roslynBranchName: RoslynBranchName,
-                roslynBuildConfig: RoslynBuildConfig,
+                githubBuildQueueName: GithubBuildQueueName,
+                githubBranchName: GithubBranchName,
+                githubBuildConfig: GithubBuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                roslynDropPath: RoslynDropPath,
+                githubBuildDropPath: GithubBuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: mailRecipient,
@@ -665,13 +665,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                roslynBuildQueueName: RoslynBuildQueueName,
-                roslynBranchName: RoslynBranchName,
-                roslynBuildConfig: RoslynBuildConfig,
+                githubBuildQueueName: GithubBuildQueueName,
+                githubBranchName: GithubBranchName,
+                githubBuildConfig: GithubBuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                roslynDropPath: RoslynDropPath,
+                githubBuildDropPath: GithubBuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -695,13 +695,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                roslynBuildQueueName: RoslynBuildQueueName,
-                roslynBranchName: RoslynBranchName,
-                roslynBuildConfig: RoslynBuildConfig,
+                githubBuildQueueName: GithubBuildQueueName,
+                githubBranchName: GithubBranchName,
+                githubBuildConfig: GithubBuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                roslynDropPath: RoslynDropPath,
+                githubBuildDropPath: GithubBuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -725,13 +725,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                roslynBuildQueueName: RoslynBuildQueueName,
-                roslynBranchName: RoslynBranchName,
-                roslynBuildConfig: RoslynBuildConfig,
+                githubBuildQueueName: GithubBuildQueueName,
+                githubBranchName: GithubBranchName,
+                githubBuildConfig: GithubBuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                roslynDropPath: RoslynDropPath,
+                githubBuildDropPath: GithubBuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -755,13 +755,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                roslynBuildQueueName: RoslynBuildQueueName,
-                roslynBranchName: RoslynBranchName,
-                roslynBuildConfig: RoslynBuildConfig,
+                githubBuildQueueName: GithubBuildQueueName,
+                githubBranchName: GithubBranchName,
+                githubBuildConfig: GithubBuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                roslynDropPath: RoslynDropPath,
+                githubBuildDropPath: GithubBuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -785,13 +785,13 @@ namespace Roslyn.Insertion
                 username: Username,
                 password: Password,
                 visualStudioBranchName: VisualStudioBranchName,
-                roslynBuildQueueName: RoslynBuildQueueName,
-                roslynBranchName: RoslynBranchName,
-                roslynBuildConfig: RoslynBuildConfig,
+                githubBuildQueueName: GithubBuildQueueName,
+                githubBranchName: GithubBranchName,
+                githubBuildConfig: GithubBuildConfig,
                 vstsUri: VSTSUri,
                 tfsProjectName: TFSProjectName,
                 newBranchName: NewBranchName,
-                roslynDropPath: RoslynDropPath,
+                githubBuildDropPath: GithubBuildDropPath,
                 specificbuild: SpecificBuild,
                 emailServerName: EmailServerName,
                 mailRecipient: MailRecipient,
@@ -816,11 +816,11 @@ namespace Roslyn.Insertion
 
         public string VisualStudioBranchName { get; }
 
-        public string RoslynBuildQueueName { get; }
+        public string GithubBuildQueueName { get; }
 
-        public string RoslynBranchName { get; }
+        public string GithubBranchName { get; }
 
-        public string RoslynBuildConfig { get; }
+        public string GithubBuildConfig { get; }
 
         public string VSTSUri { get; }
 
@@ -828,7 +828,7 @@ namespace Roslyn.Insertion
 
         public string NewBranchName { get; }
 
-        public string RoslynDropPath { get; }
+        public string GithubBuildDropPath { get; }
 
         public string SpecificBuild { get; }
 
@@ -863,12 +863,12 @@ namespace Roslyn.Insertion
             !string.IsNullOrEmpty(Username) &&
             !string.IsNullOrEmpty(Password) &&
             !string.IsNullOrEmpty(VisualStudioBranchName) &&
-            !string.IsNullOrEmpty(RoslynBuildQueueName) &&
-            !string.IsNullOrEmpty(RoslynBranchName) &&
-            !string.IsNullOrEmpty(RoslynBuildConfig) &&
+            !string.IsNullOrEmpty(GithubBuildQueueName) &&
+            !string.IsNullOrEmpty(GithubBranchName) &&
+            !string.IsNullOrEmpty(GithubBuildConfig) &&
             !string.IsNullOrEmpty(VSTSUri) &&
             !string.IsNullOrEmpty(TFSProjectName) &&
-            !string.IsNullOrEmpty(RoslynDropPath);
+            !string.IsNullOrEmpty(GithubBuildDropPath);
 
         public string ValidationErrors
         {
@@ -895,19 +895,19 @@ namespace Roslyn.Insertion
                     builder.AppendLine($"{nameof(VisualStudioBranchName).ToLowerInvariant()} is required");
                 }
 
-                if (string.IsNullOrEmpty(RoslynBuildQueueName))
+                if (string.IsNullOrEmpty(GithubBuildQueueName))
                 {
-                    builder.AppendLine($"{nameof(RoslynBuildQueueName).ToLowerInvariant()} is required");
+                    builder.AppendLine($"{nameof(GithubBuildQueueName).ToLowerInvariant()} is required");
                 }
 
-                if (string.IsNullOrEmpty(RoslynBranchName))
+                if (string.IsNullOrEmpty(GithubBranchName))
                 {
-                    builder.AppendLine($"{nameof(RoslynBranchName).ToLowerInvariant()} is required");
+                    builder.AppendLine($"{nameof(GithubBranchName).ToLowerInvariant()} is required");
                 }
 
-                if (string.IsNullOrEmpty(RoslynBuildConfig))
+                if (string.IsNullOrEmpty(GithubBuildConfig))
                 {
-                    builder.AppendLine($"{nameof(RoslynBuildConfig).ToLowerInvariant()} is required");
+                    builder.AppendLine($"{nameof(GithubBuildConfig).ToLowerInvariant()} is required");
                 }
 
                 if (string.IsNullOrEmpty(VSTSUri))
@@ -920,9 +920,9 @@ namespace Roslyn.Insertion
                     builder.AppendLine($"{nameof(TFSProjectName).ToLowerInvariant()} is required");
                 }
 
-                if (string.IsNullOrEmpty(RoslynDropPath))
+                if (string.IsNullOrEmpty(GithubBuildDropPath))
                 {
-                    builder.AppendLine($"{nameof(RoslynDropPath).ToLowerInvariant()} is required");
+                    builder.AppendLine($"{nameof(GithubBuildDropPath).ToLowerInvariant()} is required");
                 }
 
                 return builder.ToString();


### PR DESCRIPTION
… non-roslyn github repositories now