### PR TITLE
Allow projects to opt-out of source build

### DIFF
--- a/sdks/RepoToolset/sdk/Sdk.targets
+++ b/sdks/RepoToolset/sdk/Sdk.targets
@@ -4,6 +4,12 @@
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildThisFileFullPath);$(MSBuildAllProjects)</MSBuildAllProjects>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <_SuppressAllTargets>false</_SuppressAllTargets>
+    <_SuppressAllTargets Condition="'$(DotNetBuildFromSource)' == 'true' and '$(ExcludeFromSourceBuild)' == 'true'">true</_SuppressAllTargets>
+  </PropertyGroup>
   
-  <Import Project="..\tools\Imports.targets" Condition="'$(__ExcludeSdkImports)' != 'true'" />
+  <Import Project="..\tools\Imports.targets" Condition="'$(__ExcludeSdkImports)' != 'true' and !$(_SuppressAllTargets)" />
+  <Import Project="..\tools\Empty.targets" Condition="'$(__ExcludeSdkImports)' != 'true' and $(_SuppressAllTargets)"/>
 </Project>

--- a/sdks/RepoToolset/tools/Build.proj
+++ b/sdks/RepoToolset/tools/Build.proj
@@ -61,7 +61,7 @@
     <RealSign>false</RealSign>
     <RealSign Condition="'$(SignType)' == 'real' or '$(PB_SignType)' == 'real'">true</RealSign>
 
-    <Sign Condition="'$(PB_SignType)' != '' and '$(PB_SignType)' != 'real'">false</Sign>
+    <Sign Condition="('$(PB_SignType)' != '' and '$(PB_SignType)' != 'real') or '$(DotNetBuildFromSource)' == 'true'">false</Sign>
     <Test Condition="'$(PB_SkipTests)' == 'true'">false</Test>
     <IntegrationTest Condition="'$(PB_SkipTests)' == 'true'">false</IntegrationTest>
     <PerformanceTest Condition="'$(PB_SkipTests)' == 'true'">false</PerformanceTest>
@@ -114,6 +114,11 @@
       <_CommonProps Include="VersionsPropsPath=$(VersionsPropsPath)"/>
       <_CommonProps Include="FixedVersionsPropsPath=$(FixedVersionsPropsPath)" Condition="'$(FixedVersionsPropsPath)' != ''"/>
       <_CommonProps Include="DotNetPackageVersionPropsPath=$(DotNetPackageVersionPropsPath)"/>
+      <!-- 
+        When building from source we suppress restore for projects that set ExcludeFromSourceBuild=true.
+        NuGet Restore task reports a warning for such projects, which we suppress here.
+      -->
+      <_CommonProps Include="DisableWarnForInvalidRestoreProjects=true" Condition="'$(DotNetBuildFromSource)' == 'true'"/>
     </ItemGroup>
 
     <ItemGroup Condition="$(_RestoreTools)">

--- a/sdks/RepoToolset/tools/Empty.targets
+++ b/sdks/RepoToolset/tools/Empty.targets
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
+
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+
+  <!--
+    The project shoudln't build in source only build.
+  -->
+
+  <Target Name="_IsProjectRestoreSupported"/>
+  <Target Name="Restore"/>
+  <Target Name="Build"/>
+  <Target Name="Test"/>
+  <Target Name="Pack"/>
+
+</Project>

--- a/sdks/RepoToolset/tools/Empty.targets
+++ b/sdks/RepoToolset/tools/Empty.targets
@@ -7,7 +7,10 @@
   </PropertyGroup>
 
   <!--
-    The project shoudln't build in source only build.
+    Import this file to suppress all targets while allowing the project to participate in the build.
+    Workaround for https://github.com/dotnet/sdk/issues/2071.
+    
+    The targets defined here are not sufficient for the project to be open in Visual Studio without issues though.    
   -->
 
   <Target Name="_IsProjectRestoreSupported"/>

--- a/src/BuildTasks/RoslynTools.BuildTasks.csproj
+++ b/src/BuildTasks/RoslynTools.BuildTasks.csproj
@@ -6,6 +6,8 @@
     <IsPackable>true</IsPackable>
     <NuspecFile>RoslynTools.BuildTasks.nuspec</NuspecFile>
     <NuspecBasePath>$(OutputPath)</NuspecBasePath>
+
+    <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,5 +12,11 @@
     <DebugType Condition="'$(BuildingForLiveUnitTesting)' != 'true'">embedded</DebugType>
 
     <PublishOutputToSymStore>false</PublishOutputToSymStore>
+
+    <!--
+      Most projects in the repo do not participate in source build.
+      Those that do override this setting.
+    -->
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Implements `ExcludeFromSourceBuild` property that projects can set to exclude themselves from source build.