### PR TITLE
Update dotnet/sdk merges with 2.1.5xx

### DIFF
--- a/src/AzureFunctionPackage/Functions/Common/config.xml
+++ b/src/AzureFunctionPackage/Functions/Common/config.xml
@@ -75,7 +75,8 @@
     <merge from="release/2.1.1xx" to="release/2.1.2xx" />
     <merge from="release/2.1.2xx" to="release/2.1.3xx" />
     <merge from="release/2.1.3xx" to="release/2.1.4xx" />
-    <merge from="release/2.1.4xx" to="release/2.2.1xx" />
+    <merge from="release/2.1.4xx" to="release/2.1.5xx" />
+    <merge from="release/2.1.5xx" to="release/2.2.1xx" />
     <merge from="release/2.2.1xx" to="master" />
   </repo>
   <repo owner="Microsoft" name="visualfsharp">


### PR DESCRIPTION
Extra merge bot hop for introduction of 2.1.5xx in dotnet/sdk in between 2.1.4xx and 2.2.1xx.

cc @livarcocc @peterhuene