### PR TITLE
Add a `-diag` switch to sign tool to show more verbose output

### DIFF
--- a/src/SignTool/README.md
+++ b/src/SignTool/README.md
@@ -2,15 +2,15 @@
 
 This is a batch signing and verification tool for Microbuild environments.  The tool is run as a post-build step and driven by a declarative configuration file.  The high level features of the tool are:
 
-- Performance: The tool operates as a post-build step and uses the minimum number of requests possible.  This can have a dramatic performance improvement over the typical implementation which signs as a post-compile step.  For example, in Roslyn it took build + sign times down from 1-2 hours to 8 minutes. 
+- Performance: The tool operates as a post-build step and uses the minimum number of requests possible.  This can have a dramatic performance improvement over the typical implementation which signs as a post-compile step.  For example, in Roslyn it took build + sign times down from 1-2 hours to 8 minutes.
 - Verification: Using the `-test` argument the tool can be run as part of a CI leg to verify the consistency of the configuration file.  This enables developers to catch many build and packaging errors that normally would cause a signed build to break post check-in.
 - VSIX: The tool can handle the nesting issues that come with VSIX: both nested PE and nested VSIX.  The tool will correctly sign the VSIX content first, repack the VSIX with signed content and then sign the containing VSIX.  Arbitrary levels of nesting are supported.
-- Declarative config file: The config file is designed to be declarative and explicit about all files included in the signing process. 
-- Post signing checks: Takes extra steps to ensure a file is properly signed after the signing process completes. 
+- Declarative config file: The config file is designed to be declarative and explicit about all files included in the signing process.
+- Post signing checks: Takes extra steps to ensure a file is properly signed after the signing process completes.
 
 ## Configuration File
 
-The configuration file has two main sections: sign and exclude.  
+The configuration file has two main sections: sign and exclude.
 
 ``` json
 {
@@ -19,7 +19,7 @@ The configuration file has two main sections: sign and exclude.
 }
 ```
 
-Each entry in the sign section has the following format: 
+Each entry in the sign section has the following format:
 
 ``` json
 {
@@ -35,10 +35,10 @@ Each entry in the sign section has the following format:
 The properties have the following semantics:
 
 - certificate: name of the Authenticode certificate to use for signing.  Valid values include Microsoft402, WindowsPhone623, MicrosoftSHA1Win8WinBlue and VsixSHA2.  More are likely available.  This value must be specified.
-- strongName: name of the key to use when strong naming the binary.  This can be `null` for values which do not require strong name signing such as VSIX files. 
-- values: array of paths, relative to the binaries directory, which will be signed in this manner.  These paths can include `*` globbing for directory names (helps support localization). 
+- strongName: name of the key to use when strong naming the binary.  This can be `null` for values which do not require strong name signing such as VSIX files.
+- values: array of paths, relative to the binaries directory, which will be signed in this manner.  These paths can include `*` globbing for directory names (helps support localization).
 
-The exclude section is only relevant when VSIX values are being signed.  It's not uncommon to include files in a VSIX which are not built by the repo producing the VSIX.  Such files should not be included in signing (responsibility of the repo that produced them).  
+The exclude section is only relevant when VSIX values are being signed.  It's not uncommon to include files in a VSIX which are not built by the repo producing the VSIX.  Such files should not be included in signing (responsibility of the repo that produced them).
 
 Part of the sign tool verification process is to ensure every file is properly accounted for.  That includes digging through VSIX and making sure there are no stray entries.  The exclude list serves as an explicit declaration that the file is a) meant to be in the VSIX and b) not meant to be signed.
 
@@ -57,10 +57,10 @@ The command line for SignTool is the following:
 The only required argument is `outputPath` and `-config`.  The rest will be inferred to reasonable defaults. Detailed breakdown:
 
 - `-config`: Path to the configuration file. Default is to use `build\config\SignToolData.json` from the nearest directory containing `.git`.
-- `<output path>`: The base path off which all the entries in the config file are based. 
+- `<output path>`: The base path off which all the entries in the config file are based.
 - `-test`: The tool will operate in verification mode.  This checks the correctness of the config file, ensures the VSIXes have contents that are identical to the build output (not just name matching), and that binaries are in a correct signing state.  Designed for developer and CI runs.
 - `-testSign`: The binaries will be test signed. The default is to real sign.
 - `-msbuildPath`: Path to the MSBuild.exe binary used to run the actual signing process on Microbuild.  The default is to use MSBuid 14.0 standard installation.
 - `-nugetPackagesPath`: Defaults to `~\.nuget\packages`.  Needed to specify the `<Import>` statements for Microbuild.
-- `-intermediateOutputPath`: Defaults to `<outputPath>\Obj`.  
-
+- `-intermediateOutputPath`: Defaults to `<outputPath>\Obj`.
+- `-diag`: Display diagnostic output.

--- a/src/SignTool/SignTool/Program.cs
+++ b/src/SignTool/SignTool/Program.cs
@@ -131,7 +131,7 @@ namespace SignTool
             foreach (var item in fileJson.SignList)
             {
                 var data = new SignInfo(certificate: item.Certificate, strongName: item.StrongName);
-                
+
                 foreach (FileSignDataEntry entry in item.FileList)
                 {
                     if (map.ContainsKey(entry))
@@ -158,7 +158,7 @@ namespace SignTool
 
 
         /// <summary>
-        /// The 'files to sign' section supports globbing. The only caveat is that globs must expand to match at least a 
+        /// The 'files to sign' section supports globbing. The only caveat is that globs must expand to match at least a
         /// single file else an error occurs. This function will expand those globs as necessary.
         /// </summary>
         private static List<string> ExpandFileList(string outputPath, IEnumerable<string> relativeFileNames, ref bool allGood)
@@ -232,6 +232,7 @@ outputConfig: Run tool to produce an orchestration json file with specified name
             string msbuildBinaryLogFilePath = null;
             var test = false;
             var testSign = false;
+            var diag = false;
 
             var i = 0;
 
@@ -246,6 +247,10 @@ outputConfig: Run tool to produce an orchestration json file with specified name
                         break;
                     case "-testsign":
                         testSign = true;
+                        i++;
+                        break;
+                    case "-diag":
+                        diag = true;
                         i++;
                         break;
                     case "-intermediateoutputpath":
@@ -337,6 +342,7 @@ outputConfig: Run tool to produce an orchestration json file with specified name
                 configFile: configFile,
                 test: test,
                 testSign: testSign,
+                diagnosticOutput: diag,
                 orchestrationManifestPath: outputConfigFile);
             return true;
         }

--- a/src/SignTool/SignTool/SignTool.SignToolBase.cs
+++ b/src/SignTool/SignTool/SignTool.SignToolBase.cs
@@ -44,7 +44,8 @@ namespace SignTool
                 textWriter.WriteLine(content);
 
                 string fileName = MSBuildPath;
-                var commandLine = $@"/v:m ""{buildFilePath}""";
+                var verbosity = _args.DiagnosticOutput ? "diag" : "m";
+                var commandLine = $@"/v:{verbosity} ""{buildFilePath}""";
                 if (!string.IsNullOrEmpty(_args.MSBuildBinaryLogFilePath))
                 {
                     commandLine += $@" /binaryLogger:""{_args.MSBuildBinaryLogFilePath}""";

--- a/src/SignTool/SignTool/SignToolArgs.cs
+++ b/src/SignTool/SignTool/SignToolArgs.cs
@@ -11,6 +11,7 @@ namespace SignTool
         internal string ConfigFile { get; }
         internal bool Test { get; }
         internal bool TestSign { get; }
+        internal bool DiagnosticOutput { get; }
         internal string OrchestrationManifestPath { get; }
 
         internal SignToolArgs(
@@ -23,6 +24,7 @@ namespace SignTool
             string configFile,
             bool test,
             bool testSign,
+            bool diagnosticOutput,
             string orchestrationManifestPath
             )
         {
@@ -35,6 +37,7 @@ namespace SignTool
             ConfigFile = configFile;
             Test = test;
             TestSign = testSign;
+            DiagnosticOutput = diagnosticOutput;
             OrchestrationManifestPath = orchestrationManifestPath;
         }
     }


### PR DESCRIPTION
Make it easier to gather more detailed information when something is going wrong.