### PR TITLE
Revert "Use NuGet.Versioning for SemanticVersion"

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/RIT.csproj
+++ b/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/RIT.csproj
@@ -1,4 +1,4 @@
-﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>RoslynInsertionTool</RootNamespace>

--- a/src/RoslynInsertionTool/RoslynInsertionTool/CoreXT.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/CoreXT.cs
@@ -9,7 +9,6 @@ using System.Xml.Linq;
 using Microsoft.TeamFoundation.SourceControl.WebApi;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using NuGet.Versioning;
 
 namespace Roslyn.Insertion
 {

--- a/src/RoslynInsertionTool/RoslynInsertionTool/PackageInfo.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/PackageInfo.cs
@@ -3,7 +3,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using NuGet.Versioning;
 
 namespace Roslyn.Insertion
 {

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.Packages.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.Packages.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
-using NuGet.Versioning;
 
 namespace Roslyn.Insertion
 {
@@ -78,7 +77,7 @@ namespace Roslyn.Insertion
         {
             if (package.IsRoslyn)
             {
-                if (package.Version < previousPackageVersion)
+                if (package.Version.Version < previousPackageVersion.Version)
                 {
                     throw new OutdatedPackageException(
                         $"The version of package '{package}' is older than previously inserted '{previousPackageVersion}'.",

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.csproj
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.csproj
@@ -1,4 +1,4 @@
-﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -23,7 +23,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Services.Release.Client" Version="15.127.0-preview" />
     <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" Version="3.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="NuGet.Versioning" Version="4.9.4" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.2.1" />
     <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.3.1" />

--- a/src/RoslynInsertionTool/RoslynInsertionTool/SemanticVersion.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/SemanticVersion.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+
+namespace Roslyn.Insertion
+{
+    internal struct SemanticVersion : IEquatable<SemanticVersion>
+    {
+        public Version Version { get; }
+        public string Suffix { get; }
+
+        public SemanticVersion(Version version, string suffix = "")
+        {
+            Debug.Assert(version != null);
+            Debug.Assert(suffix.Length == 0 || suffix.StartsWith("-"));
+
+            Version = version;
+            Suffix = suffix;
+        }
+
+        public bool HasSuffix => Suffix.Length != 0;
+
+        public override string ToString() => Version.ToString() + Suffix;
+        public bool Equals(SemanticVersion other) => Version == other.Version && Suffix == other.Suffix;
+        public override bool Equals(object obj) => obj is SemanticVersion && Equals((SemanticVersion)obj);
+        public override int GetHashCode() => Version.GetHashCode() ^ Suffix.GetHashCode();
+        public static bool operator ==(SemanticVersion x, SemanticVersion y) => x.Equals(y);
+        public static bool operator !=(SemanticVersion x, SemanticVersion y) => !x.Equals(y);
+        public static bool operator <(SemanticVersion x, SemanticVersion y)
+            => x.Version < y.Version || (x.Version == y.Version && (x.Suffix.CompareTo(y.Suffix) < 0));
+        public static bool operator <=(SemanticVersion x, SemanticVersion y)
+            => x == y || x < y;
+        public static bool operator >(SemanticVersion x, SemanticVersion y)
+            => x.Version > y.Version || (x.Version == y.Version && (x.Suffix.CompareTo(y.Suffix) > 0));
+        public static bool operator >=(SemanticVersion x, SemanticVersion y)
+            => x == y || x > y;
+
+        internal static SemanticVersion Parse(string str)
+        {
+            var dash = str.IndexOf('-');
+            return dash >= 0 ? new SemanticVersion(Version.Parse(str.Substring(0, dash)), str.Substring(dash)) : new SemanticVersion(Version.Parse(str));
+        }
+
+        // -beta1-######-##
+        internal BuildVersion GetSuffixBuildVersion()
+        {
+            var parts = Suffix.Split('-');
+            return new BuildVersion(int.Parse(parts[2]), int.Parse(parts[3]));
+        }
+    }
+}


### PR DESCRIPTION
Reverts dotnet/roslyn-tools#722

Not all versions are semantic versions - https://devdiv.visualstudio.com/DevDiv/_releaseProgress?_a=release-environment-logs&releaseId=593379&environmentId=3190919