### PR TITLE
Write a tool to tag commits that shipped in VS

### DIFF
--- a/RoslynTools.sln
+++ b/RoslynTools.sln
@@ -72,6 +72,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GitHubCreateMergePRs", "src
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PRFinder", "src\RoslynInsertionTool\PRFinder\PRFinder.csproj", "{15BE78E3-355F-4B15-ABB4-FA750B2D846B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CreateTagsForVSRelease", "src\CreateTagsForVSRelease\CreateTagsForVSRelease.csproj", "{08AAEF36-C81B-4BAE-8172-EA0D3139B0BE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -382,6 +384,18 @@ Global
 		{15BE78E3-355F-4B15-ABB4-FA750B2D846B}.Release|x64.Build.0 = Release|Any CPU
 		{15BE78E3-355F-4B15-ABB4-FA750B2D846B}.Release|x86.ActiveCfg = Release|Any CPU
 		{15BE78E3-355F-4B15-ABB4-FA750B2D846B}.Release|x86.Build.0 = Release|Any CPU
+		{08AAEF36-C81B-4BAE-8172-EA0D3139B0BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{08AAEF36-C81B-4BAE-8172-EA0D3139B0BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{08AAEF36-C81B-4BAE-8172-EA0D3139B0BE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{08AAEF36-C81B-4BAE-8172-EA0D3139B0BE}.Debug|x64.Build.0 = Debug|Any CPU
+		{08AAEF36-C81B-4BAE-8172-EA0D3139B0BE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{08AAEF36-C81B-4BAE-8172-EA0D3139B0BE}.Debug|x86.Build.0 = Debug|Any CPU
+		{08AAEF36-C81B-4BAE-8172-EA0D3139B0BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{08AAEF36-C81B-4BAE-8172-EA0D3139B0BE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{08AAEF36-C81B-4BAE-8172-EA0D3139B0BE}.Release|x64.ActiveCfg = Release|Any CPU
+		{08AAEF36-C81B-4BAE-8172-EA0D3139B0BE}.Release|x64.Build.0 = Release|Any CPU
+		{08AAEF36-C81B-4BAE-8172-EA0D3139B0BE}.Release|x86.ActiveCfg = Release|Any CPU
+		{08AAEF36-C81B-4BAE-8172-EA0D3139B0BE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/CreateTagsForVSRelease/CreateTagsForVSRelease.csproj
+++ b/src/CreateTagsForVSRelease/CreateTagsForVSRelease.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.1.1" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.0.3" />
+    <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.153.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/CreateTagsForVSRelease/Program.cs
+++ b/src/CreateTagsForVSRelease/Program.cs
@@ -1,0 +1,228 @@
+using Azure.Identity;
+using Azure.Security.KeyVault.Secrets;
+using LibGit2Sharp;
+using Microsoft.TeamFoundation.Build.WebApi;
+using Microsoft.TeamFoundation.SourceControl.WebApi;
+using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
+using Microsoft.VisualStudio.Services.Common;
+using Microsoft.VisualStudio.Services.WebApi;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace CreateTagsForVSRelease
+{
+    public static class Program
+    {
+        public static async Task Main(string[] args)
+        {
+            var client = new SecretClient(
+                vaultUri: new Uri("https://roslyninfra.vault.azure.net:443"),
+                credential: new DefaultAzureCredential(includeInteractiveCredentials: true));
+
+            var azureDevOpsSecret = await client.GetSecretAsync("vslsnap-vso-auth-token");
+            using var connection = new VssConnection(
+                new Uri("https://devdiv.visualstudio.com/DefaultCollection"),
+                new WindowsCredential(new NetworkCredential("vslsnap", azureDevOpsSecret.Value.Value)));
+
+            using var gitClient = await connection.GetClientAsync<GitHttpClient>();
+            using var buildClient = await connection.GetClientAsync<BuildHttpClient>();
+
+            var visualStudioReleases = await GetVisualStudioReleasesAsync(gitClient);
+            var roslynRepository = new Repository(args[0]);
+            var existingTags = roslynRepository.Tags.ToImmutableArray();
+
+            foreach (var visualStudioRelease in visualStudioReleases)
+            {
+                var roslynTagName = TryGetRoslynTagName(visualStudioRelease);
+
+                if (roslynTagName != null)
+                {
+                    if (!existingTags.Any(t => t.FriendlyName == roslynTagName))
+                    {
+                        Console.WriteLine($"Tag {roslynTagName} is missing.");
+
+                        var roslynBuild = await TryGetRoslynBuildForReleaseAsync(visualStudioRelease, gitClient, buildClient);
+
+                        if (roslynBuild != null)
+                        {
+                            Console.WriteLine($"Tagging {roslynBuild.CommitSha} as {roslynTagName}.");
+
+                            string message = $"Build Branch: {roslynBuild.SourceBranch}\r\nInternal ID: {roslynBuild.BuildId}\r\nInternal VS ID: {visualStudioRelease.BuildId}";
+
+                            roslynRepository.ApplyTag(roslynTagName, roslynBuild.CommitSha, new Signature("dotnet bot", "dotnet-bot@microsoft.com", when: visualStudioRelease.CreationTime), message);
+                        }
+                        else
+                        {
+                            Console.WriteLine($"Unable to find the build for {roslynTagName}.");
+                        }
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Tag {roslynTagName} already exists.");
+                    }
+                }
+            }
+        }
+
+        private static async Task<RoslynBuildInformation?> TryGetRoslynBuildForReleaseAsync(VisualStudioVersion release, GitHttpClient gitClient, BuildHttpClient buildClient)
+        {
+            var commit = new GitVersionDescriptor { VersionType = GitVersionType.Commit, Version = release.CommitSha };
+            GitRepository vsRepository = await GetVSRepositoryAsync(gitClient);
+
+            using var componentsJsonStream = await gitClient.GetItemContentAsync(
+                vsRepository.Id,
+                @".corext\Configs\dotnetcodeanalysis-components.json",
+                download: true,
+                versionDescriptor: commit);
+
+            var fileContents = await new StreamReader(componentsJsonStream).ReadToEndAsync();
+            var componentsJson = JObject.Parse(fileContents);
+
+            var languageServicesUrlAndManifestName = (string)componentsJson["Components"]["Microsoft.CodeAnalysis.LanguageServices"]["url"];
+
+            var parts = languageServicesUrlAndManifestName.Split(';');
+            if (parts.Length != 2)
+            {
+                return null;
+            }
+
+            if (!parts[1].EndsWith(".vsman"))
+            {
+                return null;
+            }
+
+            var buildNumber = new Uri(parts[0]).Segments.Last();
+
+            var buildDefinition = (await buildClient.GetDefinitionsAsync(vsRepository.ProjectReference.Id, name: "Roslyn-Signed")).Single();
+            var build = (await buildClient.GetBuildsAsync(buildDefinition.Project.Id, definitions: new[] { buildDefinition.Id }, buildNumber: buildNumber)).SingleOrDefault();
+
+            if (build == null)
+            {
+                return null;
+            }
+
+            var buildId = buildDefinition.Name + "_" + build.BuildNumber;
+
+            return new RoslynBuildInformation(commitSha: build.SourceVersion, build.SourceBranch.Replace("refs/heads/", ""), buildId);
+        }
+
+        private static async Task<ImmutableArray<VisualStudioVersion>> GetVisualStudioReleasesAsync(GitHttpClient gitClient)
+        {
+            GitRepository vsRepository = await GetVSRepositoryAsync(gitClient);
+            var tags = await gitClient.GetRefsAsync(vsRepository.Id, filterContains: "release/vs", peelTags: true);
+
+            var builder = ImmutableArray.CreateBuilder<VisualStudioVersion>();
+
+            foreach (var tag in tags)
+            {
+                const string tagPrefix = "refs/tags/release/vs/";
+
+                if (!tag.Name.StartsWith(tagPrefix))
+                {
+                    continue;
+                }
+
+                string[] parts = tag.Name.Substring(tagPrefix.Length).Split('-');
+
+                if (parts.Length != 1 && parts.Length != 2)
+                {
+                    continue;
+                }
+
+                var isDottedVersionRegex = new Regex("^[0-9]+(\\.[0-9]+)*$");
+
+                if (!isDottedVersionRegex.IsMatch(parts[0]))
+                {
+                    continue;
+                }
+
+                // If there is no peeled object, it means it's a simple tag versus an annotated tag; those aren't usually how
+                // VS releases are tagged so skip it
+                if (tag.PeeledObjectId == null)
+                {
+                    continue;
+                }
+
+                var annotatedTag = await gitClient.GetAnnotatedTagAsync(vsRepository.ProjectReference.Id, vsRepository.Id, tag.ObjectId);
+                if (annotatedTag == null)
+                {
+                    continue;
+                }
+
+                JObject buildInformation;
+
+                try
+                {
+                    buildInformation = JObject.Parse(annotatedTag.Message);
+                }
+                catch
+                {
+                    continue;
+                }
+
+                // It's not entirely clear to me how this format was chosen, but for consistency with old tags, we'll keep it
+                string buildId = buildInformation["Branch"].ToString().Replace("/", ".") + "-" + buildInformation["BuildNumber"];
+
+                if (parts.Length == 2)
+                {
+                    const string previewPrefix = "preview.";
+
+                    if (!parts[1].StartsWith(previewPrefix))
+                    {
+                        continue;
+                    }
+
+                    string possiblePreviewVersion = parts[1].Substring(previewPrefix.Length);
+
+                    if (!isDottedVersionRegex.IsMatch(possiblePreviewVersion))
+                    {
+                        continue;
+                    }
+
+                    builder.Add(new VisualStudioVersion(parts[0], possiblePreviewVersion, tag.PeeledObjectId, annotatedTag.TaggedBy.Date, buildId));
+                }
+                else
+                {
+                    builder.Add(new VisualStudioVersion(parts[0], previewVersion: null, tag.PeeledObjectId, annotatedTag.TaggedBy.Date, buildId));
+                }
+            }
+
+            return builder.ToImmutable();
+        }
+
+        private static async Task<GitRepository> GetVSRepositoryAsync(GitHttpClient gitClient)
+        {
+            return await gitClient.GetRepositoryAsync("DevDiv", "VS");
+        }
+
+        private static string? TryGetRoslynTagName(VisualStudioVersion release)
+        {
+            string tag = "Visual-Studio-";
+
+            if (release.MainVersion.StartsWith("16."))
+            {
+                tag += "2019-";
+            }
+            else
+            {
+                // We won't worry about tagging earlier things than VS2019 releases for now
+                return null;
+            }
+
+            tag += "Version-" + release.MainVersion;
+
+            if (release.PreviewVersion != null)
+            {
+                tag += "-Preview-" + release.PreviewVersion;
+            }
+
+            return tag;
+        }
+    }
+}

--- a/src/CreateTagsForVSRelease/RoslynBuildInformation.cs
+++ b/src/CreateTagsForVSRelease/RoslynBuildInformation.cs
@@ -1,0 +1,16 @@
+namespace CreateTagsForVSRelease
+{
+    internal sealed class RoslynBuildInformation
+    {
+        public readonly string CommitSha;
+        public readonly string SourceBranch;
+        public readonly string BuildId;
+
+        public RoslynBuildInformation(string commitSha, string sourceBranch, string buildId)
+        {
+            CommitSha = commitSha;
+            SourceBranch = sourceBranch;
+            BuildId = buildId;
+        }
+    }
+}

--- a/src/CreateTagsForVSRelease/VisualStudioVersion.cs
+++ b/src/CreateTagsForVSRelease/VisualStudioVersion.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace CreateTagsForVSRelease
+{
+    public struct VisualStudioVersion
+    {
+        public readonly string MainVersion;
+        public readonly string? PreviewVersion;
+        public readonly string CommitSha;
+        public readonly DateTime CreationTime;
+        public readonly string BuildId;
+
+        public VisualStudioVersion(string mainVersion, string? previewVersion, string commitSha, DateTime creationTime, string buildId)
+        {
+            MainVersion = mainVersion;
+            PreviewVersion = previewVersion;
+            CommitSha = commitSha;
+            CreationTime = creationTime;
+            BuildId = buildId;
+        }
+    }
+}


### PR DESCRIPTION
This tool walks the internal VS repo and sees what builds are tagged there, and then tags the matching builds in our repo.