### PR TITLE
log exceptions when creating merge PRs

### DIFF
--- a/src/AzureFunctionPackage/Functions/GitHubCreateMergePRs/run.csx
+++ b/src/AzureFunctionPackage/Functions/GitHubCreateMergePRs/run.csx
@@ -62,10 +62,19 @@ private static async Task RunAsync(ExecutionContext context, bool isAutomatedRun
             }
 
             var addAutoMergeLabel = bool.Parse(merge.Attribute("addAutoMergeLabel")?.Value ?? "true");
-            await MakeGithubPr(gh, owner, name, fromBranch, toBranch, addAutoMergeLabel, isAutomatedRun);
-            
-            // Delay in order to avoid triggering GitHub rate limiting
-            await Task.Delay(4000);
+            try
+            {
+                await MakeGithubPr(gh, owner, name, fromBranch, toBranch, addAutoMergeLabel, isAutomatedRun);
+            }
+            catch (Exception ex)
+            {
+                Log.Error("Error creating merge PR.", ex);
+            }
+            finally
+            {
+                // Delay in order to avoid triggering GitHub rate limiting
+                await Task.Delay(4000);
+            }
         }
     }
 }


### PR DESCRIPTION
This is the first step in observing the type of rate-limiting that's being imposed by GH.

Next step: temporarily remove `Task.Delay()` so we can see whether GH is rate-limiting this script from an API standpoint or abuse, because that will dictate the type of fix necessary to remove the delay altogether.