### PR TITLE
Disable localization for roslyn-tools

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -46,6 +46,7 @@
     <MonoOptionsVersion>5.3.0.1</MonoOptionsVersion>
 
     <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
+    <UsingToolXliff>false</UsingToolXliff>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Localization produces a lot of large resource assemblies that we don't need, and increases the time needed to download artifacts in deployment.