### PR TITLE
do not fail insertion if DependentAssemblyVersionsFile is not found

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.AssemblyVersions.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.AssemblyVersions.cs
@@ -15,9 +15,17 @@ namespace Roslyn.Insertion
         {
             var versionsUpdater = new VersionsUpdater(GetAbsolutePathForEnlistment(), WarningMessages);
 
-            foreach (var nameAndVersion in ReadAssemblyVersions(artifacts.GetDependentAssemblyVersionsFile()))
+            var pathToDependentAssemblyVersionsFile = artifacts.GetDependentAssemblyVersionsFile();
+            if (File.Exists(pathToDependentAssemblyVersionsFile))
             {
-                versionsUpdater.UpdateComponentVersion(nameAndVersion.Key, nameAndVersion.Value);
+                foreach (var nameAndVersion in ReadAssemblyVersions(pathToDependentAssemblyVersionsFile))
+                {
+                    versionsUpdater.UpdateComponentVersion(nameAndVersion.Key, nameAndVersion.Value);
+                }
+            }
+            else
+            {
+                Console.WriteLine($"No dependent-assembly-versions file found at path '{pathToDependentAssemblyVersionsFile}'");
             }
 
             versionsUpdater.Save();


### PR DESCRIPTION
This file is supposed to be optional yet we fail the insertion if it cannot be found