### PR TITLE
Various minor improvements

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool/CoreXT.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/CoreXT.cs
@@ -35,13 +35,13 @@ namespace Roslyn.Insertion
             var vsRepoId = RoslynInsertionTool.VSRepoId;
             var vsBranch = new GitVersionDescriptor { VersionType = GitVersionType.Commit, Version = commitId };
 
-            var defaultConfigStream = await gitClient.GetItemContentAsync(
+            using var defaultConfigStream = await gitClient.GetItemContentAsync(
                 vsRepoId,
                 DefaultConfigPath,
                 download: true,
                 versionDescriptor: vsBranch);
 
-            var defaultConfigOriginal = new StreamReader(defaultConfigStream).ReadToEnd();
+            var defaultConfigOriginal = await new StreamReader(defaultConfigStream).ReadToEndAsync();
 
             ComponentToFileMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             ComponentFileToDocumentMap = new Dictionary<string, (string, JObject)>(StringComparer.OrdinalIgnoreCase);
@@ -254,8 +254,7 @@ namespace Roslyn.Insertion
             try
             {
                 using var fileStream = await gitClient.GetItemContentAsync(RoslynInsertionTool.VSRepoId, path: componentsJSONPath, versionDescriptor: versionDescriptor);
-                using var streamReader = new StreamReader(fileStream);
-                var original = streamReader.ReadToEnd();
+                var original = await new StreamReader(fileStream).ReadToEndAsync();
                 var jsonDocument = (JObject)JToken.Parse(original);
                 return (original, jsonDocument);
             }

--- a/src/RoslynInsertionTool/RoslynInsertionTool/CoreXT.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/CoreXT.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.TeamFoundation.SourceControl.WebApi;
 using Newtonsoft.Json;
@@ -29,16 +30,16 @@ namespace Roslyn.Insertion
             ConfigDocument = XDocument.Parse(configOriginalText, LoadOptions.None);
         }
 
-        public static CoreXT Load(GitHttpClient gitClient, string commitId)
+        public static async Task<CoreXT> Load(GitHttpClient gitClient, string commitId)
         {
             var vsRepoId = RoslynInsertionTool.VSRepoId;
             var vsBranch = new GitVersionDescriptor { VersionType = GitVersionType.Commit, Version = commitId };
 
-            var defaultConfigStream = gitClient.GetItemContentAsync(
+            var defaultConfigStream = await gitClient.GetItemContentAsync(
                 vsRepoId,
                 DefaultConfigPath,
                 download: true,
-                versionDescriptor: vsBranch).Result;
+                versionDescriptor: vsBranch);
 
             var defaultConfigOriginal = new StreamReader(defaultConfigStream).ReadToEnd();
 
@@ -46,7 +47,7 @@ namespace Roslyn.Insertion
             ComponentFileToDocumentMap = new Dictionary<string, (string, JObject)>(StringComparer.OrdinalIgnoreCase);
             dirtyFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            PopulateComponentJsonMaps(gitClient, commitId);
+            await PopulateComponentJsonMaps(gitClient, commitId);
 
             return new CoreXT(defaultConfigOriginal);
         }
@@ -186,11 +187,11 @@ namespace Roslyn.Insertion
             }
         }
 
-        private static void PopulateComponentJsonMaps(
+        private static async Task PopulateComponentJsonMaps(
             GitHttpClient gitClient,
             string commitId)
         {
-            var (mainOriginal, mainComponentsJsonDocument) = GetJsonDocumentForComponentsFile(gitClient, commitId, ComponentsJsonPath);
+            var (mainOriginal, mainComponentsJsonDocument) = await GetJsonDocumentForComponentsFile(gitClient, commitId, ComponentsJsonPath);
             if (mainComponentsJsonDocument != null)
             {
                 ComponentFileToDocumentMap[ComponentsJsonPath] = (mainOriginal, mainComponentsJsonDocument);
@@ -207,7 +208,7 @@ namespace Roslyn.Insertion
                         if (!string.IsNullOrEmpty(subComponentFileName))
                         {
                             var componentsJSONPath = ".corext/Configs/" + subComponentFileName;
-                            var (original, jDoc) = GetJsonDocumentForComponentsFile(gitClient, commitId, componentsJSONPath);
+                            var (original, jDoc) = await GetJsonDocumentForComponentsFile(gitClient, commitId, componentsJSONPath);
 
                             if (jDoc != null && !ComponentFileToDocumentMap.ContainsKey(componentsJSONPath))
                             {
@@ -244,30 +245,24 @@ namespace Roslyn.Insertion
             }
         }
 
-        private static (string original, JObject document) GetJsonDocumentForComponentsFile(
+        private static async Task<(string original, JObject document)> GetJsonDocumentForComponentsFile(
             GitHttpClient gitClient,
             string commitId,
             string componentsJSONPath)
         {
-            JObject jsonDocument = null;
-            string original = null;
-
             var versionDescriptor = new GitVersionDescriptor { VersionType = GitVersionType.Commit, Version = commitId };
             try
             {
-                using (var filestream = gitClient.GetItemContentAsync(RoslynInsertionTool.VSRepoId, path: componentsJSONPath, versionDescriptor: versionDescriptor).Result)
-                using (var streamReader = new StreamReader(filestream))
-                {
-                    original = streamReader.ReadToEnd();
-                    jsonDocument = (JObject)JToken.Parse(original);
-                }
+                using var fileStream = await gitClient.GetItemContentAsync(RoslynInsertionTool.VSRepoId, path: componentsJSONPath, versionDescriptor: versionDescriptor);
+                using var streamReader = new StreamReader(fileStream);
+                var original = streamReader.ReadToEnd();
+                var jsonDocument = (JObject)JToken.Parse(original);
+                return (original, jsonDocument);
             }
             catch (Exception e)
             {
                 throw new IOException($"Unable to load file from '{componentsJSONPath}'", e);
             }
-
-            return (original, jsonDocument);
         }
 
         private (string original, JObject document) GetJsonDocumentForComponent(string componentName)

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.AssemblyVersions.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.AssemblyVersions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Roslyn.Insertion
 {
@@ -12,9 +13,9 @@ namespace Roslyn.Insertion
     {
         private const string VersionEqualsPrefix = "Version=";
 
-        private static GitChange UpdateAssemblyVersionsOpt(GitHttpClient gitClient, string commitId, InsertionArtifacts artifacts)
+        private static async Task<GitChange> UpdateAssemblyVersionsOpt(GitHttpClient gitClient, string commitId, InsertionArtifacts artifacts)
         {
-            var versionsUpdater = new VersionsUpdater(gitClient, commitId, WarningMessages);
+            var versionsUpdater = await VersionsUpdater.Create(gitClient, commitId, WarningMessages);
 
             var pathToDependentAssemblyVersionsFile = artifacts.GetDependentAssemblyVersionsFile();
             if (File.Exists(pathToDependentAssemblyVersionsFile))

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
@@ -397,50 +397,19 @@ namespace Roslyn.Insertion
         {
             var buildClient = ProjectCollection.GetClient<BuildHttpClient>();
 
-            // Allocate temporary files
-            var tempZipFile = Path.GetTempFileName();
-            var tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-
-            // Get zip file from TFS and write to disk
-            using (var logStream = await buildClient.GetBuildLogsZipAsync(Options.TFSProjectName, newestBuild.Id, cancellationToken: cancellationToken))
-            using (var tempStream = File.OpenWrite(tempZipFile))
+            var allLogs = await buildClient.GetBuildLogsAsync(Options.TFSProjectName, newestBuild.Id, cancellationToken: cancellationToken);
+            foreach (var log in allLogs)
             {
-                await logStream.CopyToAsync(tempStream);
-            }
-
-            // Open zip file and extract log entry on disk
-            using (var zipFile = ZipFile.OpenRead(tempZipFile))
-            {
-                var entry = zipFile.Entries.SingleOrDefault(x => x.FullName.Contains("Upload VSTS Drop"));
-                if(entry == null)
+                var headerLine = await buildClient.GetBuildLogLinesAsync(Options.TFSProjectName, newestBuild.Id, log.Id, startLine: 0, endLine: 1, cancellationToken: cancellationToken);
+                if (headerLine[0].Contains("Upload VSTS Drop"))
                 {
-                    var zipFileEntries = string.Join(Environment.NewLine, zipFile.Entries.Select(x => x.FullName));
-                    Console.WriteLine($"Listing all log file entries:{Environment.NewLine}{zipFileEntries}");
-                    throw new Exception("This build did not upload its contents to VSTS Drop and is invalid.");
+                    using var stream = await buildClient.GetBuildLogAsync(Options.TFSProjectName, newestBuild.Id, log.Id, cancellationToken: cancellationToken);
+                    var logText = await new StreamReader(stream).ReadToEndAsync();
+                    return logText;
                 }
-                entry.ExtractToFile(tempFile);
             }
 
-            // Read in log text
-            string logText;
-            using (var tempFileStream = File.OpenRead(tempFile))
-            using (var streamReader = new StreamReader(tempFileStream))
-            {
-                logText = await streamReader.ReadToEndAsync();
-            }
-
-            // Attempt to delete temporary files
-            try
-            {
-                File.Delete(tempZipFile);
-                File.Delete(tempFile);
-            }
-            catch (Exception)
-            {
-                // swallow exceptions
-            }
-
-            return logText;
+            throw new Exception($"Build {newestBuild.BuildNumber} did not upload its contents to VSTS Drop and is invalid.");
         }
 
         internal static async Task<(List<GitCommit> changes, string diffLink)> GetChangesBetweenBuildsAsync(Build fromBuild, Build tobuild, CancellationToken cancellationToken)

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
@@ -518,7 +518,6 @@ namespace Roslyn.Insertion
 
             var firstCommit = changes[0];
             var repoURL = $"http://github.com/{oldBuild.Repository.Id}";
-            description.AppendLine($@"Changes since [{oldBuild.SourceVersion.Substring(0, 7)}]({firstCommit.RemoteUrl})");
 
             foreach (var commit in changes)
             {

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
@@ -280,7 +280,7 @@ namespace Roslyn.Insertion
 
             Directory.CreateDirectory(tempDirectory);
 
-            var archiveDownloadPath = Path.Combine(tempDirectory, string.Concat(artifact.Name, ".zip"));
+            var archiveDownloadPath = Path.Combine(tempDirectory, artifact.Name);
             Console.WriteLine($"Downloading artifacts to {archiveDownloadPath}");
 
             Stopwatch watch = Stopwatch.StartNew();

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
@@ -158,7 +158,7 @@ namespace Roslyn.Insertion
 
                 var allChanges = new List<GitChange>();
 
-                var coreXT = CoreXT.Load(gitClient, baseBranch.ObjectId);
+                var coreXT = await CoreXT.Load(gitClient, baseBranch.ObjectId);
                 if (Options.InsertCoreXTPackages)
                 {
                     // ************** Update Nuget Packages For Branch************************
@@ -195,7 +195,7 @@ namespace Roslyn.Insertion
                     // ************** Update assembly versions ************************
                     cancellationToken.ThrowIfCancellationRequested();
                     Console.WriteLine($"Updating assembly versions");
-                    if (UpdateAssemblyVersionsOpt(gitClient, baseBranch.ObjectId, insertionArtifacts) is GitChange assemblyVersionChange)
+                    if (await UpdateAssemblyVersionsOpt(gitClient, baseBranch.ObjectId, insertionArtifacts) is GitChange assemblyVersionChange)
                     {
                         allChanges.Add(assemblyVersionChange);
                     }


### PR DESCRIPTION
Closes #579 
Closes #572 (triggered builds must download artifacts, and now we download the Upload VSTS Drop logs more efficiently, so not really anything left to do here)