### PR TITLE
Move Roslyn to create insertion on successful signed build

### DIFF
--- a/src/RoslynInsertionTool/scripts/VS-Insertion.ps1
+++ b/src/RoslynInsertionTool/scripts/VS-Insertion.ps1
@@ -59,8 +59,12 @@ Do-Insertion -component "Roslyn"  -queueName "Roslyn-Signed"  -fromBranch "dev16
 Do-Insertion -component "Roslyn"  -queueName "Roslyn-Signed"  -fromBranch "release/dev16.1-vs-deps"  -toBranch "rel/d16.1"  -insertToolset "false"  -insertDevdiv "false"  -updatecorextlibraries "true"  -queueValidation "true"
 
 ## Testing insertion on successful Signed Build
+
+# Dev 16.2 Preview 3
+#Do-Insertion -component "Roslyn"  -queueName "Roslyn-Signed"  -fromBranch "release/dev16.2-preview3-vs-deps"  -toBranch "rel/d16.2"     -insertToolset "false"  -insertDevdiv "false"  -updatecorextlibraries "true"  -queueValidation "true"
+
 # Dev 16.2 Preview 4
-#Do-Insertion -component "Roslyn"            -queueName "Roslyn-Signed"         -fromBranch "master-vs-deps"                    -toBranch "lab/d16.2stg" -insertToolset "true"  -insertDevdiv "false"   -updatecorextlibraries "true" -queueValidation "true"
+#Do-Insertion -component "Roslyn"  -queueName "Roslyn-Signed"  -fromBranch "master-vs-deps"                    -toBranch "lab/d16.2stg"  -insertToolset "true"   -insertDevdiv "false"  -updatecorextlibraries "true"  -queueValidation "true"
 
 # Dev 16.3 Preview 1
-#Do-Insertion -component "Roslyn"            -queueName "Roslyn-Signed"         -fromBranch "release/dev16.3-preview1-vs-deps"  -toBranch "master"       -insertToolset "true"  -insertDevdiv "false"   -updatecorextlibraries "true" -queueValidation "true"
+#Do-Insertion -component "Roslyn"  -queueName "Roslyn-Signed"  -fromBranch "release/dev16.3-preview1-vs-deps"  -toBranch "master"        -insertToolset "true"   -insertDevdiv "false"  -updatecorextlibraries "true"  -queueValidation "true"

--- a/src/RoslynInsertionTool/scripts/VS-Insertion.ps1
+++ b/src/RoslynInsertionTool/scripts/VS-Insertion.ps1
@@ -42,25 +42,25 @@ function Do-Insertion(
 #Do-Insertion -component "F#" -queueName "FSharp-Signed" -fromBranch "dev16.1" -toBranch "lab/ml"    -insertCore "false" -insertDevdiv "false" -dropPath "\\cpvsbuild\drops\FSharp"
 
 ###
-### Non-F# Insertions (handled by the Infrastructure Team)
+### Unit Testing Insertions
 ###
 
-# Dev15.8 - Servicing only
-#Do-Insertion -component "Roslyn"            -queueName "Roslyn-Signed"         -fromBranch "dev15.8.x-vs-deps" -toBranch "rel/d15.8" -insertToolset "false" -insertDevdiv "false" -queueValidation "true" -updatecorextl#ibraries "true"
-
-# Dev15.9
-Do-Insertion -component "Roslyn"            -queueName "Roslyn-Signed"         -fromBranch "dev15.9.x-vs-deps"        -toBranch "rel/d15.9"    -insertToolset "false" -insertDevdiv "false"   -updatecorextlibraries "true" -queueValidation "true"
-
-# Dev16.0
-Do-Insertion -component "Roslyn"            -queueName "Roslyn-Signed"         -fromBranch "dev16.0-vs-deps"          -toBranch "rel/d16.0"    -insertToolset "false" -insertDevdiv "false"   -updatecorextlibraries "true" -queueValidation "true"
-
-# Dev16.1
-Do-Insertion -component "Roslyn"            -queueName "Roslyn-Signed"         -fromBranch "release/dev16.1-vs-deps"  -toBranch "rel/d16.1"    -insertToolset "false" -insertDevdiv "false"   -updatecorextlibraries "true" -queueValidation "true"
-
 # Dev 16.2 Preview 4
-Do-Insertion -component "Roslyn"            -queueName "Roslyn-Signed"         -fromBranch "master-vs-deps"                    -toBranch "lab/d16.2stg" -insertToolset "true"  -insertDevdiv "false"   -updatecorextlibraries "true" -queueValidation "true"
-Do-Insertion -component "VS Unit Testing"   -queueName "VSUnitTesting-Signed"  -fromBranch "master"                            -toBranch "lab/d16.2stg" -insertCore "true"     -queueValidation "true" -dropPath "server"
-Do-Insertion -component "Live Unit Testing" -queueName "TestImpact-Signed"     -fromBranch "master"                            -toBranch "lab/d16.2stg" -insertCore "false"    -insertDevdiv "false"   -queueValidation "true"
+Do-Insertion -component "VS Unit Testing"    -queueName "VSUnitTesting-Signed"  -fromBranch "master"  -toBranch "lab/d16.2stg"  -insertCore "true"   -queueValidation "true"  -dropPath "server"
+Do-Insertion -component "Live Unit Testing"  -queueName "TestImpact-Signed"     -fromBranch "master"  -toBranch "lab/d16.2stg"  -insertCore "false"  -insertDevdiv "false"    -queueValidation "true"
+
+###
+### Roslyn Insertions
+###
+
+#Do-Insertion -component "Roslyn"  -queueName "Roslyn-Signed"  -fromBranch "dev15.8.x-vs-deps"        -toBranch "rel/d15.8"  -insertToolset "false"  -insertDevdiv "false"  -updatecorextlibraries "true"  -queueValidation "true"
+Do-Insertion -component "Roslyn"  -queueName "Roslyn-Signed"  -fromBranch "dev15.9.x-vs-deps"        -toBranch "rel/d15.9"  -insertToolset "false"  -insertDevdiv "false"  -updatecorextlibraries "true"  -queueValidation "true"
+Do-Insertion -component "Roslyn"  -queueName "Roslyn-Signed"  -fromBranch "dev16.0-vs-deps"          -toBranch "rel/d16.0"  -insertToolset "false"  -insertDevdiv "false"  -updatecorextlibraries "true"  -queueValidation "true"
+Do-Insertion -component "Roslyn"  -queueName "Roslyn-Signed"  -fromBranch "release/dev16.1-vs-deps"  -toBranch "rel/d16.1"  -insertToolset "false"  -insertDevdiv "false"  -updatecorextlibraries "true"  -queueValidation "true"
+
+## Testing insertion on successful Signed Build
+# Dev 16.2 Preview 4
+#Do-Insertion -component "Roslyn"            -queueName "Roslyn-Signed"         -fromBranch "master-vs-deps"                    -toBranch "lab/d16.2stg" -insertToolset "true"  -insertDevdiv "false"   -updatecorextlibraries "true" -queueValidation "true"
 
 # Dev 16.3 Preview 1
-Do-Insertion -component "Roslyn"            -queueName "Roslyn-Signed"         -fromBranch "release/dev16.3-preview1-vs-deps"  -toBranch "master"       -insertToolset "true"  -insertDevdiv "false"   -updatecorextlibraries "true" -queueValidation "true"
+#Do-Insertion -component "Roslyn"            -queueName "Roslyn-Signed"         -fromBranch "release/dev16.3-preview1-vs-deps"  -toBranch "master"       -insertToolset "true"  -insertDevdiv "false"   -updatecorextlibraries "true" -queueValidation "true"


### PR DESCRIPTION
For 16.2 preview3, we will create insertions as needed
For 16.2 preview4, insertions will be created by https://devdiv.visualstudio.com/DevDiv/_releaseDefinition?definitionId=1837&_a=definition-pipeline
For 16.3, insertions will be created by https://devdiv.visualstudio.com/DevDiv/_releaseDefinition?definitionId=1838&_a=definition-pipeline