### PR TITLE
Update config for dev16.1->release/dev16.1 change

### DIFF
--- a/src/AzureFunctionPackage/Functions/Common/config.xml
+++ b/src/AzureFunctionPackage/Functions/Common/config.xml
@@ -4,8 +4,8 @@
     <merge from="dev15.0.x" to="dev15.9.x" />
     <merge from="dev15.9.x" to="dev16.0" />
     <merge from="dev16.0" to="dev16.1-preview3" />
-    <merge from="dev16.1-preview3" to="releases/dev16.1" />
-    <merge from="releases/dev16.1" to="master" />
+    <merge from="dev16.1-preview3" to="release/dev16.1" />
+    <merge from="release/dev16.1" to="master" />
 
     <!-- Roslyn branches (between vs-deps branches) -->
     <merge from="dev15.0.x-vs-deps" to="dev15.9.x-vs-deps" />
@@ -19,7 +19,7 @@
     <merge from="dev15.9.x" to="dev15.9.x-vs-deps" />
     <merge from="dev16.0" to="dev16.0-vs-deps" />
     <merge from="dev16.1-preview3" to="dev16.1-preview3-vs-deps" />
-    <merge from="releases/dev16.1" to="releases/dev16.1-vs-deps" />
+    <merge from="release/dev16.1" to="releases/dev16.1-vs-deps" />
     <merge from="master" to="master-vs-deps" />
 
     <!-- Feature branches -->

--- a/src/AzureFunctionPackage/Functions/Common/config.xml
+++ b/src/AzureFunctionPackage/Functions/Common/config.xml
@@ -4,8 +4,8 @@
     <merge from="dev15.0.x" to="dev15.9.x" />
     <merge from="dev15.9.x" to="dev16.0" />
     <merge from="dev16.0" to="dev16.1-preview3" />
-    <merge from="dev16.1-preview3" to="dev16.1" />
-    <merge from="dev16.1" to="master" />
+    <merge from="dev16.1-preview3" to="releases/dev16.1" />
+    <merge from="releases/dev16.1" to="master" />
 
     <!-- Roslyn branches (between vs-deps branches) -->
     <merge from="dev15.0.x-vs-deps" to="dev15.9.x-vs-deps" />
@@ -19,7 +19,7 @@
     <merge from="dev15.9.x" to="dev15.9.x-vs-deps" />
     <merge from="dev16.0" to="dev16.0-vs-deps" />
     <merge from="dev16.1-preview3" to="dev16.1-preview3-vs-deps" />
-    <merge from="dev16.1" to="dev16.1-vs-deps" />
+    <merge from="releases/dev16.1" to="releases/dev16.1-vs-deps" />
     <merge from="master" to="master-vs-deps" />
 
     <!-- Feature branches -->

--- a/src/RoslynInsertionTool/scripts/VS-Insertion.ps1
+++ b/src/RoslynInsertionTool/scripts/VS-Insertion.ps1
@@ -63,7 +63,7 @@ Do-Insertion -component "VS Unit Testing"   -queueName "VSUnitTesting-Signed"  -
 Do-Insertion -component "Roslyn"            -queueName "Roslyn-Signed"         -fromBranch "dev16.1-preview3-vs-deps" -toBranch "rel/d16.1" -insertToolset "true"  -insertDevdiv "false"   -updatecorextlibraries "true" -queueValidation "true"
 
 # Dev16.1 Preview 4
-Do-Insertion -component "Roslyn"            -queueName "Roslyn-Signed"         -fromBranch "dev16.1-vs-deps"          -toBranch "lab/d16.1stg" -insertToolset "true"  -insertDevdiv "false"   -updatecorextlibraries "true" -queueValidation "true"
+Do-Insertion -component "Roslyn"            -queueName "Roslyn-Signed"         -fromBranch "releases/dev16.1-vs-deps"          -toBranch "lab/d16.1stg" -insertToolset "true"  -insertDevdiv "false"   -updatecorextlibraries "true" -queueValidation "true"
 
 # Dev 16.2 Preview 1
 Do-Insertion -component "Roslyn"            -queueName "Roslyn-Signed"         -fromBranch "master-vs-deps"  -toBranch "lab/d16.2stg" -insertToolset "true"  -insertDevdiv "false"   -updatecorextlibraries "true" -queueValidation "true"

--- a/src/RoslynInsertionTool/scripts/VS-Insertion.ps1
+++ b/src/RoslynInsertionTool/scripts/VS-Insertion.ps1
@@ -63,7 +63,7 @@ Do-Insertion -component "VS Unit Testing"   -queueName "VSUnitTesting-Signed"  -
 Do-Insertion -component "Roslyn"            -queueName "Roslyn-Signed"         -fromBranch "dev16.1-preview3-vs-deps" -toBranch "rel/d16.1" -insertToolset "true"  -insertDevdiv "false"   -updatecorextlibraries "true" -queueValidation "true"
 
 # Dev16.1 Preview 4
-Do-Insertion -component "Roslyn"            -queueName "Roslyn-Signed"         -fromBranch "releases/dev16.1-vs-deps"          -toBranch "lab/d16.1stg" -insertToolset "true"  -insertDevdiv "false"   -updatecorextlibraries "true" -queueValidation "true"
+Do-Insertion -component "Roslyn"            -queueName "Roslyn-Signed"         -fromBranch "release/dev16.1-vs-deps"          -toBranch "lab/d16.1stg" -insertToolset "true"  -insertDevdiv "false"   -updatecorextlibraries "true" -queueValidation "true"
 
 # Dev 16.2 Preview 1
 Do-Insertion -component "Roslyn"            -queueName "Roslyn-Signed"         -fromBranch "master-vs-deps"  -toBranch "lab/d16.2stg" -insertToolset "true"  -insertDevdiv "false"   -updatecorextlibraries "true" -queueValidation "true"


### PR DESCRIPTION
This updates the bot config to begin inserting and merging based off of `releases/dev16.1` and `releases/dev16.1-vs-deps` instead of `dev16.1` and `dev16.1-vs-deps`.

/cc @jaredpar @dpoeschl @JoeRobich 