### PR TITLE
Stop GH merge bot from closing existing PRs

### DIFF
--- a/src/GithubMergeTool/GithubMergeTool.cs
+++ b/src/GithubMergeTool/GithubMergeTool.cs
@@ -16,13 +16,11 @@ namespace GithubMergeTool
         private static readonly Uri GithubBaseUri = new Uri("https://api.github.com/");
 
         private readonly HttpClient _client;
-        private readonly string _username;
 
         public GithubMergeTool(
             string username,
             string password)
         {
-            _username = username;
             var client = new HttpClient();
             client.BaseAddress = GithubBaseUri;
 
@@ -58,7 +56,7 @@ namespace GithubMergeTool
 
             // Check to see if there's already a PR
             HttpResponseMessage prsResponse = await _client.GetAsync(
-                $"repos/{repoOwner}/{repoName}/pulls?state=open&base={destBranch}&head={_username}:{prBranchName}");
+                $"repos/{repoOwner}/{repoName}/pulls?state=open&base={destBranch}&head={repoOwner}:{prBranchName}");
             if (!prsResponse.IsSuccessStatusCode)
             {
                 return (false, prsResponse);


### PR DESCRIPTION
The merge tool looks for existing PRs for its merges and stops if it
finds any. However, the 'head user' specified by the GH API for listing
pull requests is not, in fact, the user name of the person who created
the PR, but the repo owner of the repo the branch was created on. The
code has been changed accordingly.