### PR TITLE
Support creating weekly github auto-merges

### DIFF
--- a/src/AzureFunctionPackage/Functions/Common/config.xml
+++ b/src/AzureFunctionPackage/Functions/Common/config.xml
@@ -22,7 +22,7 @@
     <!-- Feature branches -->
     <merge from="master" to="features/editorconfig-in-compiler" />
     <merge from="master" to="features/lspSupport" />
-    <merge from="master" to="features/NullableDogfood" />
+    <merge from="master" to="features/NullableDogfood" frequency="weekly" />
     <merge from="master" to="features/readonly-members" />
     <merge from="master" to="demos/records" />
   </repo>

--- a/src/AzureFunctionPackage/Functions/GitHubCreateMergePRs/run.csx
+++ b/src/AzureFunctionPackage/Functions/GitHubCreateMergePRs/run.csx
@@ -53,6 +53,13 @@ private static async Task RunAsync(ExecutionContext context)
         {
             var fromBranch = merge.Attribute("from").Value;
             var toBranch = merge.Attribute("to").Value;
+
+            var frequency = merge.Attribute("frequency")?.Value ?? "daily";
+            if (frequency == "weekly" && DateTime.Now.DayOfWeek != DayOfWeek.Sunday)
+            {
+                continue;
+            }
+
             var addAutoMergeLabel = bool.Parse(merge.Attribute("addAutoMergeLabel")?.Value ?? "true");
             await MakeGithubPr(gh, owner, name, fromBranch, toBranch, addAutoMergeLabel);
         }


### PR DESCRIPTION
Frequent requests to fix merge conflicts or build warnings in merges to feature branches can be disruptive. Allow feature branches to opt-in to a weekly merge.