### PR TITLE
Tag PR owners when a newly created PR has merge conflicts

### DIFF
--- a/src/GitHubCreateMergePRs/Program.cs
+++ b/src/GitHubCreateMergePRs/Program.cs
@@ -134,6 +134,7 @@ public class Program
         foreach (var repo in config.Root.Elements("repo"))
         {
             var owner = repo.Attribute("owner").Value;
+            var mergeOwners = repo.Attribute("mergeOwners")?.Value.Split(',').ToList() ?? new List<string>();
             var name = repo.Attribute("name").Value;
 
             // We don't try to update existing PR unless asked.
@@ -149,7 +150,7 @@ public class Program
                     continue;
                 }
 
-                var prOwners = merge.Attribute("owners")?.Value.Split(',').ToList() ?? new List<string>();
+                var prOwners = merge.Attribute("owners")?.Value.Split(',').ToList() ?? mergeOwners;
                 var addAutoMergeLabel = bool.Parse(merge.Attribute("addAutoMergeLabel")?.Value ?? "true");
                 try
                 {

--- a/src/GitHubCreateMergePRs/config.xml
+++ b/src/GitHubCreateMergePRs/config.xml
@@ -1,5 +1,5 @@
 <config>
-  <repo owner="dotnet" name="roslyn">
+  <repo owner="dotnet" name="roslyn" mergeOwners="RikkiGibson">
     <!-- Roslyn servicing branches -->
     <merge from="dev15.9.x" to="dev16.0-vs-deps" />
     <merge from="dev16.0-vs-deps" to="release/dev16.3" />

--- a/src/GithubMergeTool/GithubMergeTool.cs
+++ b/src/GithubMergeTool/GithubMergeTool.cs
@@ -187,7 +187,7 @@ namespace GithubMergeTool
                 }
             }
 
-            string autoTriggeredMessage = isAutoTriggered ? "" : $@"(created from a manual run of the PR generation tool)\n";
+            string autoTriggeredMessage = isAutoTriggered ? "" : "(created from a manual run of the PR generation tool)";
 
             var prMessage = $@"
 This is an automatically generated pull request from {srcBranch} into {destBranch}.
@@ -286,6 +286,11 @@ git push upstream {prBranchName} --force
                     assignees = new[] { new { login = "" } }
                 });
                 Console.WriteLine("Actual assignees: " + (assigneeData.assignees.Any() ? string.Join(", ", assigneeData.assignees.Select(a => a.login)) : "(none)"));
+
+                if (hasConflicts == true)
+                {
+                    response = await PostComment(prNumber, "⚠ This PR has merge conflicts. " + string.Join(" ", prOwners.Select(owner => "@" + owner)));
+                }
             }
 
             if (!response.IsSuccessStatusCode)


### PR DESCRIPTION
example PR: RikkiGibson/roslyn#32

The expectation is that the repo-level 'mergeOwners' attribute is the username of the current tiger or similar. Merges that have a specific owner such as for a feature branch never notify the tiger when they are conflicts--they just notify the specific owner.

Someday it would be nice to automatically tag authors associated with conflicting changes. That will be more work though. Due to GitHub API limitations it might require local cloning and merging to enable us to identify and blame on conflicting regions.