### PR TITLE
Remove Roslyn dev15.0.x branches from code flow

### DIFF
--- a/src/GitHubCreateMergePRs/config.xml
+++ b/src/GitHubCreateMergePRs/config.xml
@@ -1,7 +1,6 @@
 <config>
   <repo owner="dotnet" name="roslyn" updateExistingPr="true">
     <!-- Roslyn branches (non-vs-deps) (flowing between releases) -->
-    <merge from="dev15.0.x" to="dev15.9.x" />
     <merge from="dev15.9.x" to="dev16.0" />
     <merge from="dev16.0" to="release/dev16.3" />
     <merge from="release/dev16.3" to="release/dev16.4" />
@@ -9,7 +8,6 @@
     <merge from="release/dev16.5" to="master" />
 
     <!-- Roslyn branches (between vs-deps branches) -->
-    <merge from="dev15.0.x-vs-deps" to="dev15.9.x-vs-deps" />
     <merge from="dev15.9.x-vs-deps" to="dev16.0-vs-deps" />
     <merge from="dev16.0-vs-deps" to="release/dev16.3-vs-deps" />
     <merge from="release/dev16.3-vs-deps" to="release/dev16.4-vs-deps" />
@@ -17,7 +15,6 @@
     <merge from="release/dev16.5-vs-deps" to="master-vs-deps" />
 
     <!-- Roslyn branches (from non-vs-deps to vs-deps) -->
-    <merge from="dev15.0.x" to="dev15.0.x-vs-deps" />
     <merge from="dev15.9.x" to="dev15.9.x-vs-deps" />
     <merge from="dev16.0" to="dev16.0-vs-deps" />
     <merge from="release/dev16.3" to="release/dev16.3-vs-deps" />


### PR DESCRIPTION
Noticed in the CreateMergePR pipeline log that these branches no longer exist

```console
Merging roslyn from dev15.0.x to dev15.9.x
[error]Error creating PR. GH response code: NotFound
```