### PR TITLE
Fix to insert partially successful builds

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
@@ -285,6 +285,11 @@ namespace Roslyn.Insertion
 
                 var newBuildDescription = $"to {buildToInsert.GetBuildDescription()}";
                 var prDescription = $"Updating {Options.InsertionName} {oldBuildDescription}{newBuildDescription}";
+                if (buildToInsert.Result == BuildResult.PartiallySucceeded)
+                {
+                    prDescription += Environment.NewLine + ":warning: The build being inserted has partially succeeded.";
+                }
+
                 if (!useExistingPr || Options.OverwritePr)
                 {
                     try


### PR DESCRIPTION
Fix to pick up latest builds that have partially succeeded as well with proper warnings. We dont anticipate this to happen unless there is a non-critical tooling problem like failing to index sources.

Addresses #666 .