### PR TITLE
Send both base and head shas when merging

### DIFF
--- a/src/GithubMergeTool/GithubMergeTool.cs
+++ b/src/GithubMergeTool/GithubMergeTool.cs
@@ -339,9 +339,11 @@ Once all conflicts are resolved and all the tests pass, you are free to merge th
 
             // Merge the PR
             var mergeSha = (string)prInfo["head"]["sha"];
+            var baseSha = (string)prInfo["base"]["sha"];
             var mergeBody = $@"
 {{
-    ""sha"": ""{mergeSha}""
+    ""head"": ""{mergeSha}"",
+    ""base"": ""{baseSha}""
 }}";
             var mergeResponse = await _client.PutAsyncAsJson(prUri + "/merge", mergeBody);
             if (!mergeResponse.IsSuccessStatusCode)


### PR DESCRIPTION
GitHub V3 API expects both head and base shas https://developer.github.com/v3/repos/merging/#input