### PR TITLE
Run the merge pipeline every 3 hours

### DIFF
--- a/merge-pr-pipeline.yml
+++ b/merge-pr-pipeline.yml
@@ -16,7 +16,7 @@ pr:
 - master
 
 schedules:
-- cron: "0 */12 * * *"
+- cron: "0 */3 * * *"
   displayName: Roslyn Merge Tool
   branches:
     include:


### PR DESCRIPTION
Trying to gauge thoughts on running merges every three hours instead of every 12.  

We specifically want to do this for Roslyn -vs-deps branches, but if an overall change to 3 works then we can do it this way rather than more difficult changes

Questions -
1.  Do we need to have different schedules for different repos?
2.  Should we only run on a more frequent schedule for specific branches?

If the answer to either 1 or 2 is Yes, then we'll need to make more invasive changes (e.g. multiple pipelines)

 @jmarolf @dmonroym @brettfo @mavasani @JoeRobich for thoughts