### PR TITLE
Replace RepoToolsetDir with MSBuildThisFileDirectory

### DIFF
--- a/sdks/RepoToolset/tools/VisualStudio.targets
+++ b/sdks/RepoToolset/tools/VisualStudio.targets
@@ -164,7 +164,7 @@
       <_SwixArgs Include="SwixBuildPath=$(NuGetPackageRoot)microbuild.plugins.swixbuild\$(MicroBuildPluginsSwixBuildVersion)\"/>
     </ItemGroup>
 
-    <MSBuild Projects="$(RepoToolsetDir)VisualStudio.SetupPackage.swixproj" Properties="@(_SwixArgs)" Targets="Build"/>
+    <MSBuild Projects="$(MSBuildThisFileDirectory)VisualStudio.SetupPackage.swixproj" Properties="@(_SwixArgs)" Targets="Build"/>
 
     <Copy SourceFiles="$(IntermediateOutputPath)$(TargetName).vsix;$(IntermediateOutputPath)$(TargetName).json"
           DestinationFolder="$(VisualStudioSetupInsertionPath)" />


### PR DESCRIPTION
Before the switch to sdks, `RepoToolsetDir` was supposed to be set by the repository. Now that repotoolset components are imported via sdk.props/targets, all paths should be local and self contained.

I tested that this works by modifying my local copy of repotoolset. Without the change it fails because `RepoToolsetDir` evaluates to empty string and it uses the current directory, not the project file directory as the base path for relative paths. With the change, the vsix magically appears :)

This is the only occurrence of `RepoToolsetDir`.