### PR TITLE
sanitize the input branch name

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.Git.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.Git.cs
@@ -12,6 +12,8 @@ namespace Roslyn.Insertion
 {
     static partial class RoslynInsertionTool
     {
+        private const string RefsHeadsPrefix = "refs/heads/";
+
         private static readonly Lazy<Repository> LazyEnlistment = new Lazy<Repository>(() =>
         {
             var absolutePath = GetAbsolutePathForEnlistment();
@@ -166,6 +168,11 @@ namespace Roslyn.Insertion
             if (!baseBranchName.StartsWith("origin/"))
             {
                 baseBranchName = "origin/" + baseBranchName;
+            }
+
+            if (branchToSwitchTo.StartsWith(RefsHeadsPrefix))
+            {
+                branchToSwitchTo = branchToSwitchTo.Substring(RefsHeadsPrefix.Length);
             }
 
             FetchLatest(Enlistment, GetFetchOptions());


### PR DESCRIPTION
When updating an existing PR the remote branch name sometimes starts with `refs/heads/` which needs to be removed.