### PR TITLE
Source Build fixes

### DIFF
--- a/sdks/RepoToolset/tools/Build.proj
+++ b/sdks/RepoToolset/tools/Build.proj
@@ -10,7 +10,9 @@
     Configuration                   Build configuration: "Debug", "Release", etc.
 
     DotNetPackageVersionPropsPath   Package version overrides.
+    DotNetRestoreSourcePropsPath    Overrides of ResourceSources (list of NuGet feeds to download dependencies from)
     DotNetBuildFromSource           Building the entire stack from source with no external dependencies.
+    DotNetBuildOffline              Building without access to NuGet servers.
 
     CIBuild                         "true" when building on CI server
     Restore                         "true" to restore toolset and solution
@@ -79,6 +81,7 @@
   <Target Name="Execute">
     <Error Text="Property 'Projects' must be specified" Condition="'$(Projects)' == ''"/>
     <Error Text="Property 'RepoRoot' must be specified" Condition="'$(_RepoRootOriginal)' == ''"/>
+    <Error Text="File 'global.json' must exist in directory specified by RepoRoot: '$(_RepoRootOriginal)'" Condition="'$(_RepoRootOriginal)' != '' and !Exists('$(RepoRoot)global.json')"/>
 
     <PropertyGroup>
       <_MSBuildCmd Condition="'$(MSBuildRuntimeType)' != 'Core'">"$(MSBuildBinPath)\MSBuild.exe" /nodeReuse:false</_MSBuildCmd>

--- a/sdks/RepoToolset/tools/Compiler.props
+++ b/sdks/RepoToolset/tools/Compiler.props
@@ -6,12 +6,11 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Compilers" Version="$(MicrosoftNetCompilersVersion)" PrivateAssets="all" />
+  <ItemGroup Condition="'$(MSBuildRuntimeType)' == 'Core'">
+    <PackageReference Include="Microsoft.NETCore.Compilers" Version="$(MicrosoftNETCoreCompilersVersion)" PrivateAssets="true" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <ToolsetCompilerPackageDir>$(NuGetPackageRoot)microsoft.net.compilers\$(MicrosoftNetCompilersVersion)\</ToolsetCompilerPackageDir>
-  </PropertyGroup>
-
+  <ItemGroup Condition="'$(MSBuildRuntimeType)' != 'Core'">
+    <PackageReference Include="Microsoft.Net.Compilers" Version="$(MicrosoftNetCompilersVersion)" PrivateAssets="true" />
+  </ItemGroup>
 </Project>

--- a/sdks/RepoToolset/tools/DefaultVersions.props
+++ b/sdks/RepoToolset/tools/DefaultVersions.props
@@ -58,8 +58,8 @@
   <!-- RestoreSources overrides - defines DotNetRestoreSources variable if available -->
   <Import Project="$(DotNetRestoreSourcePropsPath)" Condition="'$(DotNetRestoreSourcePropsPath)' != ''"/>
 
-  <!-- Force sources to DotNetRestoreSources if specified, ignore any sources set by the repo -->
-  <PropertyGroup Condition="'$(DotNetRestoreSources)' != ''">
+  <!-- Force sources to DotNetRestoreSources if building offline, discard any sources set by the repo -->
+  <PropertyGroup Condition="'$(DotNetBuildOffline)' == 'true'">
     <RestoreSources>$(DotNetRestoreSources)</RestoreSources>
   </PropertyGroup>
 
@@ -75,5 +75,7 @@
 
     <!-- Add externally defined NuGet package restore sources. This property is set by Build.proj. -->
     <RestoreSources Condition="'$(__ExternalRestoreSources)' != ''">$(__ExternalRestoreSources);$(RestoreSources)</RestoreSources>
+
+    <RestoreSources Condition="'$(DotNetRestoreSources)' != ''">$(DotNetRestoreSources);$(RestoreSources)</RestoreSources>
   </PropertyGroup>
 </Project>

--- a/sdks/RepoToolset/tools/DefaultVersions.props
+++ b/sdks/RepoToolset/tools/DefaultVersions.props
@@ -17,9 +17,15 @@
     <!-- Opt-out features -->
     <UsingToolXliff Condition="'$(UsingToolXliff)' == ''">true</UsingToolXliff>
     <UsingToolXUnit Condition="'$(UsingToolXUnit)' == ''">true</UsingToolXUnit>
-    <UsingToolMicrosoftNetCompilers Condition="'$(UsingToolMicrosoftNetCompilers)' == ''">true</UsingToolMicrosoftNetCompilers>
     <UsingToolPdbConverter Condition="'$(UsingToolPdbConverter)' == ''">true</UsingToolPdbConverter>
 
+    <!--
+      Always use compilers from the package on CI build, to get consistent results.
+      Locally we want to dogfood the compilers that come with the dotnet SDK or msbuild used to build the repo.
+      The local compilers are also precompiled and thus faster.
+    -->
+    <_UsingToolMicrosoftNetCompilers Condition="'$(CIBuild)' == 'true'">true</_UsingToolMicrosoftNetCompilers>
+                                    
     <!-- Opt-in features -->
     <UsingToolVSSDK Condition="'$(UsingToolVSSDK)' == ''">false</UsingToolVSSDK>
     <UsingToolIbcOptimization Condition="'$(UsingToolIbcOptimization)' == ''">false</UsingToolIbcOptimization>
@@ -29,8 +35,8 @@
     <MicroBuildPluginsSwixBuildVersion Condition="'$(MicroBuildPluginsSwixBuildVersion)' == ''">1.0.147</MicroBuildPluginsSwixBuildVersion>
     <MicroBuildCoreVersion Condition="'$(MicroBuildCoreVersion)' == ''">0.2.0</MicroBuildCoreVersion>
     <MicrosoftDotNetIBCMergeVersion Condition="'$(MicrosoftDotNetIBCMergeVersion)' == ''">4.7.1-alpha-00001</MicrosoftDotNetIBCMergeVersion>
-    <MicrosoftNetCompilersVersion Condition="'$(MicrosoftNetCompilersVersion)' == ''">2.7.0-beta2-62330-02</MicrosoftNetCompilersVersion>
-    <MicrosoftNetCompilersNetCoreVersion Condition="'$(MicrosoftNetCompilersNetCoreVersion)' == ''">2.7.0-beta2-62330-02</MicrosoftNetCompilersNetCoreVersion>
+    <MicrosoftNetCompilersVersion Condition="'$(MicrosoftNetCompilersVersion)' == ''">2.8.0-beta3-62723-11</MicrosoftNetCompilersVersion>
+    <MicrosoftNETCoreCompilersVersion Condition="'$(MicrosoftNETCoreCompilersVersion)' == ''">$(MicrosoftNetCompilersVersion)</MicrosoftNETCoreCompilersVersion>
     <!-- Using a private build of Microsoft.Net.Test.SDK to work around issue https://github.com/Microsoft/vstest/issues/373 -->
     <MicrosoftNETTestSdkVersion Condition="'$(MicrosoftNETTestSdkVersion)' == ''">15.6.0-dev</MicrosoftNETTestSdkVersion>
     <MicrosoftVSSDKBuildToolsVersion Condition="'$(MicrosoftVSSDKBuildToolsVersion)' == ''">15.1.192</MicrosoftVSSDKBuildToolsVersion>
@@ -49,10 +55,18 @@
   <Import Project="$(DotNetPackageVersionPropsPath)" Condition="'$(DotNetPackageVersionPropsPath)' != ''" />
   <Import Project="$(FixedVersionsPropsPath)" Condition="'$(FixedVersionsPropsPath)' != ''"/>
 
-  <PropertyGroup>
+  <!-- RestoreSources overrides - defines DotNetRestoreSources variable if available -->
+  <Import Project="$(DotNetRestoreSourcePropsPath)" Condition="'$(DotNetRestoreSourcePropsPath)' != ''"/>
+
+  <!-- Force sources to DotNetRestoreSources if specified, ignore any sources set by the repo -->
+  <PropertyGroup Condition="'$(DotNetRestoreSources)' != ''">
+    <RestoreSources>$(DotNetRestoreSources)</RestoreSources>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(DotNetBuildOffline)' != 'true'">
     <RestoreSources>$(RestoreSources);https://api.nuget.org/v3/index.json</RestoreSources>
     <RestoreSources Condition="'$(UsingToolXliff)' == 'true' and $(XliffTasksVersion.Contains('-'))">$(RestoreSources);https://dotnet.myget.org/F/dotnet-core/api/v3/index.json</RestoreSources>
-    <RestoreSources Condition="'$(UsingToolMicrosoftNetCompilers)' == 'true' and $(MicrosoftNetCompilersVersion.Contains('-'))">$(RestoreSources);https://dotnet.myget.org/F/roslyn/api/v3/index.json</RestoreSources>
+    <RestoreSources Condition="'$(_UsingToolMicrosoftNetCompilers)' == 'true' and $(MicrosoftNetCompilersVersion.Contains('-'))">$(RestoreSources);https://dotnet.myget.org/F/roslyn/api/v3/index.json</RestoreSources>
     <RestoreSources Condition="'$(UsingToolNetFrameworkReferenceAssemblies)' == 'true'">$(RestoreSources);https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json</RestoreSources>
     <RestoreSources Condition="$(XUnitVersion.Contains('-')) or $(XUnitRunnerVisualStudioVersion.Contains('-')) or $(XUnitRunnerVisualStudioVersion.Contains('-'))">$(RestoreSources);https://www.myget.org/F/xunit/api/v3/index.json</RestoreSources>
 

--- a/sdks/RepoToolset/tools/Directory.Build.props
+++ b/sdks/RepoToolset/tools/Directory.Build.props
@@ -1,5 +1,5 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project>
   <!-- This is an empty Directory.Build.props file to prevent the Directory.Build.props file from the repo from being used
-       when building Build.proj if the repo toolset targets are imported directly from the repo -->
+       if the toolset package is restored to a subdirectory in the repo -->
 </Project>

--- a/sdks/RepoToolset/tools/Directory.Build.targets
+++ b/sdks/RepoToolset/tools/Directory.Build.targets
@@ -1,5 +1,5 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project>
   <!-- This is an empty Directory.Build.targets file to prevent the Directory.Build.targets file from the repo from being used
-       when building Build.proj if the repo toolset targets are imported directly from the repo -->
+       if the toolset package is restored to a subdirectory in the repo -->
 </Project>

--- a/sdks/RepoToolset/tools/Settings.props
+++ b/sdks/RepoToolset/tools/Settings.props
@@ -14,8 +14,8 @@
   <Import Project="Version.props"/>
   <Import Project="ProjectDefaults.props"/>
   <Import Project="Tests.props" />
-
-  <Import Project="Compiler.props" Condition="'$(UsingToolMicrosoftNetCompilers)' == 'true'" />
+  
+  <Import Project="Compiler.props" Condition="'$(_UsingToolMicrosoftNetCompilers)' == 'true'" />  
   <Import Project="Localization.props" Condition="'$(UsingToolXliff)' == 'true'"/>
   <Import Project="XUnit.props" Condition="'$(UsingToolXUnit)' == 'true' and ('$(IsUnitTestProject)' == 'true' or '$(IsIntegrationTestProject)' == 'true' or '$(IsPerformanceTestProject)' == 'true')"/>
   <Import Project="VisualStudio.props" Condition="'$(UsingToolVSSDK)' == 'true'"/>


### PR DESCRIPTION
A few of fixes for source build and Linux build:
- Respect `DotNetRestoreSourcePropsPath` and `DotNetBuildOffline` source build variables
- Use `Microsoft.NETCore.Compilers` package when building via dotnet CLI on CI.
- Use `Microsoft.NET.Compilers` package when building via desktop msbuild on CI.
- Use locally installed compilers when building on dev machine.