### PR TITLE
Add tool to generate table of hashes for CodeActions

### DIFF
--- a/RoslynTools.sln
+++ b/RoslynTools.sln
@@ -72,7 +72,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GitHubCreateMergePRs", "src
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PRFinder", "src\RoslynInsertionTool\PRFinder\PRFinder.csproj", "{15BE78E3-355F-4B15-ABB4-FA750B2D846B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CreateTagsForVSRelease", "src\CreateTagsForVSRelease\CreateTagsForVSRelease.csproj", "{08AAEF36-C81B-4BAE-8172-EA0D3139B0BE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CreateTagsForVSRelease", "src\CreateTagsForVSRelease\CreateTagsForVSRelease.csproj", "{08AAEF36-C81B-4BAE-8172-EA0D3139B0BE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BuildActionTelemetryTable", "src\BuildActionTelemetryTable\BuildActionTelemetryTable.csproj", "{535A8F91-7AB8-45F3-B6E1-E953AAE6A42A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -396,6 +398,14 @@ Global
 		{08AAEF36-C81B-4BAE-8172-EA0D3139B0BE}.Release|x64.Build.0 = Release|Any CPU
 		{08AAEF36-C81B-4BAE-8172-EA0D3139B0BE}.Release|x86.ActiveCfg = Release|Any CPU
 		{08AAEF36-C81B-4BAE-8172-EA0D3139B0BE}.Release|x86.Build.0 = Release|Any CPU
+		{535A8F91-7AB8-45F3-B6E1-E953AAE6A42A}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{535A8F91-7AB8-45F3-B6E1-E953AAE6A42A}.Debug|x64.ActiveCfg = Debug|x86
+		{535A8F91-7AB8-45F3-B6E1-E953AAE6A42A}.Debug|x86.ActiveCfg = Debug|x86
+		{535A8F91-7AB8-45F3-B6E1-E953AAE6A42A}.Debug|x86.Build.0 = Debug|x86
+		{535A8F91-7AB8-45F3-B6E1-E953AAE6A42A}.Release|Any CPU.ActiveCfg = Release|x86
+		{535A8F91-7AB8-45F3-B6E1-E953AAE6A42A}.Release|x64.ActiveCfg = Release|x86
+		{535A8F91-7AB8-45F3-B6E1-E953AAE6A42A}.Release|x86.ActiveCfg = Release|x86
+		{535A8F91-7AB8-45F3-B6E1-E953AAE6A42A}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/BuildActionTelemetryTable/BuildActionTelemetryTable.csproj
+++ b/src/BuildActionTelemetryTable/BuildActionTelemetryTable.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net472</TargetFrameworks>
+    <LangVersion>8.0</LangVersion>
+
+    <MicrosoftCodeAnalysisVersion>3.8.0-4.20464.1</MicrosoftCodeAnalysisVersion>
+
+     <!--
+         Since the old hash function was framework and runtime dependent and VS runs 32-bit, we need to
+         run 32-bit in order to generate the same hashes.
+    -->
+    <Platforms>x86</Platforms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="$(MicrosoftCodeAnalysisVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features " Version="$(MicrosoftCodeAnalysisVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="$(MicrosoftCodeAnalysisVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="$(MicrosoftCodeAnalysisVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Features" Version="$(MicrosoftCodeAnalysisVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(MicrosoftCodeAnalysisVersion)" />
+
+    <PackageReference Include="SQLitePCLRaw.core" Version="1.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/BuildActionTelemetryTable/Hash.cs
+++ b/src/BuildActionTelemetryTable/Hash.cs
@@ -1,0 +1,382 @@
+// Borrowed from https://github.com/dotnet/roslyn/blob/e704ca635bd6de70a0250e34c4567c7a28fa9f6d/src/Compilers/Core/Portable/InternalUtilities/Hash.cs
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+
+namespace Roslyn.Utilities
+{
+    internal static class Hash
+    {
+        /// <summary>
+        /// This is how VB Anonymous Types combine hash values for fields.
+        /// </summary>
+        internal static int Combine(int newKey, int currentKey)
+        {
+            return unchecked((currentKey * (int)0xA5555529) + newKey);
+        }
+
+        internal static int Combine(bool newKeyPart, int currentKey)
+        {
+            return Combine(currentKey, newKeyPart ? 1 : 0);
+        }
+
+        /// <summary>
+        /// This is how VB Anonymous Types combine hash values for fields.
+        /// PERF: Do not use with enum types because that involves multiple
+        /// unnecessary boxing operations.  Unfortunately, we can't constrain
+        /// T to "non-enum", so we'll use a more restrictive constraint.
+        /// </summary>
+        internal static int Combine<T>(T newKeyPart, int currentKey) where T : class?
+        {
+            int hash = unchecked(currentKey * (int)0xA5555529);
+
+            if (newKeyPart != null)
+            {
+                return unchecked(hash + newKeyPart.GetHashCode());
+            }
+
+            return hash;
+        }
+
+        internal static int CombineValues<T>(IEnumerable<T>? values, int maxItemsToHash = int.MaxValue)
+        {
+            if (values == null)
+            {
+                return 0;
+            }
+
+            var hashCode = 0;
+            var count = 0;
+            foreach (var value in values)
+            {
+                if (count++ >= maxItemsToHash)
+                {
+                    break;
+                }
+
+                // Should end up with a constrained virtual call to object.GetHashCode (i.e. avoid boxing where possible).
+                if (value != null)
+                {
+                    hashCode = Hash.Combine(value.GetHashCode(), hashCode);
+                }
+            }
+
+            return hashCode;
+        }
+
+        internal static int CombineValues<T>(T[]? values, int maxItemsToHash = int.MaxValue)
+        {
+            if (values == null)
+            {
+                return 0;
+            }
+
+            var maxSize = Math.Min(maxItemsToHash, values.Length);
+            var hashCode = 0;
+
+            for (int i = 0; i < maxSize; i++)
+            {
+                T value = values[i];
+
+                // Should end up with a constrained virtual call to object.GetHashCode (i.e. avoid boxing where possible).
+                if (value != null)
+                {
+                    hashCode = Hash.Combine(value.GetHashCode(), hashCode);
+                }
+            }
+
+            return hashCode;
+        }
+
+        internal static int CombineValues<T>(ImmutableArray<T> values, int maxItemsToHash = int.MaxValue)
+        {
+            if (values.IsDefaultOrEmpty)
+            {
+                return 0;
+            }
+
+            var hashCode = 0;
+            var count = 0;
+            foreach (var value in values)
+            {
+                if (count++ >= maxItemsToHash)
+                {
+                    break;
+                }
+
+                // Should end up with a constrained virtual call to object.GetHashCode (i.e. avoid boxing where possible).
+                if (value != null)
+                {
+                    hashCode = Hash.Combine(value.GetHashCode(), hashCode);
+                }
+            }
+
+            return hashCode;
+        }
+
+        internal static int CombineValues(IEnumerable<string?>? values, StringComparer stringComparer, int maxItemsToHash = int.MaxValue)
+        {
+            if (values == null)
+            {
+                return 0;
+            }
+
+            var hashCode = 0;
+            var count = 0;
+            foreach (var value in values)
+            {
+                if (count++ >= maxItemsToHash)
+                {
+                    break;
+                }
+
+                if (value != null)
+                {
+                    hashCode = Hash.Combine(stringComparer.GetHashCode(value), hashCode);
+                }
+            }
+
+            return hashCode;
+        }
+
+        /// <summary>
+        /// The offset bias value used in the FNV-1a algorithm
+        /// See http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+        /// </summary>
+        internal const int FnvOffsetBias = unchecked((int)2166136261);
+
+        /// <summary>
+        /// The generative factor used in the FNV-1a algorithm
+        /// See http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+        /// </summary>
+        internal const int FnvPrime = 16777619;
+
+        /// <summary>
+        /// Compute the FNV-1a hash of a sequence of bytes
+        /// See http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+        /// </summary>
+        /// <param name="data">The sequence of bytes</param>
+        /// <returns>The FNV-1a hash of <paramref name="data"/></returns>
+        internal static int GetFNVHashCode(byte[] data)
+        {
+            int hashCode = Hash.FnvOffsetBias;
+
+            for (int i = 0; i < data.Length; i++)
+            {
+                hashCode = unchecked((hashCode ^ data[i]) * Hash.FnvPrime);
+            }
+
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Compute the FNV-1a hash of a sequence of bytes and determines if the byte
+        /// sequence is valid ASCII and hence the hash code matches a char sequence
+        /// encoding the same text.
+        /// See http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+        /// </summary>
+        /// <param name="data">The sequence of bytes that are likely to be ASCII text.</param>
+        /// <param name="isAscii">True if the sequence contains only characters in the ASCII range.</param>
+        /// <returns>The FNV-1a hash of <paramref name="data"/></returns>
+        internal static int GetFNVHashCode(ReadOnlySpan<byte> data, out bool isAscii)
+        {
+            int hashCode = Hash.FnvOffsetBias;
+
+            byte asciiMask = 0;
+
+            for (int i = 0; i < data.Length; i++)
+            {
+                byte b = data[i];
+                asciiMask |= b;
+                hashCode = unchecked((hashCode ^ b) * Hash.FnvPrime);
+            }
+
+            isAscii = (asciiMask & 0x80) == 0;
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Compute the FNV-1a hash of a sequence of bytes
+        /// See http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+        /// </summary>
+        /// <param name="data">The sequence of bytes</param>
+        /// <returns>The FNV-1a hash of <paramref name="data"/></returns>
+        internal static int GetFNVHashCode(ImmutableArray<byte> data)
+        {
+            int hashCode = Hash.FnvOffsetBias;
+
+            for (int i = 0; i < data.Length; i++)
+            {
+                hashCode = unchecked((hashCode ^ data[i]) * Hash.FnvPrime);
+            }
+
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Compute the hashcode of a sub-string using FNV-1a
+        /// See http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+        /// Note: FNV-1a was developed and tuned for 8-bit sequences. We're using it here
+        /// for 16-bit Unicode chars on the understanding that the majority of chars will
+        /// fit into 8-bits and, therefore, the algorithm will retain its desirable traits
+        /// for generating hash codes.
+        /// </summary>
+        internal static int GetFNVHashCode(ReadOnlySpan<char> data)
+        {
+            int hashCode = Hash.FnvOffsetBias;
+
+            for (int i = 0; i < data.Length; i++)
+            {
+                hashCode = unchecked((hashCode ^ data[i]) * Hash.FnvPrime);
+            }
+
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Compute the hashcode of a sub-string using FNV-1a
+        /// See http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+        /// Note: FNV-1a was developed and tuned for 8-bit sequences. We're using it here
+        /// for 16-bit Unicode chars on the understanding that the majority of chars will
+        /// fit into 8-bits and, therefore, the algorithm will retain its desirable traits
+        /// for generating hash codes.
+        /// </summary>
+        /// <param name="text">The input string</param>
+        /// <param name="start">The start index of the first character to hash</param>
+        /// <param name="length">The number of characters, beginning with <paramref name="start"/> to hash</param>
+        /// <returns>The FNV-1a hash code of the substring beginning at <paramref name="start"/> and ending after <paramref name="length"/> characters.</returns>
+        internal static int GetFNVHashCode(string text, int start, int length)
+            => GetFNVHashCode(text.AsSpan(start, length));
+
+        internal static int GetCaseInsensitiveFNVHashCode(string text)
+        {
+            return GetCaseInsensitiveFNVHashCode(text, 0, text.Length);
+        }
+
+        internal static int GetCaseInsensitiveFNVHashCode(string text, int start, int length)
+        {
+            int hashCode = Hash.FnvOffsetBias;
+            int end = start + length;
+
+            for (int i = start; i < end; i++)
+            {
+                hashCode = unchecked((hashCode ^ CaseInsensitiveComparison.ToLower(text[i])) * Hash.FnvPrime);
+            }
+
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Compute the hashcode of a sub-string using FNV-1a
+        /// See http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+        /// </summary>
+        /// <param name="text">The input string</param>
+        /// <param name="start">The start index of the first character to hash</param>
+        /// <returns>The FNV-1a hash code of the substring beginning at <paramref name="start"/> and ending at the end of the string.</returns>
+        internal static int GetFNVHashCode(string text, int start)
+        {
+            return GetFNVHashCode(text, start, length: text.Length - start);
+        }
+
+        /// <summary>
+        /// Compute the hashcode of a string using FNV-1a
+        /// See http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+        /// </summary>
+        /// <param name="text">The input string</param>
+        /// <returns>The FNV-1a hash code of <paramref name="text"/></returns>
+        internal static int GetFNVHashCode(string text)
+        {
+            return CombineFNVHash(Hash.FnvOffsetBias, text);
+        }
+
+        /// <summary>
+        /// Compute the hashcode of a string using FNV-1a
+        /// See http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+        /// </summary>
+        /// <param name="text">The input string</param>
+        /// <returns>The FNV-1a hash code of <paramref name="text"/></returns>
+        internal static int GetFNVHashCode(System.Text.StringBuilder text)
+        {
+            int hashCode = Hash.FnvOffsetBias;
+            int end = text.Length;
+
+            for (int i = 0; i < end; i++)
+            {
+                hashCode = unchecked((hashCode ^ text[i]) * Hash.FnvPrime);
+            }
+
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Compute the hashcode of a sub string using FNV-1a
+        /// See http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+        /// </summary>
+        /// <param name="text">The input string as a char array</param>
+        /// <param name="start">The start index of the first character to hash</param>
+        /// <param name="length">The number of characters, beginning with <paramref name="start"/> to hash</param>
+        /// <returns>The FNV-1a hash code of the substring beginning at <paramref name="start"/> and ending after <paramref name="length"/> characters.</returns>
+        internal static int GetFNVHashCode(char[] text, int start, int length)
+        {
+            int hashCode = Hash.FnvOffsetBias;
+            int end = start + length;
+
+            for (int i = start; i < end; i++)
+            {
+                hashCode = unchecked((hashCode ^ text[i]) * Hash.FnvPrime);
+            }
+
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Compute the hashcode of a single character using the FNV-1a algorithm
+        /// See http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+        /// Note: In general, this isn't any more useful than "char.GetHashCode". However,
+        /// it may be needed if you need to generate the same hash code as a string or
+        /// substring with just a single character.
+        /// </summary>
+        /// <param name="ch">The character to hash</param>
+        /// <returns>The FNV-1a hash code of the character.</returns>
+        internal static int GetFNVHashCode(char ch)
+        {
+            return Hash.CombineFNVHash(Hash.FnvOffsetBias, ch);
+        }
+
+        /// <summary>
+        /// Combine a string with an existing FNV-1a hash code
+        /// See http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+        /// </summary>
+        /// <param name="hashCode">The accumulated hash code</param>
+        /// <param name="text">The string to combine</param>
+        /// <returns>The result of combining <paramref name="hashCode"/> with <paramref name="text"/> using the FNV-1a algorithm</returns>
+        internal static int CombineFNVHash(int hashCode, string text)
+        {
+            foreach (char ch in text)
+            {
+                hashCode = unchecked((hashCode ^ ch) * Hash.FnvPrime);
+            }
+
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Combine a char with an existing FNV-1a hash code
+        /// See http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+        /// </summary>
+        /// <param name="hashCode">The accumulated hash code</param>
+        /// <param name="ch">The new character to combine</param>
+        /// <returns>The result of combining <paramref name="hashCode"/> with <paramref name="ch"/> using the FNV-1a algorithm</returns>
+        internal static int CombineFNVHash(int hashCode, char ch)
+        {
+            return unchecked((hashCode ^ ch) * Hash.FnvPrime);
+        }
+    }
+}

--- a/src/BuildActionTelemetryTable/Program.cs
+++ b/src/BuildActionTelemetryTable/Program.cs
@@ -1,0 +1,121 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Microsoft.CodeAnalysis.CodeActions;
+
+namespace BuildActionTelemetryTable
+{
+    class Program
+    {
+        private static readonly string s_executingPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+
+        private static readonly string[] s_excludeList = new[]
+        {
+            "Microsoft.CodeAnalysis.AnalyzerUtilities.dll"
+        };
+
+        static void Main(string[] args)
+        {
+            var assemblies = GetAssemblies(args);
+            var codeActionTypes = GetCodeActionTypes(assemblies);
+            var telemetryInfos = codeActionTypes.Select(type => GetTelemetryInfo(type));
+
+            var hashes = new StringBuilder();
+
+            hashes.AppendLine("let actions = datatable(ActionName: string, Prefix: string, Suffix: string)");
+
+            hashes.AppendLine("[");
+
+            foreach (var (ActionTypeName, Prefix, Suffix) in telemetryInfos)
+            {
+                hashes.AppendLine(@$"  ""{ActionTypeName}"", ""{Prefix}"", ""{Suffix}"",");
+            }
+
+            hashes.Append("];");
+
+            File.WriteAllText("ActionTable.txt", hashes.ToString());
+        }
+
+        internal static ImmutableArray<Assembly> GetAssemblies(string[] paths)
+        {
+            if (paths.Length == 0)
+            {
+                // By default inspect the Roslyn assemblies
+                paths = Directory.EnumerateFiles(s_executingPath, "Microsoft.CodeAnalysis*.dll")
+                    .Where(path => !s_excludeList.Any(exclude => path.EndsWith(exclude)))
+                    .ToArray();
+            }
+
+            return paths.Select(path => Assembly.LoadFrom(path))
+                .ToImmutableArray();
+        }
+
+        internal static ImmutableArray<Type> GetCodeActionTypes(IEnumerable<Assembly> assemblies)
+        {
+            var types = assemblies.SelectMany(
+                assembly => assembly.GetTypes().Where(
+                    type => !type.GetTypeInfo().IsInterface && !type.GetTypeInfo().IsAbstract));
+
+            return types
+                .Where(t => typeof(CodeAction).IsAssignableFrom(t))
+                .ToImmutableArray();
+        }
+
+        internal static (string ActionTypeName, string Prefix, string Suffix) GetTelemetryInfo(Type type, short scope = 0)
+        {
+            type = GetTypeForTelemetry(type);
+
+            // AssemblyQualifiedName will change across version numbers, FullName won't
+
+            // GetHashCode on string is not stable. From documentation:
+            // The hash code itself is not guaranteed to be stable.
+            // Hash codes for identical strings can differ across .NET implementations, across .NET versions,
+            // and across .NET platforms (such as 32-bit and 64-bit) for a single version of .NET. In some cases,
+            // they can even differ by application domain.
+            // This implies that two subsequent runs of the same program may return different hash codes.
+            //
+            // As such, we keep the original prefix that was being used for legacy purposes, but
+            // use a stable hashing algorithm (FNV) that doesn't depend on platform
+            // or .NET implementation. We can map the prefix across legacy versions, but
+            // as we support more platforms and variations of builds the suffix will be constant
+            // and usable
+            var prefix = type.FullName.GetHashCode();
+            var suffix = Roslyn.Utilities.Hash.GetFNVHashCode(type.FullName);
+
+            // Suffix is the remaining 8 bytes, and the hash code only makes up 4. Pad
+            // the remainder with an empty byte array
+            var suffixBytes = BitConverter.GetBytes(suffix).Concat(new byte[4]).ToArray();
+            var telemetryId = new Guid(prefix, scope, 0, suffixBytes).ToString();
+
+            return (type.FullName, telemetryId.Substring(0, 8), telemetryId.Substring(19));
+        }
+
+        internal static Type GetTypeForTelemetry(Type type)
+            => type.IsConstructedGenericType ? type.GetGenericTypeDefinition() : type;
+
+        internal static short GetScopeIdForTelemetry(FixAllScope scope)
+            => (short)(scope switch
+            {
+                FixAllScope.Document => 1,
+                FixAllScope.Project => 2,
+                FixAllScope.Solution => 3,
+                _ => 4,
+            });
+
+        internal enum FixAllScope
+        {
+            None,
+            Document,
+            Project,
+            Solution
+        }
+    }
+}


### PR DESCRIPTION
This tool generates a table of ActionName, (Hash) Prefix, and (Hash) Suffix which can be used from a Kusto query to decode lightbulb session telemetry events. When no commandline arguments are passed, this tool generates the hashes for the Roslyn code actions. When passing arguments, they should be space separated paths to the assemblies whose code actions should be included in the table.  