### PR TITLE
Log.Error doesn't have an overload that takes an exception

### DIFF
--- a/src/AzureFunctionPackage/Functions/GitHubAutoMergePRs/run.csx
+++ b/src/AzureFunctionPackage/Functions/GitHubAutoMergePRs/run.csx
@@ -58,7 +58,7 @@ private static async Task RunAsync(ExecutionContext context)
             {
                 // If a specific merge fails, we don't want to fail all merges. Log the exception
                 // and continue trying to merge other PRs 
-                Log.Error(ex);
+                Log.Error(ex?.ToString());
             }
             
             // Delay in order to avoid triggering GitHub rate limiting

--- a/src/AzureFunctionPackage/Functions/GitHubAutoMergePRs/run.csx
+++ b/src/AzureFunctionPackage/Functions/GitHubAutoMergePRs/run.csx
@@ -58,7 +58,7 @@ private static async Task RunAsync(ExecutionContext context)
             {
                 // If a specific merge fails, we don't want to fail all merges. Log the exception
                 // and continue trying to merge other PRs 
-                Log.Error(ex?.ToString());
+                Log.Error(ex.ToString());
             }
             
             // Delay in order to avoid triggering GitHub rate limiting


### PR DESCRIPTION
Use `ex?.ToString()` instead to output the error.