### PR TITLE
Use more of the available characters in the message limit

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
@@ -560,7 +560,7 @@ namespace Roslyn.Insertion
                     .Reverse()
                     .ToList();
 
-                return (result, $"https://github.com/{repoId}/compare/{fromSHA}...{toSHA}?w=1");
+                return (result, $"//github.com/{repoId}/compare/{fromSHA}...{toSHA}?w=1");
             }
 
             throw new NotSupportedException("Only builds created from GitHub repos support enumerating commits.");

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
@@ -579,7 +579,7 @@ namespace Roslyn.Insertion
 
             var description = new StringBuilder(prDescription + Environment.NewLine);
 
-            var repoURL = $"http://github.com/{oldBuild.Repository.Id}";
+            var repoURL = $"//github.com/{oldBuild.Repository.Id}";
 
             var commitHeaderAdded = false;
             var mergePRHeaderAdded = false;

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
@@ -695,7 +695,7 @@ namespace Roslyn.Insertion
             var result = description.ToString();
             if (result.Length > hardLimit)
             {
-                LogWarning($"PR description is {description.Length} characters long, but the limit is {hardLimit}.");
+                LogWarning($"PR description is {result.Length} characters long, but the limit is {hardLimit}.");
                 LogWarning(result);
             }
 

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
@@ -572,6 +572,8 @@ namespace Roslyn.Insertion
 
         internal static string AppendChangesToDescription(string prDescription, Build oldBuild, List<GitCommit> changes)
         {
+            const int hardLimit = 4000; // Azure DevOps limitation
+
             if (!changes.Any())
             {
                 return prDescription;
@@ -676,7 +678,6 @@ namespace Roslyn.Insertion
                 }
 
                 const string limitMessage = "Changelog truncated due to description length limit.";
-                const int hardLimit = 4000; // Azure DevOps limitation
 
                 // we want to be able to fit this PR link, as well as the limit message (plus line breaks) in case the next PR link doesn't fit
                 int limit = hardLimit - (prLink.Length + 1) - (limitMessage.Length + 1);
@@ -691,7 +692,14 @@ namespace Roslyn.Insertion
                 }
             }
 
-            return description.ToString();
+            var result = description.ToString();
+            if (result.Length > hardLimit)
+            {
+                LogWarning($"PR description is {description.Length} characters long, but the limit is {hardLimit}.");
+                LogWarning(result);
+            }
+
+            return result;
         }
 
         public static string GetGitHubPullRequestUrl(string repoURL, string prNumber)

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
@@ -675,12 +675,19 @@ namespace Roslyn.Insertion
                     prLink = $@"- [{comment}]({repoURL}/commit/{fullSHA})";
                 }
 
-                description.AppendLine(prLink);
+                const string limitMessage = "Changelog truncated due to description length limit.";
+                const int hardLimit = 4000; // Azure DevOps limitation
 
-                if (description.Length > 3500)
+                // we want to be able to fit this PR link, as well as the limit message (plus line breaks) in case the next PR link doesn't fit
+                int limit = hardLimit - (prLink.Length + 1) - (limitMessage.Length + 1);
+                if (description.Length > limit)
                 {
-                    description.AppendLine("Changelog truncated due to description length limit.");
+                    description.AppendLine(limitMessage);
                     break;
+                }
+                else
+                {
+                    description.AppendLine(prLink);
                 }
             }
 


### PR DESCRIPTION
The last insertion used 3581 of 4000 available characters. It feels like we could fit more information in the description.

BTW, this `http://github.com` -> `//github.com` change does not affect the way the link gets copied when you right click in the browser. You still get an https prefix so it shouldn't introduce problems in practice.

Baseline insertion: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/254613
Insertion with this change: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/254665