### PR TITLE
Updating the new RPS policy name

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
@@ -336,7 +336,7 @@ namespace Roslyn.Insertion
 
                     try
                     {
-                        await QueueBuildPolicy(pullRequest, "CloudBuild - Request RPS");
+                        await QueueBuildPolicy(pullRequest, "Request Perf DDRITs");
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
RPS isn't triggering on the insertion builds because of a policy name change that was made [here](https://devdiv.visualstudio.com/Engineering/_git/PullRequestBot/pullrequest/204633?_a=files). Updating our scripts to reflect the new name.