### PR TITLE
version numbers don't always have the 'Version=' prefix

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.AssemblyVersions.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.AssemblyVersions.cs
@@ -9,6 +9,8 @@ namespace Roslyn.Insertion
 {
     static partial class RoslynInsertionTool
     {
+        private const string VersionEqualsPrefix = "Version=";
+
         private static void UpdateAssemblyVersions(string artifactsFolder)
         {
             var versionsUpdater = new VersionsUpdater(GetAbsolutePathForEnlistment(), WarningMessages);
@@ -25,7 +27,9 @@ namespace Roslyn.Insertion
         {
             return from line in File.ReadAllLines(path)
                    let columns = line.Split(',')
-                   let version = Version.Parse(columns[1].Trim().Substring("Version=".Length)) // trim Version= from the start
+                   let versionFull = columns[1].Trim()
+                   let versionProper = versionFull.StartsWith(VersionEqualsPrefix) ? versionFull.Substring(VersionEqualsPrefix.Length) : versionFull
+                   let version = Version.Parse(versionProper)
                    let fullVersion = new Version(version.Major, Math.Max(version.Minor, 0), Math.Max(version.Build, 0), Math.Max(version.Revision, 0))
                    select new KeyValuePair<string, Version>(columns[0].Trim(), fullVersion);
         }


### PR DESCRIPTION
This was ultimately leading to a bunch of insertions failing because the format of the `DevDivInsertionFiles.csv` file sometimes looks like:

```
SomeAssembly, Version=1.2.3.4
```

and sometimes looks like:

```
SomeAssembly,1.2.3.4
```
