### PR TITLE
Insert OptProf props files

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool/ArcadeInsertionArtifacts.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/ArcadeInsertionArtifacts.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 
 namespace Roslyn.Insertion
 {
@@ -42,5 +43,8 @@ namespace Roslyn.Insertion
 
         public override string GetDependentAssemblyVersionsFile()
             => Path.Combine(_vsSetupDirectory, "DevDivPackages", "DependentAssemblyVersions.csv");
+
+        public override string[] GetOptProfPropertyFiles()
+            => Directory.EnumerateFiles(Path.Combine(_vsSetupDirectory, "Insertion", "OptProf"), "*.props", SearchOption.TopDirectoryOnly).ToArray();
     }
 }

--- a/src/RoslynInsertionTool/RoslynInsertionTool/InsertionArtifacts.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/InsertionArtifacts.cs
@@ -7,5 +7,6 @@ namespace Roslyn.Insertion
     {
         public abstract string GetPackagesDirectory();
         public abstract string GetDependentAssemblyVersionsFile();
+        public abstract string[] GetOptProfPropertyFiles();
     }
 }

--- a/src/RoslynInsertionTool/RoslynInsertionTool/LegacyInsertionArtifacts.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/LegacyInsertionArtifacts.cs
@@ -50,5 +50,8 @@ namespace Roslyn.Insertion
 
         public override string GetDependentAssemblyVersionsFile()
             => Path.Combine(_binariesDirectory, "DevDivInsertionFiles", "DependentAssemblyVersions.csv");
+
+        public override string[] GetOptProfPropertyFiles()
+            => Array.Empty<string>();
     }
 }

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
@@ -154,8 +154,11 @@ namespace Roslyn.Insertion
                     // *********** Copy OptimizationInputs.props file ***********************
                     foreach (var propsFile in insertionArtifacts.GetOptProfPropertyFiles())
                     {
-                        var targetFilePath = Path.Combine(enlistmentRoot, @"src\Tests\config\runsettings\Official\OptProf", Path.GetFileName(propsFile));
+                        var targetDirectory = Path.Combine(enlistmentRoot, @"src\Tests\config\runsettings\Official\OptProf\External");
+                        var targetFilePath = Path.Combine(targetDirectory, Path.GetFileName(propsFile));
+
                         Console.WriteLine($"Updating {targetFilePath}");
+                        Directory.CreateDirectory(targetDirectory);
                         File.Copy(propsFile, targetFilePath, overwrite: true);
                     }
                 }

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
@@ -130,9 +130,10 @@ namespace Roslyn.Insertion
 
                 shouldRollBackGitChanges = branch != null;
 
-                var coreXT = CoreXT.Load(GetAbsolutePathForEnlistment());
+                var enlistmentRoot = GetAbsolutePathForEnlistment();
+                var coreXT = CoreXT.Load(enlistmentRoot);
 
-                if(Options.InsertCoreXTPackages)
+                if (Options.InsertCoreXTPackages)
                 {
                     // ************** Update Nuget Packages For Branch************************
                     cancellationToken.ThrowIfCancellationRequested();
@@ -149,6 +150,14 @@ namespace Roslyn.Insertion
                     cancellationToken.ThrowIfCancellationRequested();
                     Console.WriteLine($"Updating CoreXT default.config file");
                     coreXT.SaveConfig();
+
+                    // *********** Copy OptimizationInputs.props file ***********************
+                    foreach (var propsFile in insertionArtifacts.GetOptProfPropertyFiles())
+                    {
+                        var targetFilePath = Path.Combine(enlistmentRoot, @"src\Tests\config\runsettings\Official\OptProf", Path.GetFileName(propsFile));
+                        Console.WriteLine($"Updating {targetFilePath}");
+                        File.Copy(propsFile, targetFilePath, overwrite: true);
+                    }
                 }
 
                 if (Options.UpdateCoreXTLibraries || Options.UpdateAssemblyVersions)


### PR DESCRIPTION
Insert `.props` files from `VSSetup\Insertion\OptProf` directory to `{VS enlistment}\src\Tests\config\runsettings\Official\OptProf\External`.

These will be picked up by VS IBC training build.