### PR TITLE
Remove unused line

### DIFF
--- a/sdks/RepoToolset/tools/RepoLayout.props
+++ b/sdks/RepoToolset/tools/RepoLayout.props
@@ -48,8 +48,6 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <RepoRoot Condition="'$(RepoRoot)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'global.json'))\</RepoRoot>
-
     <!-- TODO: remove condition once all repos update their dir structure (https://github.com/dotnet/roslyn-tools/issues/177) -->
     <_EngDir Condition="Exists('$(RepoRoot)eng')">$(RepoRoot)eng\</_EngDir>
     <_EngDir Condition="'$(_EngDir)' == ''">$(RepoRoot)build\</_EngDir>


### PR DESCRIPTION
This line led me to believe that reporoot would default to the directory of `global.json`, but it appears that auto-discovery was intentionally disabled via https://github.com/dotnet/roslyn-tools/commit/23bab92f5e8242e6a4f564cc94cb943c29f88e50

At this point, RepoRoot has already been set to `$([System.IO.Path]::GetFullPath('$(RepoRoot)/'))` which corresponds to the current directory because `/` gets resolved.

@tmat 