### PR TITLE
Update config.xml

### DIFF
--- a/src/GitHubCreateMergePRs/config.xml
+++ b/src/GitHubCreateMergePRs/config.xml
@@ -11,7 +11,6 @@
     <merge from="release/dev16.6" to="release/dev16.7" />
     <merge from="release/dev16.7" to="release/dev16.8" />
     <merge from="release/dev16.8" to="master" />
-    <merge from="master" to="release/dev16.9-preview1" />
 
     <!-- Roslyn branches (between vs-deps branches) -->
     <merge from="release/dev16.3-vs-deps" to="release/dev16.4-vs-deps" />
@@ -19,8 +18,7 @@
     <merge from="release/dev16.5-vs-deps" to="release/dev16.6-vs-deps" />
     <merge from="release/dev16.6-vs-deps" to="release/dev16.7-vs-deps" />
     <merge from="release/dev16.7-vs-deps" to="release/dev16.8-vs-deps" />
-    <merge from="release/dev16.8-vs-deps" to="master-vs-deps" />
-    <merge from="master-vs-deps" to="release/dev16.9-preview1-vs-deps" />      
+    <merge from="release/dev16.8-vs-deps" to="master-vs-deps" />   
 
     <!-- Roslyn branches (from non-vs-deps to vs-deps) -->
     <merge from="release/dev16.3" to="release/dev16.3-vs-deps" />
@@ -29,7 +27,6 @@
     <merge from="release/dev16.6" to="release/dev16.6-vs-deps" />
     <merge from="release/dev16.7" to="release/dev16.7-vs-deps" />
     <merge from="release/dev16.8" to="release/dev16.8-vs-deps" />
-    <merge from="release/dev16.9-preview1" to="release/dev16.9-preview1-vs-deps" />
     <merge from="master" to="master-vs-deps" />
 
     <!-- Roslyn feature branches -->


### PR DESCRIPTION
Roslyn master is now 16.9, making the `release/dev16.9-preview1` branch redundant, so let's remove these entries.

When it comes time to snap 16.9 off of master, let's name the branch `release/dev16.9` to preserve our naming convention.

/cc @dibarbet @allisonchou 