### PR TITLE
Remove MyGet publishing

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -53,14 +53,6 @@ stages:
         testRunTitle: 'Unit Tests'
       condition: succeededOrFailed()
 
-    - task: NuGetPublisher@0
-      displayName: Publish NuGet Packages to MyGet
-      inputs:
-        searchPattern: '$(Build.SourcesDirectory)\artifacts\packages\$(BuildConfiguration)\NonShipping\*.nupkg'
-        connectedServiceName: 'RoslynTools NuGet feed'
-        nuGetVersion: 4.0.0.2283
-      condition: succeeded()
-
     # Note that insertion scripts currently depend on bin directory being uploaded to drops.
     - task: PublishBuildArtifacts@1
       displayName: Publish binaries

--- a/NuGet.config
+++ b/NuGet.config
@@ -6,7 +6,6 @@
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="vs-devcore" value="https://www.myget.org/F/vs-devcore/api/v3/index.json" />
   </packageSources>
   <disabledPackageSources />
 </configuration>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Roslyn Tools
 A set of tools used by Roslyn.
 
-Builds are available on MyGet gallery: https://dotnet.myget.org/Gallery/roslyn-tools.
+Builds are available in the dotnet-tools Azure Package feed: https://dev.azure.com/dnceng/public/_packaging?_a=feed&feed=dotnet-tools
 
 [//]: # (Begin current test results)
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -42,11 +42,4 @@
     <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
     <UsingToolXliff>false</UsingToolXliff>
   </PropertyGroup>
-  <PropertyGroup>
-    <RestoreSources>
-      $(RestoreSources);
-      https://www.myget.org/F/vs-devcore/api/v3/index.json;
-      https://dotnet.myget.org/F/system-commandline/api/v3/index.json
-    </RestoreSources>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
We've been publishing to Azure Packages for a while. This completes the transition.

This PR does not update RepoTools project and all the embedded myget references within it.