### PR TITLE
When creating insertions for dev/ or features/ branches mark queuer as reviewer

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
@@ -343,8 +343,12 @@ namespace Roslyn.Insertion
                     Console.WriteLine($"Create Pull Request");
                     try
                     {
-                        // If this insertion was queued for PR validation, then add queuer as a reviewer instead of mlinfraswat.
-                        var reviewerId = !string.IsNullOrEmpty(GetBuildPRNumber(buildToInsert))
+                        // If this insertion was queued for PR validation, for a dev branch, or for a feature branch,
+                        // then add the build queuer as a reviewer instead of mlinfraswat.
+                        var isPrValidation = !string.IsNullOrEmpty(GetBuildPRNumber(buildToInsert));
+                        var isDevOrFeatureBranch = Options.BranchName.StartsWith("dev/") || Options.BranchName.StartsWith("features/");
+
+                        var reviewerId = isPrValidation || isDevOrFeatureBranch
                             ? buildToInsert.RequestedBy.Id
                             : MLInfraSwatUserId.ToString();
 


### PR DESCRIPTION
Sometimes dev or feature branches have test insertions created. Instead of setting a PRnumber these insertions come from branch builds and can be identified by their prefix. These insertions should make the build queuer the reviewer.