### PR TITLE
Make it easier to run the tool locally

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/RoslynInsertionToolCommandline.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/RoslynInsertionToolCommandline.cs
@@ -233,6 +233,11 @@ partial class RoslynInsertionToolCommandline
                 "Prepend the generated pull request's title with the specified value.",
                 titlePrefix => options = options.WithTitlePrefix(titlePrefix)
             },
+            {
+                "local",
+                "Run the tool in local mode (prompt for login instead of providing username and password).",
+                isLocal => options = options.WithIsLocal(true)
+            },
         };
 
         List<string> extraArguments = null;
@@ -259,7 +264,11 @@ partial class RoslynInsertionToolCommandline
             return true;
         }
 
-        if (string.IsNullOrEmpty(options.Password))
+        if (options.IsLocal)
+        {
+            Console.WriteLine("Running in local mode using client credentials (will prompt for login).");
+        }
+        else if (string.IsNullOrEmpty(options.Password))
         {
             Console.WriteLine($"Attempting to get credentials from KeyVault.");
             try

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.Git.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.Git.cs
@@ -118,6 +118,13 @@ namespace Roslyn.Insertion
         private static Credentials GetCredentials()
         {
             Console.WriteLine("Getting credentials");
+
+            if (Options.IsLocal)
+            {
+                // TODO: local mode doesn't work when actually pushing yet
+                return new DefaultCredentials();
+            }
+
             return new UsernamePasswordCredentials
             {
                 Username = Options.Username,

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
@@ -296,6 +296,10 @@ namespace Roslyn.Insertion
                                 Console.WriteLine("Could not create diff links.");
                             }
 
+                            Console.WriteLine("---PR description---");
+                            Console.WriteLine(prDescription);
+                            Console.WriteLine("---End PR description---");
+
                             branch = PushChanges(branch, buildVersion, cancellationToken);
                             pullRequest = await CreatePullRequestAsync(branch.FriendlyName, prDescription, buildVersion.ToString(), options.TitlePrefix, cancellationToken);
                             shouldRollBackGitChanges = false;

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionToolOptions.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionToolOptions.cs
@@ -59,6 +59,7 @@ namespace Roslyn.Insertion
             bool createDummyPr,
             int updateExistingPr,
             bool overwritePr,
+            bool isLocal,
             string logFileLocation,
             string clientId,
             string clientSecret,
@@ -92,6 +93,7 @@ namespace Roslyn.Insertion
             CreateDummyPr = createDummyPr;
             UpdateExistingPr = updateExistingPr;
             OverwritePr = overwritePr;
+            IsLocal = isLocal;
             LogFileLocation = logFileLocation;
             ClientId = clientId;
             ClientSecret = clientSecret;
@@ -127,6 +129,7 @@ namespace Roslyn.Insertion
             Optional<bool> createDummyPr = default,
             Optional<int> updateExistingPr = default,
             Optional<bool> overwritePr = default,
+            Optional<bool> isLocal = default,
             Optional<string> logFileLocation = default,
             Optional<string> clientId = default,
             Optional<string> clientSecret = default,
@@ -161,6 +164,7 @@ namespace Roslyn.Insertion
                 createDummyPr: createDummyPr.ValueOrFallback(CreateDummyPr),
                 updateExistingPr: updateExistingPr.ValueOrFallback(UpdateExistingPr),
                 overwritePr: overwritePr.ValueOrFallback(OverwritePr),
+                isLocal: isLocal.ValueOrFallback(IsLocal),
                 logFileLocation: logFileLocation.ValueOrFallback(LogFileLocation),
                 clientId: clientId.ValueOrFallback(ClientId),
                 clientSecret: clientSecret.ValueOrFallback(ClientSecret),
@@ -232,6 +236,8 @@ namespace Roslyn.Insertion
 
         public RoslynInsertionToolOptions WithTitlePrefix(string titlePrefix) => Update(titlePrefix: titlePrefix);
 
+        public RoslynInsertionToolOptions WithIsLocal(bool isLocal) => Update(isLocal: isLocal);
+
         public string EnlistmentPath { get; }
 
         public string Username { get; }
@@ -288,6 +294,8 @@ namespace Roslyn.Insertion
 
         public bool OverwritePr { get; }
 
+        public bool IsLocal { get; }
+
         public string LogFileLocation { get; }
 
         public string ClientId { get; }
@@ -321,11 +329,12 @@ namespace Roslyn.Insertion
                 }
                 else
                 {
+                    var hasCredentials = (!string.IsNullOrEmpty(Username) && !string.IsNullOrEmpty(Password)) || IsLocal;
+
                     return
                         !OverwritePr &&
                         !string.IsNullOrEmpty(EnlistmentPath) &&
-                        !string.IsNullOrEmpty(Username) &&
-                        !string.IsNullOrEmpty(Password) &&
+                        hasCredentials &&
                         !string.IsNullOrEmpty(VisualStudioBranchName) &&
                         !string.IsNullOrEmpty(BuildQueueName) &&
                         !string.IsNullOrEmpty(BranchName) &&


### PR DESCRIPTION
This PR adds a `/local` flag to run the tool locally. It prompts you with a nice popup login window. This way you don't have to type your corporate username and password in the command line/save it in VS debug options/other bad stuff like that.

TODO: make pushing the PR branch locally work. I suspect the client credential uses a token but libgit2sharp doesn't expose any way to provide a custom header with the token for a git push. So we would have to either:

1. send a patch to libgit2sharp to add the option (probably not that hard, since they did do the native bridging in libgit2/libgit2sharp#1233)
2. just `Process.Start("git", ...).WaitForExit()`

/cc @JoeRobich @dibarbet @jmarolf