### PR TITLE
Add property to control whether RoslynTools Sdk imports Microsoft.NET.Sdk

### DIFF
--- a/sdks/RepoToolset/tools/Imports.targets
+++ b/sdks/RepoToolset/tools/Imports.targets
@@ -6,7 +6,7 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
-  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" Condition="'$(ImportNetSdkFromRepoToolset)' == 'true'" />
   
   <PropertyGroup>
     <DeployProjectOutput Condition="'$(DeployProjectOutput)' == ''">$(__DeployProjectOutput)</DeployProjectOutput>

--- a/sdks/RepoToolset/tools/Settings.props
+++ b/sdks/RepoToolset/tools/Settings.props
@@ -4,6 +4,8 @@
 
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+
+    <ImportNetSdkFromRepoToolset Condition="'$(ImportNetSdkFromRepoToolset)' == ''">true</ImportNetSdkFromRepoToolset>
   </PropertyGroup>
 
   <Import Project="BuildTasks.props" />
@@ -21,5 +23,5 @@
   <Import Project="VisualStudio.props" Condition="'$(UsingToolVSSDK)' == 'true'"/>
 
   <!-- Directory.Build.props are imported next by .NET SDK (via Common.targets) -->
-  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" Condition="'$(ImportNetSdkFromRepoToolset)' == 'true'" />
 </Project>

--- a/sdks/RepoToolset/tools/Workarounds.targets
+++ b/sdks/RepoToolset/tools/Workarounds.targets
@@ -36,19 +36,6 @@
   </Target>
 
   <!--
-    Work around bug in Microsoft.NET.Sdk < v2.0 where satellites were deployed on top of each other in root.
-    https://github.com/dotnet/sdk/issues/1360
-  -->
-  <Target Name="WorkaroundIncorrectSatelliteDeployment" AfterTargets="ResolveLockFileCopyLocalProjectDeps">
-    <ItemGroup>
-      <ReferenceCopyLocalPaths Remove="@(ResourceCopyLocalItems)" />
-      <ReferenceCopyLocalPaths Include="@(ResourceCopyLocalItems)"  Condition="'@(ResourceCopyLocalItems)' != ''">
-        <DestinationSubDirectory>$([System.IO.Directory]::GetParent(%(ResourceCopyLocalItems.FullPath)).get_Name())\</DestinationSubDirectory>
-      </ReferenceCopyLocalPaths>
-    </ItemGroup>
-  </Target>
-
-  <!--
     XAML targets create a temp project with OutDir set, which makes the SDK create an empty directory for it,
     polluting the output dir. Avoid creating these directories.
     https://github.com/dotnet/sdk/issues/1367


### PR DESCRIPTION
This adds an `ImportNetSdkFromRepoToolset` property which can be used to control whether the RoslynTools.RepoToolset Sdk imports Microsoft.NET.Sdk.  It defaults to true (so behavior is unchanged), but if you set it to false, you can use Microsoft.NET.Sdk (or Microsoft.NET.Sdk.Web) in your project files.  This means that new project templates will work without modification.

In order to do this, you can put the following in a Directory.Build.props file:

```xml
  <PropertyGroup>
    <ImportNetSdkFromRepoToolset>false</ImportNetSdkFromRepoToolset>
  </PropertyGroup>

  <Import Project="Sdk.props" Sdk="RoslynTools.RepoToolset" />
```

Similarly, you would put the following in Directory.Build.targets:

```xml
<Import Project="Sdk.targets" Sdk="RoslynTools.RepoToolset" />
```

Additionally, this PR removes the `WorkaroundIncorrectSatelliteDeployment` target, which fixes #249