### PR TITLE
Update the PR description with a link to the last commit

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
@@ -241,7 +241,7 @@ namespace Roslyn.Insertion
                 if (branch != null)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
-                    var prDescription = $"Updating {Options.InsertionName} to {buildVersion}. [({commitSHA})]({lastCommitUrl})";
+                    var prDescription = $"Updating {Options.InsertionName} to {buildVersion} ([{commitSHA}]({lastCommitUrl}))";
                     if (useExistingPr && pullRequest != null)
                     {
                         // update an existing pr


### PR DESCRIPTION
Pull information from the buildToInsert so that we can link to the last commit for this build.

Changes the PR description from `Updating {Options.InsertionName} to {buildVersion}` into `Updating {Options.InsertionName} to {buildVersion}. [({commitSHA})]({lastCommitUrl})`.

You can see an example on https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/158228?_a=overview