### PR TITLE
Option to have an MSBuild binary log emitted

### DIFF
--- a/src/SignTool/SignTool/Program.cs
+++ b/src/SignTool/SignTool/Program.cs
@@ -260,7 +260,7 @@ outputConfig: Run tool to produce an orchestration json file with specified name
                             return false;
                         }
                         break;
-                    case "-msbuildBinaryLog":
+                    case "-msbuildbinarylog":
                         if (!ParsePathOption(args, ref i, current, out msbuildBinaryLogFilePath))
                         {
                             return false;

--- a/src/SignTool/SignTool/Program.cs
+++ b/src/SignTool/SignTool/Program.cs
@@ -209,6 +209,7 @@ outputPath: Directory containing the binaries.
 intermediateOutputPath: Directory containing intermediate output.  Default is (outputpath\..\Obj).
 nugetPackagesPath: Path containing downloaded NuGet packages.
 msbuildPath: Path to MSBuild.exe to use as signing mechanism.
+msbuildBinaryLog: Path to the binary log to generate when invoking signing.
 config: Path to SignToolData.json. Default: build\config\SignToolData.json.
 outputConfig: Run tool to produce an orchestration json file with specified name.  This will contain SHA256 hashes of files for verification to consume later.
 ";
@@ -228,6 +229,7 @@ outputConfig: Run tool to produce an orchestration json file with specified name
             string nugetPackagesPath = null;
             string configFile = null;
             string outputConfigFile = null;
+            string msbuildBinaryLogFilePath = null;
             var test = false;
             var testSign = false;
 
@@ -254,6 +256,12 @@ outputConfig: Run tool to produce an orchestration json file with specified name
                         break;
                     case "-msbuildpath":
                         if (!ParsePathOption(args, ref i, current, out msbuildPath))
+                        {
+                            return false;
+                        }
+                        break;
+                    case "-msbuildBinaryLog":
+                        if (!ParsePathOption(args, ref i, current, out msbuildBinaryLogFilePath))
                         {
                             return false;
                         }
@@ -322,6 +330,7 @@ outputConfig: Run tool to produce an orchestration json file with specified name
             signToolArgs = new SignToolArgs(
                 outputPath: outputPath,
                 msbuildPath: msbuildPath,
+                msbuildBinaryLogFilePath: msbuildBinaryLogFilePath,
                 intermediateOutputPath: intermediateOutputPath,
                 nugetPackagesPath: nugetPackagesPath,
                 appPath: AppContext.BaseDirectory,

--- a/src/SignTool/SignTool/SignTool.SignToolBase.cs
+++ b/src/SignTool/SignTool/SignTool.SignToolBase.cs
@@ -45,6 +45,10 @@ namespace SignTool
 
                 string fileName = MSBuildPath;
                 var commandLine = $@"/v:m ""{buildFilePath}""";
+                if (!string.IsNullOrEmpty(_args.MSBuildBinaryLogFilePath))
+                {
+                    commandLine += $@" /binaryLogger:""{_args.MSBuildBinaryLogFilePath}""";
+                }
 
                 if (!_args.Test)
                 {

--- a/src/SignTool/SignTool/SignToolArgs.cs
+++ b/src/SignTool/SignTool/SignToolArgs.cs
@@ -1,12 +1,13 @@
 namespace SignTool
 {
-    internal struct SignToolArgs
+    internal readonly struct SignToolArgs
     {
         internal string OutputPath { get; }
         internal string IntermediateOutputPath { get; }
         internal string NuGetPackagesPath { get; }
         internal string AppPath { get; }
         internal string MSBuildPath { get; }
+        internal string MSBuildBinaryLogFilePath { get; }
         internal string ConfigFile { get; }
         internal bool Test { get; }
         internal bool TestSign { get; }
@@ -17,6 +18,7 @@ namespace SignTool
             string intermediateOutputPath,
             string appPath,
             string msbuildPath,
+            string msbuildBinaryLogFilePath,
             string nugetPackagesPath,
             string configFile,
             bool test,
@@ -28,6 +30,7 @@ namespace SignTool
             IntermediateOutputPath = intermediateOutputPath;
             AppPath = appPath;
             MSBuildPath = msbuildPath;
+            MSBuildBinaryLogFilePath = msbuildBinaryLogFilePath;
             NuGetPackagesPath = nugetPackagesPath;
             ConfigFile = configFile;
             Test = test;

--- a/src/SignTool/SignToolTests/SignTool.UnitTests.csproj
+++ b/src/SignTool/SignToolTests/SignTool.UnitTests.csproj
@@ -9,4 +9,7 @@
   <ItemGroup>
     <ProjectReference Include="..\SignTool\SignTool.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This is necessary with new signing to get diagnostic output about why
the signing is failing.