### PR TITLE
Implement concept of shipping artifact

### DIFF
--- a/src/RepoToolset/tools/BuildReleasePackages.targets
+++ b/src/RepoToolset/tools/BuildReleasePackages.targets
@@ -17,11 +17,11 @@
     <Message Text="Building release versions of NuGet packages" Importance="high" />
 
     <ItemGroup>
-      <_BuiltPackages Include="$(PackageOutputPath)*.nupkg" />
+      <_BuiltPackages Include="$(ArtifactsShippingPackagesDir)*.nupkg" />
     </ItemGroup>
-    
-    <Roslyn.Tools.UpdatePackageVersionTask VersionKind="release" Packages="@(_BuiltPackages)" OutputDirectory="$(PackageOutputPath)Release" AllowPreReleaseDependencies="true" />
-    <Roslyn.Tools.UpdatePackageVersionTask VersionKind="prerelease" Packages="@(_BuiltPackages)" OutputDirectory="$(PackageOutputPath)PreRelease" />
+
+    <Roslyn.Tools.UpdatePackageVersionTask VersionKind="release" Packages="@(_BuiltPackages)" OutputDirectory="$(ArtifactsPackagesDir)Release" AllowPreReleaseDependencies="true" />
+    <Roslyn.Tools.UpdatePackageVersionTask VersionKind="prerelease" Packages="@(_BuiltPackages)" OutputDirectory="$(ArtifactsPackagesDir)PreRelease" />
   </Target>
 
 </Project>

--- a/src/RepoToolset/tools/Imports.targets
+++ b/src/RepoToolset/tools/Imports.targets
@@ -18,6 +18,20 @@
   <!-- Default empty deploy target. -->
   <Target Name="Deploy" AfterTargets="Build" Condition="'$(DeployProjectOutput)' == 'true'" />
 
+  <!--
+    Set PackageOutputPath based on the IsShipping flag set by projects.
+    This distinction allows signing and publishing tools to determine which assets to sign/publish and which to ignore.
+    
+    Unless specified owtherwise project is assumed to produce binaries/package that ship.
+    Test projects automatically set IsShipping to false.
+  -->
+  <PropertyGroup>
+    <IsShipping Condition="'$(IsShipping)' == ''">true</IsShipping>
+    
+    <PackageOutputPath Condition="'$(IsShipping)' == 'true'">$(ArtifactsShippingPackagesDir)</PackageOutputPath>
+    <PackageOutputPath Condition="'$(IsShipping)' != 'true'">$(ArtifactsNonShippingPackagesDir)</PackageOutputPath>
+  </PropertyGroup>
+
   <Import Project="StrongName.targets"/>
   <Import Project="GenerateInternalsVisibleTo.targets" />
   <Import Project="GenerateResxSource.targets" />

--- a/src/RepoToolset/tools/Publish.proj
+++ b/src/RepoToolset/tools/Publish.proj
@@ -67,7 +67,7 @@
     <!-- Orchestrated Build blob storage -->
     <ItemGroup>
       <ItemsToPushToBlobFeed Include="@(PackagesToPublish);@(ExistingSymbolPackages);@(SymbolPackagesToGenerate)">
-        <ManifestArtifactData Condition="!%(IsShipping)">NonShipping=false</ManifestArtifactData>
+        <ManifestArtifactData Condition="!%(IsShipping)">NonShipping=true</ManifestArtifactData>
       </ItemsToPushToBlobFeed>
     </ItemGroup>
 

--- a/src/RepoToolset/tools/Publish.proj
+++ b/src/RepoToolset/tools/Publish.proj
@@ -39,20 +39,24 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <ExistingSymbolPackages Include="$(PackageOutputPath)*.symbols.nupkg" />
+      <ExistingSymbolPackages Include="$(ArtifactsShippingPackagesDir)*.symbols.nupkg" IsShipping="true" />
+      <ExistingSymbolPackages Include="$(ArtifactsNonShippingPackagesDir)*.symbols.nupkg" IsShipping="false" />
 
-      <PackagesToPublish Include="$(PackageOutputPath)*.nupkg" />
+      <PackagesToPublish Include="$(ArtifactsShippingPackagesDir)*.nupkg" IsShipping="true" />
+      <PackagesToPublish Include="$(ArtifactsNonShippingPackagesDir)*.nupkg" IsShipping="false" />
       <PackagesToPublish Remove="@(ExistingSymbolPackages)" />
+
       <PackagesToPublish Update="@(PackagesToPublish)">
         <SymbolPackageToGenerate Condition="!Exists('%(RootDir)%(Directory)%(Filename).symbols.nupkg')">$(SymbolPackagesDir)%(Filename).symbols.nupkg</SymbolPackageToGenerate>
       </PackagesToPublish>
 
       <SymbolPackagesToGenerate Include="@(PackagesToPublish->'%(SymbolPackageToGenerate)')" Condition="'%(PackagesToPublish.SymbolPackageToGenerate)' != ''">
         <OriginalPackage>%(PackagesToPublish.Identity)</OriginalPackage>
+        <IsShipping>%(PackagesToPublish.IsShipping)</IsShipping>
       </SymbolPackagesToGenerate>
     </ItemGroup>
 
-    <!--
+    <!-- 
       If a symbol package doesn't exist yet we assume that the regular package contains Portable PDBs.
       Such packages can act as symbol packages since they have the same structure.
       We just need to copy them to *.symbols.nupkg.
@@ -61,9 +65,15 @@
     <Copy SourceFiles="@(SymbolPackagesToGenerate->'%(OriginalPackage)')" DestinationFiles="@(SymbolPackagesToGenerate)" />
 
     <!-- Orchestrated Build blob storage -->
+    <ItemGroup>
+      <ItemsToPushToBlobFeed Include="@(PackagesToPublish);@(ExistingSymbolPackages);@(SymbolPackagesToGenerate)">
+        <ManifestArtifactData Condition="!%(IsShipping)">NonShipping=false</ManifestArtifactData>
+      </ItemsToPushToBlobFeed>
+    </ItemGroup>
+
     <PushToBlobFeed ExpectedFeedUrl="$(AzureFeedUrl)"
                     AccountKey="$(AzureAccountKey)"
-                    ItemsToPush="@(PackagesToPublish);@(ExistingSymbolPackages);@(SymbolPackagesToGenerate)"
+                    ItemsToPush="@(ItemsToPushToBlobFeed)"
                     ManifestName="$(BUILD_REPOSITORY_NAME)"
                     ManifestBranch="$(BUILD_SOURCEBRANCH)"
                     ManifestBuildId="$(BUILD_BUILDNUMBER)"
@@ -87,23 +97,29 @@
       <DotNetSymbolServerTokenMsdl>DryRunPTA</DotNetSymbolServerTokenMsdl>
     </PropertyGroup>
 
-    <!-- 
-      Publish Windows PDBs produced by SymStore.targets.
-      SymbolUploader doesn't support embedded PDBs yet, so let SymStore.targets do the conversion for now.
-      https://github.com/dotnet/core-eng/issues/3645
-    -->
     <ItemGroup>
-      <FilesToPublish Include="$(ArtifactsSymStoreDirectory)**\*.pdb"/>
+      <!-- 
+        Publish Windows PDBs produced by SymStore.targets (only shipping PDBs are placed there).
+        SymbolUploader doesn't support embedded PDBs yet, so let SymStore.targets do the conversion for now.
+        https://github.com/dotnet/core-eng/issues/3645
+      -->
+      <FilesToPublishToSymbolServer Include="$(ArtifactsSymStoreDirectory)**\*.pdb"/>
+
+      <!--
+        Publish Portable PDBs contained in the shipping symbol packages.
+      -->
+      <PackagesToPublishToSymbolServer Include="@(ExistingSymbolPackages);@(SymbolPackagesToGenerate)" 
+                                       Condition="%(IsShipping)"/>
     </ItemGroup>
 
     <PropertyGroup>
-      <PublishToSymbolServer Condition="'@(FilesToPublish)' == '' and '@(ExistingSymbolPackages)' == '' and '@(SymbolPackagesToGenerate)' == ''">false</PublishToSymbolServer>
+      <PublishToSymbolServer Condition="'@(FilesToPublishToSymbolServer)' == '' and '@(PackagesToPublishToSymbolServer)' == ''">false</PublishToSymbolServer>
     </PropertyGroup>
 
     <!-- Symbol Uploader: MSDL -->
     <Message Importance="High" Text="Publishing symbol packages to MSDL ..." />
-    <PublishSymbols PackagesToPublish="@(ExistingSymbolPackages);@(SymbolPackagesToGenerate)"
-                    FilesToPublish="@(FilesToPublish)"
+    <PublishSymbols PackagesToPublish="@(PackagesToPublishToSymbolServer)"
+                    FilesToPublish="@(FilesToPublishToSymbolServer)"
                     PersonalAccessToken="$(DotNetSymbolServerTokenMsdl)"
                     SymbolServerPath="https://microsoftpublicsymbols.artifacts.visualstudio.com/DefaultCollection"
                     ExpirationInDays="$(DotNetSymbolExpirationInDays)"
@@ -119,8 +135,8 @@
       Currently we need to call the task twice (https://github.com/dotnet/core-eng/issues/3489).
     -->
     <Message Importance="High" Text="Publishing symbol packages to SymWeb ..." />
-    <PublishSymbols PackagesToPublish="@(ExistingSymbolPackages);@(SymbolPackagesToGenerate)"
-                    FilesToPublish="@(FilesToPublish)"
+    <PublishSymbols PackagesToPublish="@(PackagesToPublishToSymbolServer)"
+                    FilesToPublish="@(FilesToPublishToSymbolServer)"
                     PersonalAccessToken="$(DotNetSymbolServerTokenSymWeb)"
                     SymbolServerPath="https://microsoft.artifacts.visualstudio.com/DefaultCollection"
                     ExpirationInDays="$(DotNetSymbolExpirationInDays)"

--- a/src/RepoToolset/tools/RepoLayout.props
+++ b/src/RepoToolset/tools/RepoLayout.props
@@ -69,7 +69,9 @@
     <ArtifactsTmpDir>$(ArtifactsConfigurationDir)tmp\</ArtifactsTmpDir>
     <ArtifactsTestResultsDir>$(ArtifactsConfigurationDir)TestResults\</ArtifactsTestResultsDir>
     <ArtifactsSymStoreDirectory>$(ArtifactsConfigurationDir)SymStore\</ArtifactsSymStoreDirectory>
-    <PackageOutputPath>$(ArtifactsConfigurationDir)packages\</PackageOutputPath>
+    <ArtifactsPackagesDir>$(ArtifactsConfigurationDir)packages\</ArtifactsPackagesDir>
+    <ArtifactsShippingPackagesDir>$(ArtifactsPackagesDir)Shipping\</ArtifactsShippingPackagesDir>
+    <ArtifactsNonShippingPackagesDir>$(ArtifactsPackagesDir)NonShipping\</ArtifactsNonShippingPackagesDir>
     <VisualStudioSetupOutputPath>$(ArtifactsConfigurationDir)VSSetup\</VisualStudioSetupOutputPath>
     <VisualStudioSetupInsertionPath>$(VisualStudioSetupOutputPath)Insertion\</VisualStudioSetupInsertionPath>
     <VisualStudioSetupIntermediateOutputPath>$(ArtifactsConfigurationDir)VSSetup.obj\</VisualStudioSetupIntermediateOutputPath>

--- a/src/RepoToolset/tools/SymStore.targets
+++ b/src/RepoToolset/tools/SymStore.targets
@@ -32,7 +32,7 @@
       <_SymStorePdbPath>$(_SymStoreOutputDir)$(TargetName).pdb</_SymStorePdbPath>
       <_SymStoreAssemblyPath>$(_SymStoreOutputDir)$(TargetName)$(TargetExt)</_SymStoreAssemblyPath>
 
-      <PublishOutputToSymStore Condition="'$(PublishOutputToSymStore)' == '' and Exists('$(TargetPath)') and ('$(DebugType)' == 'embedded' or Exists('$(_TargetPdbPath)'))">true</PublishOutputToSymStore>
+      <_PublishOutputToSymStore Condition="'$(IsShipping)' == 'true' and Exists('$(TargetPath)') and ('$(DebugType)' == 'embedded' or Exists('$(_TargetPdbPath)'))">true</_PublishOutputToSymStore>
     </PropertyGroup>
   </Target>
 
@@ -48,7 +48,7 @@
           AfterTargets="_InnerDeployToSymStore"
           Inputs="$(TargetPath);$(_TargetPdbPath)"
           Outputs="$(_SymStorePdbPath)"
-          Condition="'$(PublishOutputToSymStore)' == 'true' and ('$(DebugType)' == 'portable' or '$(DebugType)' == 'embedded')">
+          Condition="'$(_PublishOutputToSymStore)' == 'true' and ('$(DebugType)' == 'portable' or '$(DebugType)' == 'embedded')">
 
     <PropertyGroup>
       <_PdbConverterPath>$(NuGetPackageRoot)microsoft.diasymreader.pdb2pdb\$(MicrosoftDiaSymReaderPdb2PdbVersion)\tools\Pdb2Pdb.exe</_PdbConverterPath>
@@ -76,7 +76,7 @@
   -->
   <Target Name="_DeployWindowsSymbolsToSymStore"
           AfterTargets="_InnerDeployToSymStore"
-          Condition="'$(PublishOutputToSymStore)' == 'true' and ('$(DebugType)' == 'full' or '$(DebugType)' == 'pdbonly')"
+          Condition="'$(_PublishOutputToSymStore)' == 'true' and ('$(DebugType)' == 'full' or '$(DebugType)' == 'pdbonly')"
           Inputs="$(_TargetPdbPath)"
           Outputs="$(_SymStorePdbPath)">
 
@@ -93,7 +93,7 @@
 
   <Target Name="_DeployAssembliesToSymStore"
           AfterTargets="_InnerDeployToSymStore"
-          Condition="'$(PublishOutputToSymStore)' == 'true' and '$(UsingToolSymbolUploader)' != 'true'"
+          Condition="'$(_PublishOutputToSymStore)' == 'true' and '$(UsingToolSymbolUploader)' != 'true'"
           Inputs="$(TargetPath)"
           Outputs="$(_SymStoreAssemblyPath)">
 

--- a/src/RepoToolset/tools/Tests.props
+++ b/src/RepoToolset/tools/Tests.props
@@ -35,8 +35,8 @@
   </ItemGroup>
 
   <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
-    <!-- Do not publish test assemblies and symbols to SymStore. -->
-    <PublishOutputToSymStore Condition="'$(PublishOutputToSymStore)' == ''">false</PublishOutputToSymStore>
+    <!-- Treat test assemblies as non-shipping (do not publish or sign them). -->
+    <IsShipping Condition="'$(IsShipping)' == ''">false</IsShipping>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Introduces the concept of *shipping artifacts*. 

By default project outputs are shipping, unless the project is a test project.
Project declares that its outputs are not shipping by setting property `<IsShipping>false</IsShipping>`.

The toolset sets the `PackageOutputPath` to `packages/Shipping` and `packages/NonShipping` directories, based on the value of `IsShipping`. 

All packages in `Shipping` directory and their content must be signed and symbols published to symbol server. 

All packages in `Shipping` directory will be published to NuGet.org. `NonShipping` packages will be published to MyGet.