### PR TITLE
Add some helpful inline documentation

### DIFF
--- a/src/GithubMergeTool/GithubMergeTool.cs
+++ b/src/GithubMergeTool/GithubMergeTool.cs
@@ -192,6 +192,20 @@ namespace GithubMergeTool
             var prMessage = $@"
 This is an automatically generated pull request from {srcBranch} into {destBranch}.
 {autoTriggeredMessage}
+
+Once all conflicts are resolved and all the tests pass, you are free to merge the pull request. 🐯
+
+## Troubleshooting conflicts
+
+### Identify authors of changes which introduced merge conflicts
+Scroll to the bottom, then for each file containing conflicts copy its path into the following searches:
+- https://github.com/dotnet/roslyn/find/{srcBranch}
+- https://github.com/dotnet/roslyn/find/{destBranch}
+
+Usually the most recent change to a file between the two branches is considered to have introduced the conflicts, but sometimes it will be necessary to look for the conflicting lines and check the blame in each branch. Generally the author whose change introduced the conflicts should pull down this PR, fix the conflicts locally, then push up a commit resolving the conflicts.
+
+### Resolve merge conflicts using your local repo
+Sometimes merge conflicts may be present on GitHub but merging locally will work without conflicts. This is due to differences between the merge algorithm used in local git versus the one used by GitHub.
 ``` bash
 git fetch --all
 git checkout {prBranchName}
@@ -201,7 +215,7 @@ git merge upstream/{srcBranch}
 git commit
 git push upstream {prBranchName} --force
 ```
-Once all conflicts are resolved and all the tests pass, you are free to merge the pull request. 🐯";
+";
 
             Console.WriteLine("Creating PR");
 

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
@@ -576,7 +576,11 @@ namespace Roslyn.Insertion
 
             var prValidationMessage = GetGitHubPullRequestUrlMessage(buildToinsert, useMarkdown);
 
-            return $"Updating {Options.InsertionName} {oldBuildDescription}{newBuildDescription}{Environment.NewLine}{prValidationMessage}";
+            var documentationMessage = @"[Troubleshooting](onenote:https://microsoft.sharepoint.com/teams/managedlanguages/files/Team%20Notebook/Roslyn%20Team%20Notebook%20-%20New/Infrastructure.one#Life%20of%20a%20Tiger&section-id=%7B0E3C75FE-0827-41BF-9696-F5CD7105BC9A%7D&page-id=%7B96423CC8-6A3A-4ABF-B1BD-E4488D1EF099%7D&object-id=%7B7EBA739D-44DB-0180-278C-94C87152BFA5%7D&70)"
+                + " [(don't use the web view)](https://microsoft.sharepoint.com/teams/managedlanguages/_layouts/OneNote.aspx?id=%2Fteams%2Fmanagedlanguages%2Ffiles%2FTeam%20Notebook%2FRoslyn%20Team%20Notebook%20-%20New&wd=target%28Infrastructure.one%7C0E3C75FE-0827-41BF-9696-F5CD7105BC9A%2FLife%20of%20a%20Tiger%7C96423CC8-6A3A-4ABF-B1BD-E4488D1EF099%2F%29)"
+                + Environment.NewLine;
+
+            return $"Updating {Options.InsertionName} {oldBuildDescription}{newBuildDescription}{Environment.NewLine}{prValidationMessage}{documentationMessage}";
         }
 
         private static string GetGitHubPullRequestUrlMessage(Build build, bool useMarkdown)

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
@@ -578,12 +578,14 @@ namespace Roslyn.Insertion
 
             var nl = Environment.NewLine;
 
-            var oneNoteLink = "onenote:https://microsoft.sharepoint.com/teams/managedlanguages/files/Team%20Notebook/Roslyn%20Team%20Notebook%20-%20New/Infrastructure.one#Life%20of%20a%20Tiger&section-id=%7B0E3C75FE-0827-41BF-9696-F5CD7105BC9A%7D&page-id=%7B96423CC8-6A3A-4ABF-B1BD-E4488D1EF099%7D&object-id=%7B7EBA739D-44DB-0180-278C-94C87152BFA5%7D&70";
-            var oneNoteWebLink = "https://microsoft.sharepoint.com/teams/managedlanguages/_layouts/OneNote.aspx?id=%2Fteams%2Fmanagedlanguages%2Ffiles%2FTeam%20Notebook%2FRoslyn%20Team%20Notebook%20-%20New&wd=target%28Infrastructure.one%7C0E3C75FE-0827-41BF-9696-F5CD7105BC9A%2FLife%20of%20a%20Tiger%7C96423CC8-6A3A-4ABF-B1BD-E4488D1EF099%2F%29";
-            var troubleshootingMessage = (useMarkdown
-                    ? $"[Troubleshooting OneNote]({oneNoteLink}) (don't use the [web view]({oneNoteWebLink}))"
-                    : $"Troubleshooting OneNote: {oneNoteLink}{nl}Web view: {oneNoteWebLink}")
-                + Environment.NewLine;
+            var oneNoteLink = "https://aka.ms/roslyn-insertion-troubleshooting";
+            var oneNoteWebLink = "https://aka.ms/roslyn-insertion-troubleshooting-web";
+            var troubleshootingMessage = (Options.InsertionName, useMarkdown) switch
+            {
+                ("Roslyn", useMarkdown: true) => $"[Troubleshooting OneNote]({oneNoteLink}) (don't use the [web view]({oneNoteWebLink})){nl}",
+                ("Roslyn", useMarkdown: false) => $"Troubleshooting OneNote: {oneNoteLink}{nl}Web view: {oneNoteWebLink}{nl}",
+                _ => ""
+            };
 
             return $"Updating {Options.InsertionName} {oldBuildDescription}{newBuildDescription}{nl}{prValidationMessage}{nl}{troubleshootingMessage}";
         }

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
@@ -576,11 +576,16 @@ namespace Roslyn.Insertion
 
             var prValidationMessage = GetGitHubPullRequestUrlMessage(buildToinsert, useMarkdown);
 
-            var documentationMessage = @"[Troubleshooting](onenote:https://microsoft.sharepoint.com/teams/managedlanguages/files/Team%20Notebook/Roslyn%20Team%20Notebook%20-%20New/Infrastructure.one#Life%20of%20a%20Tiger&section-id=%7B0E3C75FE-0827-41BF-9696-F5CD7105BC9A%7D&page-id=%7B96423CC8-6A3A-4ABF-B1BD-E4488D1EF099%7D&object-id=%7B7EBA739D-44DB-0180-278C-94C87152BFA5%7D&70)"
-                + " [(don't use the web view)](https://microsoft.sharepoint.com/teams/managedlanguages/_layouts/OneNote.aspx?id=%2Fteams%2Fmanagedlanguages%2Ffiles%2FTeam%20Notebook%2FRoslyn%20Team%20Notebook%20-%20New&wd=target%28Infrastructure.one%7C0E3C75FE-0827-41BF-9696-F5CD7105BC9A%2FLife%20of%20a%20Tiger%7C96423CC8-6A3A-4ABF-B1BD-E4488D1EF099%2F%29)"
+            var nl = Environment.NewLine;
+
+            var oneNoteLink = "onenote:https://microsoft.sharepoint.com/teams/managedlanguages/files/Team%20Notebook/Roslyn%20Team%20Notebook%20-%20New/Infrastructure.one#Life%20of%20a%20Tiger&section-id=%7B0E3C75FE-0827-41BF-9696-F5CD7105BC9A%7D&page-id=%7B96423CC8-6A3A-4ABF-B1BD-E4488D1EF099%7D&object-id=%7B7EBA739D-44DB-0180-278C-94C87152BFA5%7D&70";
+            var oneNoteWebLink = "https://microsoft.sharepoint.com/teams/managedlanguages/_layouts/OneNote.aspx?id=%2Fteams%2Fmanagedlanguages%2Ffiles%2FTeam%20Notebook%2FRoslyn%20Team%20Notebook%20-%20New&wd=target%28Infrastructure.one%7C0E3C75FE-0827-41BF-9696-F5CD7105BC9A%2FLife%20of%20a%20Tiger%7C96423CC8-6A3A-4ABF-B1BD-E4488D1EF099%2F%29";
+            var troubleshootingMessage = (useMarkdown
+                    ? $"[Troubleshooting OneNote]({oneNoteLink}) (don't use the [web view]({oneNoteWebLink}))"
+                    : $"Troubleshooting OneNote: {oneNoteLink}{nl}Web view: {oneNoteWebLink}")
                 + Environment.NewLine;
 
-            return $"Updating {Options.InsertionName} {oldBuildDescription}{newBuildDescription}{Environment.NewLine}{prValidationMessage}{documentationMessage}";
+            return $"Updating {Options.InsertionName} {oldBuildDescription}{newBuildDescription}{nl}{prValidationMessage}{nl}{troubleshootingMessage}";
         }
 
         private static string GetGitHubPullRequestUrlMessage(Build build, bool useMarkdown)


### PR DESCRIPTION
/cc @JoeRobich 

The goal of this change is to make the preferred first-resort workflow easier to get going with :smile:
