### PR TITLE
Generate the build.proj file in the intermediate output path

### DIFF
--- a/src/SignTool/SignTool/SignTool.SignToolBase.cs
+++ b/src/SignTool/SignTool/SignTool.SignToolBase.cs
@@ -36,7 +36,7 @@ namespace SignTool
 
             public void Sign(int round, IEnumerable<FileSignInfo> filesToSign, TextWriter textWriter)
             {
-                var buildFilePath = Path.Combine(AppPath, "build.proj");
+                var buildFilePath = Path.Combine(IntermediateOutputPath, "build.proj");
                 
                 var content = GenerateBuildFileContent(filesToSign);
                 File.WriteAllText(buildFilePath, content);


### PR DESCRIPTION
When signtool.exe is invoked in parallel on the same machine, there is contention for access to $AppBaseDir/build.proj. This moves the build.proj file into the intermediate output path instead to avoid this contention.

cc @jmarolf 