### PR TITLE
Run !netcoreapp tests on all platforms

### DIFF
--- a/sdks/RepoToolset/tools/XUnit.targets
+++ b/sdks/RepoToolset/tools/XUnit.targets
@@ -29,7 +29,7 @@
           Inputs="*%(_TestArchitectureItems.Identity)"
           Outputs="*%(_TestArchitectureItems.Identity)"
           Returns="@(_FailedTestRuns)"
-          Condition="$(TargetFramework.StartsWith('netcoreapp')) or '$(OS)' == 'Windows_NT'">
+          Condition="$(TargetFramework.StartsWith('netcoreapp')) or '$(OS)' == 'Windows_NT' or '$(MSBuildRuntimeType)' == 'Mono'">
 
     <PropertyGroup>
       <_TestArchitecture>%(_TestArchitectureItems.Identity)</_TestArchitecture>


### PR DESCRIPTION
PR #192 broke running tests on mono (net461) on OSX.
Now:
 - run netcoreapp tests on only Linux
 - run !netcoreapp tests on all platforms