### PR TITLE
Create destination directory in DownloadFile

### DIFF
--- a/src/BuildTasks/DownloadFile.cs
+++ b/src/BuildTasks/DownloadFile.cs
@@ -51,6 +51,8 @@ namespace RoslynTools
                 return true;
             }
 
+            Directory.CreateDirectory(Path.GetDirectoryName(DestinationPath));
+
             const string FileUriProtocol = "file://";
 
             if (Uri.StartsWith(FileUriProtocol, StringComparison.Ordinal))


### PR DESCRIPTION
On a clean enlistment (such as in an official build), one of the first
things that happens is downloading the ProdCon version-override file. If
the destination directory (`artifacts/toolset`) doesn't exist, the overall
build will fail when DownloadFile's destination directory doesn't exist.

Create it instead. If it already exists, `Directory.CreateDirectory` does
not error so this should be safe.