### PR TITLE
update F# insertions

### DIFF
--- a/src/RoslynInsertionTool/scripts/VS-Insertion.ps1
+++ b/src/RoslynInsertionTool/scripts/VS-Insertion.ps1
@@ -43,10 +43,9 @@ function Do-Insertion(
 ### F# Insertions (handled by the F# team)
 ###
 
-#Do-Insertion -component "F#"                -queueName "FSharp-Signed"         -fromBranch "dev15.8"           -toBranch "rel/d15.8" -insertCore "false" -insertDevdiv "false" -queueValidation "true" -dropPath "\\cpvsbuild\drops\FSharp"
-Do-Insertion -component "F#"                -queueName "FSharp-Signed"         -fromBranch "dev15.9"           -toBranch "rel/d15.9" -insertCore "false" -insertDevdiv "false" -queueValidation "true" -dropPath "\\cpvsbuild\drops\FSharp"
-#Do-Insertion -component "F#"                -queueName "FSharp-Signed"         -fromBranch "dev16.0"        -toBranch "lab/ml" -insertCore "false"    -insertDevdiv "false" -dropPath "\\cpvsbuild\drops\FSharp"
-#Do-Insertion -component "F#"                -queueName "FSharp-Signed"         -fromBranch "dev16.0"        -toBranch "lab/ml" -insertCore "false"    -insertDevdiv "false" -dropPath "\\cpvsbuild\drops\FSharp"
+#Do-Insertion -component "F#"                -queueName "FSharp-Signed"         -fromBranch "dev15.8"        -toBranch "rel/d15.8"    -insertCore "false" -insertDevdiv "false" -queueValidation "true" -dropPath "\\cpvsbuild\drops\FSharp"
+Do-Insertion -component "F#"                -queueName "FSharp-Signed"         -fromBranch "dev15.9"        -toBranch "lab/d15.9stg" -insertCore "false" -insertDevdiv "false" -queueValidation "true" -dropPath "\\cpvsbuild\drops\FSharp"
+Do-Insertion -component "F#"                -queueName "FSharp-Signed"         -fromBranch "dev16.0"        -toBranch "lab/ml"       -insertCore "false" -insertDevdiv "false" -dropPath "\\cpvsbuild\drops\FSharp"
 
 
 ###


### PR DESCRIPTION
This does 3 things:

* Turn on insertions from `dev15.8` to `rel/d15.8`.  The latest build from `dev15.8` is already inserted into the `rel/d15.8` branch so **this will be a no-op**.  It's getting re-enabled here just to ensure that if there are any servicing fixes in the future they'll be automatically inserted.
* Move the `dev15.9` insertions to go to the preview branch `lab/d15.9stg`.  In the event we have a late-breaking fix for 15.9 we'll do manual insertions to `rel/d15.9` as necessary.
* Re-enable the insertion from `dev16.0` to `lab/ml` to conform (as much as possible) with the other insertions.