### PR TITLE
Stop publishing artifacts to drop path

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,6 +1,6 @@
 resources:
 - repo: self
-  clean: true 
+  clean: true
 
 # The variables `_DotNetArtifactsCategory` and `_DotNetValidationArtifactsCategory` are required for proper publishing of build artifacts. See https://github.com/dotnet/roslyn/pull/38259
 variables:
@@ -22,8 +22,8 @@ stages:
     displayName: Official Build
     pool:
       name: VSEng-MicroBuildVS2017
-      demands: 
-      - cmd    
+      demands:
+      - cmd
 
     steps:
     - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
@@ -33,7 +33,7 @@ stages:
         esrpSigning: true
       condition: and(succeeded(), ne(variables['SignType'], ''))
 
-    - script: eng\common\CIBuild.cmd 
+    - script: eng\common\CIBuild.cmd
                 -configuration $(BuildConfiguration)
                 /p:PB_PublishBlobFeedKey=$(PB_PublishBlobFeedKey)
                 /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
@@ -44,11 +44,11 @@ stages:
                 /p:DotnetPublishUsingPipelines=true
       displayName: Build
 
-    - task: PublishTestResults@1
-      displayName: Publish Test Results
+    - task: PublishTestResults@2
+      displayName: Publish xUnit Test Results
       inputs:
         testRunner: XUnit
-        testResultsFiles: 'artifacts/TestResults/$(BuildConfiguration)/*.xml'
+        testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
         mergeTestResults: true
         testRunTitle: 'Unit Tests'
       condition: succeededOrFailed()
@@ -56,54 +56,45 @@ stages:
     - task: NuGetPublisher@0
       displayName: Publish NuGet Packages to MyGet
       inputs:
-        searchPattern: 'artifacts\packages\$(BuildConfiguration)\NonShipping\*.nupkg'
+        searchPattern: '$(Build.SourcesDirectory)\artifacts\packages\$(BuildConfiguration)\NonShipping\*.nupkg'
         connectedServiceName: 'RoslynTools NuGet feed'
         nuGetVersion: 4.0.0.2283
       condition: succeeded()
-    
+
     # Note that insertion scripts currently depend on bin directory being uploaded to drops.
     - task: PublishBuildArtifacts@1
       displayName: Publish binaries
       inputs:
-        PathtoPublish: 'artifacts\bin'
+        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\bin'
         ArtifactName: 'bin'
-        publishLocation: FilePath
-        TargetPath: '$(DropRoot)\$(TeamName)\$(Build.DefinitionName)\$(Build.SourceBranchName)\$(Build.BuildNumber)'
-        Parallel: true
-        ParallelCount: 64
+        publishLocation: Container
       condition: succeededOrFailed()
-    
+
     - task: PublishBuildArtifacts@1
       displayName: Publish logs
       inputs:
-        PathtoPublish: 'artifacts\log\$(BuildConfiguration)'
-        ArtifactName: 'log'
-        publishLocation: FilePath
-        TargetPath: '$(DropRoot)\$(TeamName)\$(Build.DefinitionName)\$(Build.SourceBranchName)\$(Build.BuildNumber)'
-        Parallel: true
-        ParallelCount: 64
+        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\log\$(BuildConfiguration)'
+        ArtifactName: 'Build Diagnostic Files'
+        publishLocation: Container
+      continueOnError: true
       condition: succeededOrFailed()
-    
+
     - task: PublishBuildArtifacts@1
       displayName: Publish test results
       inputs:
-        PathtoPublish: 'artifacts\TestResults\$(BuildConfiguration)'
+        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)'
         ArtifactName: 'TestResults'
-        publishLocation: FilePath
-        TargetPath: '$(DropRoot)\$(TeamName)\$(Build.DefinitionName)\$(Build.SourceBranchName)\$(Build.BuildNumber)'
-        Parallel: true
-        ParallelCount: 64
+        publishLocation: Container
       condition: succeededOrFailed()
-
-    # Publish our NuPkgs as an artifact. The name of this artifact must be PackageArtifacts as the 
+    # Publish our NuPkgs as an artifact. The name of this artifact must be PackageArtifacts as the
     # arcade templates depend on the name.
     - task: PublishBuildArtifacts@1
       displayName: Publish packages
       inputs:
-        PathtoPublish: 'artifacts\packages\$(BuildConfiguration)'
+        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\packages\$(BuildConfiguration)'
         ArtifactName: 'PackageArtifacts'
       condition: succeededOrFailed()
-      
+
     # Publish Asset Manifests for Build Asset Registry job
     - task: PublishBuildArtifacts@1
       displayName: Publish Asset Manifests
@@ -111,25 +102,23 @@ stages:
         PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(BuildConfiguration)/AssetManifest'
         ArtifactName: AssetManifests
       condition: succeeded()
-    
+
     - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
       displayName: Cleanup
       condition: succeededOrFailed()
-    
+
     - task: PublishBuildArtifacts@1
       displayName: Publish MicroBuild Artifacts
       inputs:
         PathtoPublish: '$(Build.ArtifactStagingDirectory)\MicroBuild\Output'
-        ArtifactName: '$(Build.BuildNumber)'
-        publishLocation: FilePath
-        TargetPath: '$(DropRoot)\$(TeamName)\$(Build.DefinitionName)\$(Build.SourceBranchName)'
+        ArtifactName: MicroBuildOutputs
+        ArtifactType: Container
       condition: succeededOrFailed()
-
   # Publish to Build Asset Registry
   - template: /eng/common/templates/job/publish-build-assets.yml
     parameters:
       publishUsingPipelines: true
-      dependsOn:	
+      dependsOn:
         - OfficialBuild
       queue:
         name: Hosted VS2017
@@ -141,4 +130,5 @@ stages:
       # https://github.com/dotnet/arcade/issues/2871 is resolved.
       enableSymbolValidation: false
       enableSourceLinkValidation: false
-    
+
+


### PR DESCRIPTION
<strike>Borrowed the build yml from sourcelink (https://github.com/dotnet/sourcelink/blob/master/azure-pipelines.yml)</strike>

I stopped publishing to the drop path since that was causing the build to fail.