### PR TITLE
update queued build policy name to reflect recent infrastructure changes

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
@@ -339,7 +339,7 @@ namespace Roslyn.Insertion
 
                     try
                     {
-                        await QueueBuildPolicy(pullRequest, "VAL build with DDRITs and RPS");
+                        await QueueBuildPolicy(pullRequest, "VAL build with RPS");
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
DDRIT tests were recently moved to a different auto-triggered build policy and the RPS one was renamed.  This will re-enable the RPS tests to be automatically queued.