### PR TITLE
Add Delay to GitHub PR creation

### DIFF
--- a/src/AzureFunctionPackage/Functions/GitHubCreateMergePRs/run.csx
+++ b/src/AzureFunctionPackage/Functions/GitHubCreateMergePRs/run.csx
@@ -63,6 +63,9 @@ private static async Task RunAsync(ExecutionContext context, bool isAutomatedRun
 
             var addAutoMergeLabel = bool.Parse(merge.Attribute("addAutoMergeLabel")?.Value ?? "true");
             await MakeGithubPr(gh, owner, name, fromBranch, toBranch, addAutoMergeLabel, isAutomatedRun);
+            
+            // Delay in order to avoid triggering GitHub rate limiting
+            await Task.Delay(3000);
         }
     }
 }


### PR DESCRIPTION
"The Search API has a custom rate limit. For requests using Basic Authentication, OAuth, or client ID and secret, you can make up to 30 requests per minute."