### PR TITLE
Update RIT to kick off the correct RPS runs (both old & new) when insertions are created

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
@@ -339,7 +339,7 @@ namespace Roslyn.Insertion
 
                     try
                     {
-                        await QueueBuildPolicy(pullRequest, "VAL build with RPS");
+                        await QueueBuildPolicy(pullRequest, "[Deprecated] ValBuild RPS");
                     }
                     catch (Exception ex)
                     {

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
@@ -343,9 +343,18 @@ namespace Roslyn.Insertion
                     }
                     catch (Exception ex)
                     {
-                        Log.Error($"Unable to create a validation build for '{pullRequest.SourceRefName}'");
+                        Log.Error($"Unable to create a deprecated validation build for '{pullRequest.SourceRefName}'");
                         Log.Error(ex);
-                        return;
+                    }
+
+                    try
+                    {
+                        await QueueBuildPolicy(pullRequest, "CloudBuild - RPS");
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error($"Unable to create a CloudBuild validation build for '{pullRequest.SourceRefName}'");
+                        Log.Error(ex);
                     }
                 }
             }


### PR DESCRIPTION
The regular queue's name got marked as `[deprecated]` which broke things. Trying to add the new queue while we're here.