### PR TITLE
Revert "Use the auto-merge label from arcade"

### DIFF
--- a/src/GithubMergeTool/GithubMergeTool.cs
+++ b/src/GithubMergeTool/GithubMergeTool.cs
@@ -184,7 +184,7 @@ Once all conflicts are resolved and all the tests pass, you are free to merge th
             return (true, null);
         }
 
-        public const string AutoMergeLabelText = "auto-merge";
+        public const string AutoMergeLabelText = "Auto-Merge If Tests Pass";
 
         /// <summary>
         /// Fetch the list of PRs that have been marked with the <see cref="AutoMergeLabelText"/>


### PR DESCRIPTION
Reverts dotnet/roslyn-tools#540

Turns out the maestro bot doesn't support approving PRs yet, so we have to continue using our own for now.