### PR TITLE
Include nuget package ID in tag

### DIFF
--- a/src/CreateTagsForVSRelease/Program.cs
+++ b/src/CreateTagsForVSRelease/Program.cs
@@ -107,7 +107,7 @@ namespace CreateTagsForVSRelease
             fileContents = await new StreamReader(defaultConfigStream).ReadToEndAsync();
             var defaultConfig = XDocument.Parse(fileContents);
 
-            var packageVersion = defaultConfig.Root.Descendants("package").Where(p => p.Attribute("id")?.Value == "VS.Tools.Roslyn").Select(p => p.Attribute("version")?.Value).FirstOrDefault();
+            var packageVersion = defaultConfig.Root.Descendants("package").Where(p => p.Attribute("id")?.Value == "VS.ExternalAPIs.Roslyn").Select(p => p.Attribute("version")?.Value).FirstOrDefault();
 
             var buildNumber = new Uri(parts[0]).Segments.Last();
 

--- a/src/CreateTagsForVSRelease/RoslynBuildInformation.cs
+++ b/src/CreateTagsForVSRelease/RoslynBuildInformation.cs
@@ -5,12 +5,14 @@ namespace CreateTagsForVSRelease
         public readonly string CommitSha;
         public readonly string SourceBranch;
         public readonly string BuildId;
+        public readonly string? NugetPackageVersion;
 
-        public RoslynBuildInformation(string commitSha, string sourceBranch, string buildId)
+        public RoslynBuildInformation(string commitSha, string sourceBranch, string buildId, string? nugetPackageVersion)
         {
             CommitSha = commitSha;
             SourceBranch = sourceBranch;
             BuildId = buildId;
+            NugetPackageVersion = nugetPackageVersion;
         }
     }
 }


### PR DESCRIPTION
For VS for Mac insertions being able to the see the commit hash and what version of VS things went in to is great, but I need to reference the nuget package, so adding that info in would be helpful. I think.

I'm not entirely sure though, as I also need the info for VS master which _isn't_ part of this tagging..