### PR TITLE
Dev16 auto insertion updates

### DIFF
--- a/src/RoslynInsertionTool/scripts/VS-Insertion.ps1
+++ b/src/RoslynInsertionTool/scripts/VS-Insertion.ps1
@@ -58,6 +58,6 @@ Do-Insertion -component "Live Unit Testing" -queueName "TestImpact-Signed"     -
 Do-Insertion -component "VS Unit Testing"   -queueName "VSUnitTesting-Signed"  -fromBranch "dev16.0"                   -toBranch "rel/d16.0" -insertCore "true"     -queueValidation "true" -dropPath "server"
 
 # Dev16.1 Preview 1
-Do-Insertion -component "Roslyn"            -queueName "Roslyn-Signed"         -fromBranch "master-vs-deps" -toBranch "vs/master"       -insertToolset "true"  -insertDevdiv "false"   -updatecorextlibraries "true" -queueValidation "true"
+Do-Insertion -component "Roslyn"            -queueName "Roslyn-Signed"         -fromBranch "master-vs-deps" -toBranch "master"       -insertToolset "true"  -insertDevdiv "false"   -updatecorextlibraries "true" -queueValidation "true"
 #Do-Insertion -component "Live Unit Testing" -queueName "TestImpact-Signed"     -fromBranch "master"                   -toBranch "lab/d16.0stg" -insertCore "false"    -insertDevdiv "false"   -queueValidation "true"
 #Do-Insertion -component "VS Unit Testing"   -queueName "VSUnitTesting-Signed"  -fromBranch "dev16.0.x"                -toBranch "lab/d16.0stg" -insertCore "true"     -queueValidation "true" -dropPath "server"

--- a/src/RoslynInsertionTool/scripts/VS-Insertion.ps1
+++ b/src/RoslynInsertionTool/scripts/VS-Insertion.ps1
@@ -54,11 +54,10 @@ Do-Insertion -component "F#" -queueName "FSharp-Signed" -fromBranch "dev16.1" -t
 Do-Insertion -component "Roslyn"            -queueName "Roslyn-Signed"         -fromBranch "dev15.9.x-vs-deps"        -toBranch "rel/d15.9"    -insertToolset "false" -insertDevdiv "false"   -updatecorextlibraries "true" -queueValidation "true"
 
 # Dev16 Preview 4
-Do-Insertion -component "Roslyn"            -queueName "Roslyn-Signed"         -fromBranch "dev16.0-vs-deps"           -toBranch "rel/d16.0" -insertToolset "true"  -insertDevdiv "false"   -updatecorextlibraries "true" -queueValidation "true"
 Do-Insertion -component "Live Unit Testing" -queueName "TestImpact-Signed"     -fromBranch "dev16.0.x"                -toBranch "lab/d16.0stg" -insertCore "false"    -insertDevdiv "false"   -queueValidation "true"
 Do-Insertion -component "VS Unit Testing"   -queueName "VSUnitTesting-Signed"  -fromBranch "dev16.0"                   -toBranch "rel/d16.0" -insertCore "true"     -queueValidation "true" -dropPath "server"
 
 # Dev16.1 Preview 1
-Do-Insertion -component "Roslyn"            -queueName "Roslyn-Signed"         -fromBranch "master-vs-deps" -toBranch "lab/ml"       -insertToolset "true"  -insertDevdiv "false"   -updatecorextlibraries "true" -queueValidation "true"
+Do-Insertion -component "Roslyn"            -queueName "Roslyn-Signed"         -fromBranch "master-vs-deps" -toBranch "vs/master"       -insertToolset "true"  -insertDevdiv "false"   -updatecorextlibraries "true" -queueValidation "true"
 #Do-Insertion -component "Live Unit Testing" -queueName "TestImpact-Signed"     -fromBranch "master"                   -toBranch "lab/d16.0stg" -insertCore "false"    -insertDevdiv "false"   -queueValidation "true"
 #Do-Insertion -component "VS Unit Testing"   -queueName "VSUnitTesting-Signed"  -fromBranch "dev16.0.x"                -toBranch "lab/d16.0stg" -insertCore "true"     -queueValidation "true" -dropPath "server"


### PR DESCRIPTION
Disable Dev16.0 auto insertions as we're now in qb mode. 
Set master to flow to `vs/master` instead of via `vs/lab/ml`