### PR TITLE
Change return value for CreateMergePrs

### DIFF
--- a/src/GithubMergeTool/GithubMergeTool.cs
+++ b/src/GithubMergeTool/GithubMergeTool.cs
@@ -162,7 +162,7 @@ Once all conflicts are resolved and all the tests pass, you are free to merge th
             {
                 // Delete the pr branch if the PR was not created.
                 await _client.DeleteAsync($"repos/{repoOwner}/{repoName}/git/refs/heads/{prBranchName}");
-                return (false, response);
+                return (false, null);
             }
 
             jsonBody = JObject.Parse(await response.Content.ReadAsStringAsync());


### PR DESCRIPTION
The return value currently indicates that failing to create a PR because
there were no new commits is a failure, but it's actually a success
condition.