### PR TITLE
Fix links to Code of Conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,3 @@ Builds are available on MyGet gallery: https://dotnet.myget.org/Gallery/roslyn-t
 [![Build Status](https://dev.azure.com/dnceng/public/_apis/build/status/roslyn-tools-CI?branchName=master)](https://dev.azure.com/dnceng/public/_build/latest?definitionId=216)
 
 [//]: # (End current test results)
-
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


### PR DESCRIPTION
For more details, see [PR16](https://github.com/dotnet/org-policy/blob/master/doc/PR16.md).