### PR TITLE
properly specify target input and outputs

### DIFF
--- a/src/AzureFunctionPackage/AzureFunctionPackage.csproj
+++ b/src/AzureFunctionPackage/AzureFunctionPackage.csproj
@@ -45,6 +45,8 @@
   </Target>
 
   <Target Name="CopyPackageFunctionFiles"
+          Inputs="@(AzureFunction)"
+          Outputs="$(RootPackageDirectory)\%(AzureFunction.Identity)"
           DependsOnTargets="PreparePackageDirectory">
     <ItemGroup>
       <FilesToCopy Remove="**" />


### PR DESCRIPTION
Fix stupid mistake I made where I didn't specify a target's inputs/outputs which caused the copied files to be overwritten.  The end result was that the files specified in the `@(AzureFunction)` item group were duplicated in all function output locations.

Verified locally by full clean and rebuild and manually checking all package files.

MSBuild is hard.