### PR TITLE
add branch name to drop location

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -56,7 +56,7 @@ steps:
      artifacts\$(BuildConfiguration)\packages
     ArtifactName: '$(Build.BuildNumber)'
     ArtifactType: FilePath
-    TargetPath: '$(DropRoot)\$(TeamName)\$(Build.DefinitionName)'
+    TargetPath: '$(DropRoot)\$(TeamName)\$(Build.DefinitionName)\$(Build.SourceBranchName)'
   condition: and(succeededOrFailed(), not(contains(variables['PB_PublishType'], 'blob')))
 
 - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
@@ -69,7 +69,7 @@ steps:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)\MicroBuild\Output'
     ArtifactName: '$(Build.BuildNumber)'
     publishLocation: FilePath
-    TargetPath: '$(DropRoot)\$(TeamName)\$(Build.DefinitionName)'
+    TargetPath: '$(DropRoot)\$(TeamName)\$(Build.DefinitionName)\$(Build.SourceBranchName)'
   condition: and(succeededOrFailed(), not(contains(variables['PB_PublishType'], 'blob')))
 
 - task: AzureRmWebAppDeployment@4


### PR DESCRIPTION
Add the branch name to the drop location.  This is important for internal scripts that find the most recent drop location.  As it stands the most recently completed build will be found regardless of the branch name, but with this change we can filter to `master` very easily.
