### PR TITLE
Use correct overload for non-Helix based machines

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -69,7 +69,7 @@ static addBuildSteps(def job, def projectName, def os, def configName, def isPR)
       addXUnitDotNETResults(myJob, configName)
 
       if (os == 'Windows_NT') {
-        Utilities.setMachineAffinity(myJob, 'latest-dev15-3')  
+        Utilities.setMachineAffinity(myJob, os, 'latest-dev15-3')
       } else {
         Utilities.setMachineAffinity(myJob, os, 'latest-or-auto')
       }


### PR DESCRIPTION
The setMachineAffinity(job, 'foobar') overload should only be used in cases where directly referencing Helix queues (e.g. setMachineAffinity(job, 'Windows.10.Amd64.DevEx.Open')  This is the eventual endgame for all Jenkins images, but not all queues have been switched over.  Legacy images will still use setMachineAffinity(job, 'Windows_NT', 'foobar') for now.