### PR TITLE
Remove dev16.3.x from Templates code flow

### DIFF
--- a/src/GitHubCreateMergePRs/config.xml
+++ b/src/GitHubCreateMergePRs/config.xml
@@ -41,8 +41,7 @@
   </repo>
   <repo owner="dotnet" name="templates">
     <merge from="dev15.9.x" to="dev16.0.x" />
-    <merge from="dev16.0.x" to="dev16.3.x" />
-    <merge from="dev16.3.x" to="master" />
+    <merge from="dev16.0.x" to="master" />
   </repo>
   <repo owner="dotnet" name="fsharp">
     <!-- releases -->


### PR DESCRIPTION
```console
Merging templates from dev16.3.x to master
##[error]Error creating PR. GH response code: NotFound
````

This seem right? @jmarolf 