### PR TITLE
Emit SignTool errors in canonical format

### DIFF
--- a/sdks/RepoToolset/tools/Sign.proj
+++ b/sdks/RepoToolset/tools/Sign.proj
@@ -33,7 +33,8 @@
       <SignToolArgs Include='"$(ArtifactsConfigurationDir)\"' />
     </ItemGroup>
     
-    <Exec Command="$(NuGetPackageRoot)roslyntools.signtool\$(RoslynToolsSignToolVersion)\tools\SignTool.exe @(SignToolArgs, ' ')" />
+    <Exec Command="$(NuGetPackageRoot)roslyntools.signtool\$(RoslynToolsSignToolVersion)\tools\SignTool.exe @(SignToolArgs, ' ')"
+          LogStandardErrorAsError="true" />
   </Target>
 
 </Project>

--- a/src/SignTool/SignTool/BatchSignUtil.cs
+++ b/src/SignTool/SignTool/BatchSignUtil.cs
@@ -282,11 +282,11 @@ namespace SignTool
                 {
                     if (!File.Exists(fileName.FullPath))
                     {
-                        textWriter.WriteLine($"Did not find {fileName} at {fileName.FullPath}");
+                        textWriter.WriteLine($"signtool : error : Did not find {fileName} at {fileName.FullPath}");
                     }
                     else
                     {
-                        textWriter.WriteLine($"Unable to read content of {fileName.FullPath}: {ex.Message}");
+                        textWriter.WriteLine($"signtool : error : Unable to read content of {fileName.FullPath}: {ex.Message}");
                     }
                     allGood = false;
                 }
@@ -312,7 +312,7 @@ namespace SignTool
                 {
                     if (isVsixCert)
                     {
-                        textWriter.WriteLine($"Assembly {fileName} cannot be signed with a VSIX certificate");
+                        textWriter.WriteLine($"signtool : error : Assembly {fileName} cannot be signed with a VSIX certificate");
                         allGood = false;
                     }
                 }
@@ -320,13 +320,13 @@ namespace SignTool
                 {
                     if (!isVsixCert)
                     {
-                        textWriter.WriteLine($"VSIX {fileName} must be signed with a VSIX certificate");
+                        textWriter.WriteLine($"signtool : error : VSIX {fileName} must be signed with a VSIX certificate");
                         allGood = false;
                     }
 
                     if (fileSignInfo.StrongName != null)
                     {
-                        textWriter.WriteLine($"VSIX {fileName} cannot be strong name signed");
+                        textWriter.WriteLine($"signtool : error : VSIX {fileName} cannot be strong name signed");
                         allGood = false;
                     }
                 }
@@ -334,7 +334,7 @@ namespace SignTool
                 {
                     if (fileSignInfo.StrongName != null || fileSignInfo.Certificate != null)
                     {
-                        textWriter.WriteLine($"Nupkg {fileName} cannot be strong name or certificate signed");
+                        textWriter.WriteLine($"signtool : error : Nupkg {fileName} cannot be strong name or certificate signed");
                         allGood = false;
                     }
                 }
@@ -385,26 +385,26 @@ namespace SignTool
                     if (!_batchData.FileNames.Any(x => FilePathComparer.Equals(x.Name, name)))
                     {
                         allGood = false;
-                        textWriter.WriteLine($"Zip Container '{zipFileName}' has part '{name}' which is not listed in the sign or external list");
+                        textWriter.WriteLine($"signtool : error : Zip Container '{zipFileName}' has part '{name}' which is not listed in the sign or external list");
                         continue;
                     }
 
                     // This represents a binary that we need to sign.  Ensure the content in the VSIX is the same as the
-                    // content in the binaries directory by doing a chekcsum match.
+                    // content in the binaries directory by doing a checksum match.
                     using (var stream = part.GetStream())
                     {
                         string checksum = _contentUtil.GetChecksum(stream);
                         if (!contentMap.TryGetFileName(checksum, out var checksumName))
                         {
                             allGood = false;
-                            textWriter.WriteLine($"{zipFileName} has part {name} which does not match the content in the binaries directory");
+                            textWriter.WriteLine($"signtool : error : {zipFileName} has part {name} which does not match the content in the binaries directory");
                             continue;
                         }
 
                         if (!FilePathComparer.Equals(checksumName.Name, name))
                         {
                             allGood = false;
-                            textWriter.WriteLine($"{zipFileName} has part {name} with a different name in the binaries directory: {checksumName}");
+                            textWriter.WriteLine($"signtool : error : {zipFileName} has part {name} with a different name in the binaries directory: {checksumName}");
                             continue;
                         }
 
@@ -438,7 +438,7 @@ namespace SignTool
                     {
                         if (!_signTool.VerifySignedAssembly(stream))
                         {
-                            textWriter.WriteLine($"Assembly {fileName} is not signed properly");
+                            textWriter.WriteLine($"signtool : error : Assembly {fileName} is not signed properly");
                             allGood = false;
                         }
                     }
@@ -461,7 +461,7 @@ namespace SignTool
                             {
                                 if (!_signTool.VerifySignedAssembly(stream))
                                 {
-                                    textWriter.WriteLine($"Zip container {fileName} has part {relativeName} which is not signed.");
+                                    textWriter.WriteLine($"signtool : error : Zip container {fileName} has part {relativeName} which is not signed.");
                                     allGood = false;
                                 }
                             }

--- a/src/SignTool/SignTool/Program.cs
+++ b/src/SignTool/SignTool/Program.cs
@@ -44,7 +44,7 @@ namespace SignTool
                     batchData = ReadOrchestrationConfigFile(signToolArgs.OutputPath, signToolArgs.ConfigFile);
                     break;
                 default:
-                    Console.WriteLine($"Don't know how to deal with manifest kind '{configFileKind}'");
+                    Console.WriteLine($"signtool : error : Don't know how to deal with manifest kind '{configFileKind}'");
                     return 1;
             }
 
@@ -86,7 +86,7 @@ namespace SignTool
                 {
                     if (map.ContainsKey(relativeFileName))
                     {
-                        Console.WriteLine($"Duplicate file entry: {relativeFileName}");
+                        Console.WriteLine($"signtool : error : Duplicate file entry: {relativeFileName}");
                         allGood = false;
                     }
                     else
@@ -136,7 +136,7 @@ namespace SignTool
                 {
                     if (map.ContainsKey(entry))
                     {
-                        Console.WriteLine($"Duplicate signing info entry for: {entry.FilePath}");
+                        Console.WriteLine($"signtool : error : Duplicate signing info entry for: {entry.FilePath}");
                         allGood = false;
                     }
                     else
@@ -190,7 +190,7 @@ namespace SignTool
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"Error expanding glob {relativeFileName}: {ex.Message}");
+                    Console.WriteLine($"signtool : error : Error expanding glob {relativeFileName}: {ex.Message}");
                     allGood = false;
                 }
             }


### PR DESCRIPTION
This will ensure that these get surfaced as MSBuild errors at any verbosity level.

https://blogs.msdn.microsoft.com/msbuild/2006/11/02/msbuild-visual-studio-aware-error-messages-and-message-formats/