### PR TITLE
report PR creation failure

### DIFF
--- a/src/GithubMergeTool/GithubMergeTool.cs
+++ b/src/GithubMergeTool/GithubMergeTool.cs
@@ -159,7 +159,7 @@ Once all conflicts are resolved and all the tests pass, you are free to merge th
             {
                 // Delete the pr branch if the PR was not created.
                 await _client.DeleteAsync($"repos/{repoOwner}/{repoName}/git/refs/heads/{prBranchName}");
-                return (false, null);
+                return (false, response);
             }
 
             jsonBody = JObject.Parse(await response.Content.ReadAsStringAsync());


### PR DESCRIPTION
Some auto-created PRs are getting closed immediately, presumably because the backing branch is being deleted.  This is an attempt to report the status of the PR creation to try to debug why the branch is getting incorrectly deleted.