### PR TITLE
Add option to update an existing PR if it's already exist

### DIFF
--- a/merge-pr-pipeline.yml
+++ b/merge-pr-pipeline.yml
@@ -7,8 +7,6 @@ variables:
   value: $[eq(variables['Build.Reason'], 'PullRequest')]
 - name: isAutomated
   value: true
-- name: updateExistingPr
-  value: true
 
 # Make sure the pipeline doesn't build on commits.
 trigger: none
@@ -36,5 +34,5 @@ steps:
     version: 2.1.401
     installationPath: $(Agent.ToolsDirectory)/dotnet
 
-- script: dotnet run -p $(Build.SourcesDirectory)/src/GitHubCreateMergePRs/GitHubCreateMergePRs.csproj --updateExistingPr=$(updateExistingPr) --isDryRun=$(isDryRun) --isAutomated=$(isAutomated) --githubToken=$(dotnet-bot-github-auth-token)
+- script: dotnet run -p $(Build.SourcesDirectory)/src/GitHubCreateMergePRs/GitHubCreateMergePRs.csproj --isDryRun=$(isDryRun) --isAutomated=$(isAutomated) --githubToken=$(dotnet-bot-github-auth-token)
   displayName: 'Run GitHub Create Merge PRs'

--- a/merge-pr-pipeline.yml
+++ b/merge-pr-pipeline.yml
@@ -7,6 +7,8 @@ variables:
   value: $[eq(variables['Build.Reason'], 'PullRequest')]
 - name: isAutomated
   value: true
+- name: updateExistingPr
+  value: true
 
 # Make sure the pipeline doesn't build on commits.
 trigger: none
@@ -34,5 +36,5 @@ steps:
     version: 2.1.401
     installationPath: $(Agent.ToolsDirectory)/dotnet
 
-- script: dotnet run -p $(Build.SourcesDirectory)/src/GitHubCreateMergePRs/GitHubCreateMergePRs.csproj --isDryRun=$(isDryRun) --isAutomated=$(isAutomated) --githubToken=$(dotnet-bot-github-auth-token)
+- script: dotnet run -p $(Build.SourcesDirectory)/src/GitHubCreateMergePRs/GitHubCreateMergePRs.csproj --updateExistingPr=$(updateExistingPr) --isDryRun=$(isDryRun) --isAutomated=$(isAutomated) --githubToken=$(dotnet-bot-github-auth-token)
   displayName: 'Run GitHub Create Merge PRs'

--- a/src/GitHubCreateMergePRs/Program.cs
+++ b/src/GitHubCreateMergePRs/Program.cs
@@ -38,7 +38,7 @@ public class Program
 
         Console.WriteLine($"Executing with {nameof(updateExistingPr)}={updateExistingPr}, {nameof(isDryRun)}={isDryRun}, {nameof(isAutomated)}={isAutomated}, {nameof(githubToken)}={githubToken}");
         var config = GetConfig();
-        await RunAsync(config, updateExistingPr, isAutomated, isDryRun, githubToken);
+        await RunAsync(config, isAutomated, isDryRun, githubToken);
     }
 
     private static string GetArgumentValue(string arg)
@@ -118,13 +118,17 @@ public class Program
         return false;
     }
 
-    private static async Task RunAsync(XDocument config, bool updateExistingPr, bool isAutomatedRun, bool isDryRun, string githubToken)
+    private static async Task RunAsync(XDocument config, bool isAutomatedRun, bool isDryRun, string githubToken)
     {
         var gh = new GithubMergeTool.GithubMergeTool("dotnet-bot@users.noreply.github.com", githubToken, isDryRun);
         foreach (var repo in config.Root.Elements("repo"))
         {
             var owner = repo.Attribute("owner").Value;
             var name = repo.Attribute("name").Value;
+
+            // We don't try to update existing PR unless asked.
+            var updateExistingPr = bool.Parse(repo.Attribute("updateExistingPr")?.Value ?? "false");
+
             foreach (var merge in repo.Elements("merge"))
             {
                 var fromBranch = merge.Attribute("from").Value;

--- a/src/GitHubCreateMergePRs/Program.cs
+++ b/src/GitHubCreateMergePRs/Program.cs
@@ -13,7 +13,6 @@ public class Program
         // Default when no args passed in.
         var isDryRun = true;
         var isAutomated = false;
-        var updateExistingPr = true;
         var githubToken = string.Empty;
 
         foreach (var arg in args)
@@ -30,13 +29,9 @@ public class Program
             {
                 githubToken = GetArgumentValue(arg);
             }
-            else if (arg.StartsWith("--updateExistingPr"))
-            {
-                updateExistingPr = bool.Parse(GetArgumentValue(arg));
-            }
         }
 
-        Console.WriteLine($"Executing with {nameof(updateExistingPr)}={updateExistingPr}, {nameof(isDryRun)}={isDryRun}, {nameof(isAutomated)}={isAutomated}, {nameof(githubToken)}={githubToken}");
+        Console.WriteLine($"Executing with {nameof(isDryRun)}={isDryRun}, {nameof(isAutomated)}={isAutomated}, {nameof(githubToken)}={githubToken}");
         var config = GetConfig();
         await RunAsync(config, isAutomated, isDryRun, githubToken);
     }

--- a/src/GitHubCreateMergePRs/config.xml
+++ b/src/GitHubCreateMergePRs/config.xml
@@ -1,5 +1,5 @@
 <config>
-  <repo owner="dotnet" name="roslyn">
+  <repo owner="dotnet" name="roslyn" updateExistingPr="true">
     <!-- Roslyn branches (non-vs-deps) (flowing between releases) -->
     <merge from="dev15.0.x" to="dev15.9.x" />
     <merge from="dev15.9.x" to="dev16.0" />


### PR DESCRIPTION
FYI @dibarbet @JoeRobich @RikkiGibson 

I was a little concerned about the case that it triggers a rebuild when existing run is almost finished, thus delay our codeflow. But looking at the time from PR creation to auto-merge in Roslyn, it usually happens in about 1.5 hours, well within the 3 hours window. So in most cases, we will only reset when CI failed or stuck (due to infra issue), which is actually desired.

Another change I'm considering is to rerun CI if it hasn't finished in certain time, which hopefully can mitigate some transient infra issue. Thoughts?