### PR TITLE
Allow 20 minutes for the VSTS DownloadArtifactsAsync instead of 10

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
@@ -274,7 +274,7 @@ namespace Roslyn.Insertion
                 // Hence explictly waiting for the directory to be deleted before moving on.
                 Stopwatch w = Stopwatch.StartNew();
 
-                while (Directory.Exists(tempDirectory) && w.ElapsedMilliseconds < 10 * 1000) Thread.Sleep(100);
+                while (Directory.Exists(tempDirectory) && w.ElapsedMilliseconds < 20 * 1000) Thread.Sleep(100);
             }
 
             Directory.CreateDirectory(tempDirectory);


### PR DESCRIPTION
Changes that just increase timeouts aren't great, but it sounds like this is the right option for now. This step often takes a bit longer than 10 minutes, and I have to sit there respinning over and over just hoping.