### PR TITLE
Run roslyn merge tool every 5 hours instead

### DIFF
--- a/merge-pr-pipeline.yml
+++ b/merge-pr-pipeline.yml
@@ -16,7 +16,7 @@ pr:
 - master
 
 schedules:
-- cron: "0 */3 * * *"
+- cron: "0 */5 * * *"
   displayName: Roslyn Merge Tool
   branches:
     include:


### PR DESCRIPTION
Given reduced capability in our machine pool, also reduce frequency to allow CI to have a better change to finish before being reset.

@JoeRobich @RikkiGibson