### PR TITLE
add a `version` property to the inserted component

### DIFF
--- a/src/RepoToolset/tools/VisualStudio.InsertionManifests.targets
+++ b/src/RepoToolset/tools/VisualStudio.InsertionManifests.targets
@@ -13,9 +13,10 @@
     This target is invoked in a separate phase after all input VSIX files are signed.
     This is important since the manifest contain hashes of the VSIX files.
   -->
-  <Target Name="GenerateVisualStudioInsertionManifests" 
+  <Target Name="GenerateVisualStudioInsertionManifests"
           AfterTargets="Pack"
-          Outputs="%(_StubDirs.Identity)" 
+          Outputs="%(_StubDirs.Identity)"
+          DependsOnTargets="GetVsixVersion"
           Condition="'@(_StubDirs)' != ''">
     <PropertyGroup>
       <_ComponentDir>%(_StubDirs.Identity)</_ComponentDir>
@@ -27,6 +28,7 @@
       <_Args Include="SetupOutputPath=$(VisualStudioSetupInsertionPath)"/>
       <_Args Include="ComponentIntermediateOutputPath=$(VisualStudioSetupIntermediateOutputPath)$(_ComponentName)\"/>
       <_Args Include="SwixBuildPath=$(NuGetPackageRoot)microbuild.plugins.swixbuild\$(MicroBuildPluginsSwixBuildVersion)\"/>
+      <_Args Include="ManifestBuildVersion=$(_VsixVersion)" />
     </ItemGroup>
 
     <Message Text="Generating manifest for VS component '$(_ComponentName)'" Importance="high"/>

--- a/src/RoslynInsertionTool/RoslynInsertionTool/Components.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/Components.cs
@@ -9,14 +9,16 @@ namespace Roslyn.Insertion
         public string Filename { get; }
         public string Name { get; }
         public Uri Uri { get; }
+        public string Version { get; }
 
-        public Component(string componentName, string componentFilename, Uri componentUri)
+        public Component(string componentName, string componentFilename, Uri componentUri, string version)
         {
             Name = componentName;
             Filename = componentFilename;
             Uri = componentUri;
+            Version = version;
         }
 
-        public Component WithUri(Uri newUri) => new Component(Name, Filename, newUri);
+        public Component WithUri(Uri newUri) => new Component(Name, Filename, newUri, Version);
     }
 }


### PR DESCRIPTION
This is to make other internal tooling better able to handle merge conflicts by adding a version for each inserted component.

The `.vsman` files used for insertion will be scanned for a `info/buildVersion` property which will be forwarded into a `version` property in the config JSON file.  See Microsoft/visualfsharp#5226.
