### PR TITLE
Fix BuildDropPath for Arcade artifacts

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool/ArcadeInsertionArtifacts.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/ArcadeInsertionArtifacts.cs
@@ -19,9 +19,9 @@ namespace Roslyn.Insertion
 
         public static bool TryCreateFromLocalBuild(string buildDirectory, out InsertionArtifacts artifacts)
         {
-            if (buildDirectory.EndsWith(@"artifacts\VSSetup\Debug", StringComparison.OrdinalIgnoreCase) ||
-                buildDirectory.EndsWith(@"artifacts\VSSetup\Release", StringComparison.OrdinalIgnoreCase))
+            if (buildDirectory.EndsWith(ArtifactName, StringComparison.OrdinalIgnoreCase))
             {
+                Console.WriteLine($"Using artifacts provided in BuildDropPath: {buildDirectory}");
                 artifacts = new ArcadeInsertionArtifacts(buildDirectory);
                 return true;
             }


### PR DESCRIPTION
It looks like we don't use this folder structure any more in the VSSetup artifact. Updated the tool to match what we currently have.

This can save a little time on triggered pipelines which already need to download the artifacts for the build that they are triggered by.