### PR TITLE
Use Roslyn instead of al.exe to generate satellite assemblies

### DIFF
--- a/sdks/RepoToolset/tools/Localization.props
+++ b/sdks/RepoToolset/tools/Localization.props
@@ -13,6 +13,11 @@
 
   <PropertyGroup>
     <UpdateXlfOnBuild Condition="'$(CIBuild)' != 'true'">true</UpdateXlfOnBuild>
+
+    <!-- Use Satellite assembly generation task from Microsoft.NET.Sdk even when building with
+         full Framework MSBuild.  This will support public signing, is deterministic, and always
+         generates them as AnyCPU. -->
+    <GenerateSatelliteAssembliesForCore Condition="'$(GenerateSatelliteAssembliesForCore)' == ''">true</GenerateSatelliteAssembliesForCore>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdks/RepoToolset/tools/StrongName.targets
+++ b/sdks/RepoToolset/tools/StrongName.targets
@@ -50,22 +50,6 @@
     </When>
   </Choose>
 
-  <!--
-    Work around https://github.com/Microsoft/msbuild/issues/1490 (lack of support for public-signing satellites) by
-    delay-signing satellite assemblies when main assembly is public-signed.
-  -->
-  <Target Name="PrepareToDelaySignSatelliteAssemblies" BeforeTargets="GenerateSatelliteAssemblies">
-    <PropertyGroup>
-      <_DelaySignMainAssembly>$(DelaySign)</_DelaySignMainAssembly>
-      <DelaySign Condition="'$(PublicSign)' == 'true'">true</DelaySign>
-    </PropertyGroup>
-  </Target>
-  <Target Name="CleanupAfterDelaySigningSatelliteAssemblies" AfterTargets="GenerateSatelliteAssemblies">
-    <PropertyGroup>
-      <DelaySign>$(_DelaySignMainAssembly)</DelaySign>
-    </PropertyGroup>
-  </Target>
-
   <!-- Build Flag Verification -->
   <PropertyGroup>
     <PrepareForBuildDependsOn>$(PrepareForBuildDependsOn);VerifyBuildFlags</PrepareForBuildDependsOn>


### PR DESCRIPTION
Use Satellite assembly generation task from Microsoft.NET.Sdk even when building with full Framework MSBuild.  This will support public signing, is deterministic, and always generates them as AnyCPU.