### PR TITLE
report an actionable error message

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.Git.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.Git.cs
@@ -163,7 +163,12 @@ namespace Roslyn.Insertion
             }
 
             Enlistment.Checkout(branchToSwitchTo, GetCheckoutOptions());
-            var baseBranch = Enlistment.Branches.Single(b => b.FriendlyName == baseBranchName);
+            var baseBranch = Enlistment.Branches.FirstOrDefault(b => b.FriendlyName == baseBranchName);
+            if (baseBranch == null)
+            {
+                throw new ArgumentException($"Visual Studio branch {baseBranchName} not found.");
+            }
+
             Enlistment.Reset(ResetMode.Hard, baseBranch.Tip);
             var branch = Enlistment.Head;
             return branch;


### PR DESCRIPTION
If an invalid `VisualStudioBranchName` is supplied, the current error message is:

```
System.InvalidOperationException: Sequence contains no matching element
```

and that's not very actionable.  The new error message is:

```
System.ArgumentException: Visual Studio branch some-invalid-branch-name not found.
```