### PR TITLE
Use drop path from API for insertions

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.AssemblyVersions.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.AssemblyVersions.cs
@@ -9,11 +9,11 @@ namespace Roslyn.Insertion
 {
     static partial class RoslynInsertionTool
     {
-        private static void UpdateAssemblyVersions(BuildVersion buildVersion)
+        private static void UpdateAssemblyVersions(string artifactsFolder)
         {
             var versionsUpdater = new VersionsUpdater(Log, GetAbsolutePathForEnlistment(), WarningMessages);
 
-            foreach (var nameAndVersion in ReadAssemblyVersions(GetDevDivInsertionFilePath(buildVersion, "DependentAssemblyVersions.csv")))
+            foreach (var nameAndVersion in ReadAssemblyVersions(GetDevDivInsertionFilePath(artifactsFolder, "DependentAssemblyVersions.csv")))
             {
                 versionsUpdater.UpdateComponentVersion(nameAndVersion.Key, nameAndVersion.Value);
             }

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
@@ -191,6 +191,32 @@ namespace Roslyn.Insertion
                     select build).FirstOrDefault();
         }
 
+        internal static async Task<string> GetBuildDirectoryAsync(Build build, CancellationToken cancellationToken)
+        {
+            // used for local testing:
+            if (Options.BuildDropPath.EndsWith(@"Binaries\Debug", StringComparison.OrdinalIgnoreCase) ||
+                Options.BuildDropPath.EndsWith(@"Binaries\Release", StringComparison.OrdinalIgnoreCase))
+            {
+                return Options.BuildDropPath;
+            }
+
+            var buildClient = ProjectCollection.GetClient<BuildHttpClient>();
+
+            // Pull the build directory from the API
+            var artifacts = await buildClient.GetArtifactsAsync(build.Project.Id, build.Id, cancellationToken);
+            foreach (var artifact in artifacts)
+            {
+                // The drop path we're looking for is named the same as the build number
+                if (artifact.Name == build.BuildNumber)
+                {
+                    return Path.Combine(artifact.Resource.Data, build.BuildNumber);
+                }
+            }
+
+            // Should never happen since we already filtered for containing valid paths
+            throw new InvalidOperationException("Could not find drop path");
+        }
+
         private static async Task<Release> CreateReleaseAsync(Build build, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();


### PR DESCRIPTION
We were previously using a hardcoded path to find the drop path for
official builds. This changes the insertion tool to use the artifact
build pulled directly out of the VSTS API.