### PR TITLE
fix component insertion in script

### DIFF
--- a/src/RoslynInsertionTool/scripts/OneOffInsertion.ps1
+++ b/src/RoslynInsertionTool/scripts/OneOffInsertion.ps1
@@ -24,10 +24,8 @@ Write-Host ""
 $vsbn = Read-Host -Prompt "Visual Sudio branch name (insertion destination)"
 
 $ic = "true"
-switch ($componentName) {
-    (($_ -eq "Live Unit Testing") -or ($_ -eq "Project System") -or ($_ -eq "F#")) {
-        $ic = "false"
-    }
+if (($componentName -eq "Live Unit Testing") -or ($componentName -eq "Project System") -or ($componentName -eq "F#")) {
+    $ic = "false"
 }
 
 $id = "false"


### PR DESCRIPTION
Turns out that `switch` statement doesn't work like I thought and the `$ic` variable was always set to `"true"`.  This would lead to failed insertions when manually invoked (uncommon).