### PR TITLE
Remove requirement that everything using repotools must be signed

### DIFF
--- a/sdks/RepoToolset/tools/StrongName.targets
+++ b/sdks/RepoToolset/tools/StrongName.targets
@@ -61,9 +61,8 @@
   </PropertyGroup>
 
   <Target Name="VerifyBuildFlags">
-    <Error Condition="'$(SignAssembly)' != 'true'"
-           Text="SignAssembly must be true" />
-    <Error Condition="'$(PublicKey)' == '' or '$(PublicKeyToken)' == '' or '$(AssemblyOriginatorKeyFile)' == ''"
+    <Error Condition="'$(SignAssembly)' != 'false' and
+                      ('$(PublicKey)' == '' or '$(PublicKeyToken)' == '' or '$(AssemblyOriginatorKeyFile)' == '')"
            Text="PublicKey, PublicKeyToken and AssemblyOriginatorKeyFile must be specified" />
   </Target>
 


### PR DESCRIPTION
There are projects which have dependent assemblies that are not signed, and this can break certain scenarios that expect that all signed binaries have signed dependencies.