### PR TITLE
ensure all expected functions are in the package

### DIFF
--- a/src/AzureFunctionPackage/AzureFunctionPackage.csproj
+++ b/src/AzureFunctionPackage/AzureFunctionPackage.csproj
@@ -52,15 +52,22 @@
           DependsOnTargets="PreparePackageDirectory">
     <ItemGroup>
       <FilesToCopy Remove="**" />
-      <FilesToCopy Include="$(ArtifactsBinDir)%(AzureFunction.Identity)\%(AzureFunction.TargetFramework)\AzureFunctionFiles\**" />
+      <FilesToCopy Include="$(ArtifactsBinDir)%(AzureFunction.Identity)\$(Configuration)\%(AzureFunction.TargetFramework)\AzureFunctionFiles\**" />
       <FileWrites Include="@(FilesToCopy)" />
     </ItemGroup>
     <Copy SourceFiles="@(FilesToCopy)" DestinationFolder="$(RootPackageDirectory)\%(AzureFunction.Identity)" />
   </Target>
 
+  <Target Name="EnsurePackageSourceHasAllFunctions">
+    <ItemGroup>
+      <MissingFunctions Include="%(AzureFunction.Identity)" Condition="!Exists('$(RootPackageDirectory)\%(AzureFunction.Identity)')" />
+    </ItemGroup>
+    <Error Text="Azure Functions not found at '$(RootPackageDirectory)', check the body of the `CopyPackageFunctionFiles` target.  Missing functions: @(MissingFunctions)" Condition="'@(MissingFunctions)' != ''" />
+  </Target>
+
   <Target Name="CreateZipPackage"
           AfterTargets="Build"
-          DependsOnTargets="CopyPackageFiles;CopyPackageFunctionFiles"
+          DependsOnTargets="CopyPackageFiles;CopyPackageFunctionFiles;EnsurePackageSourceHasAllFunctions"
           Outputs="$(ZipPackagePath)">
     <ItemGroup>
       <FileWrites Include="$(ZipPackagePath)" />


### PR DESCRIPTION
With the migration to the Arcade build tools the shape of the artifacts directory changed which meant an empty Azure Function package was pushed, resulting in the deletion of the functions.

This PR updates the path to the expected shape and also adds an error if the expected functions were not present at zip file creation.  The `EnsurePackageSourceHasAllFunctions` target was first tested locally which resulted in the following error:

```
"D:\dotnet\roslyn-tools\src\AzureFunctionPackage\AzureFunctionPackage.csproj" (Restore;Build target) (1) ->
(EnsurePackageSourceHasAllFunctions target) ->
  D:\dotnet\roslyn-tools\src\AzureFunctionPackage\AzureFunctionPackage.csproj(66,5): error : Azure Functions not found at 'D:\dotnet\roslyn-tools\artifacts\bin\AzureFunctionPackage\Debug\\package', check the body of the `CopyPackageFunctionFiles` target.  Missing functions: GitHubAutoMergePRs;GitHubCreateMergePRs;VstsCreateMergePRs
```

Once the path shape was fixed the error disappeared and the zip package was formed correctly.