### PR TITLE
Do not try to rollback changes on an empty commit

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
@@ -267,6 +267,8 @@ namespace Roslyn.Insertion
                         {
                             Console.WriteLine($"Unable to create pull request for '{branch.FriendlyName}'");
                             Console.WriteLine(ecx);
+                            // Since it was an empty commit there should not be anything to rollback.
+                            shouldRollBackGitChanges = false;
                             return (false, 0);
                         }
                         catch (Exception ex)


### PR DESCRIPTION
We've had numerous incomplete runs of the insertion tool because of a NRE during rollback following an EmptyCommitException. It does not seem necessary to rollback in the case of an empty commit since there should be no changes.