### PR TITLE
Use full length SHAs for URLs

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
@@ -507,8 +507,8 @@ namespace Roslyn.Insertion
             {
                 var repoId = tobuild.Repository.Id; // e.g. dotnet/roslyn
 
-                var fromSHA = fromBuild.SourceVersion.Substring(0, 7);
-                var toSHA = tobuild.SourceVersion.Substring(0, 7);
+                var fromSHA = fromBuild.SourceVersion;
+                var toSHA = tobuild.SourceVersion;
 
                 var restEndpoint = $"https://api.github.com/repos/{repoId}/compare/{fromSHA}...{toSHA}";
                 var client = new HttpClient();
@@ -666,12 +666,13 @@ namespace Roslyn.Insertion
                         description.AppendLine("### Commits since last PR:");
                     }
 
-                    var sha = commit.CommitId.Substring(0, 7);
+                    var fullSHA = commit.CommitId;
+                    var shortSHA = fullSHA.Substring(0, 7);
 
                     // Take the 1st line since it should be descriptive.
-                    comment = $"{commit.Message.Split('\n')[0]} ({sha})";
+                    comment = $"{commit.Message.Split('\n')[0]} ({shortSHA})";
 
-                    prLink = $@"- [{comment}]({repoURL}/commit/{sha})";
+                    prLink = $@"- [{comment}]({repoURL}/commit/{fullSHA})";
                 }
 
                 description.AppendLine(prLink);


### PR DESCRIPTION
Some of our recent insertions were not getting nice logs because 7 digits is not consistently enough to identify a unique commit in roslyn. This addresses the problem by using the full SHA in URLs (not using the full SHA in the readable text, though.)

Example insertion: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/253967