### PR TITLE
Remove usages of dotnet.myget.org

### DIFF
--- a/docs/RepoToolset.md
+++ b/docs/RepoToolset.md
@@ -155,7 +155,7 @@ The file is present in the repo and defines versions of all dependencies used in
     <!-- Feeds to use to restore dependent packages from. -->  
     <RestoreSources>
       $(RestoreSources);
-      https://dotnet.myget.org/F/myfeed/api/v3/index.json
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/myfeed/nuget/v3/index.json
     </RestoreSources>
   </PropertyGroup>
 </Project>
@@ -210,7 +210,7 @@ Include `vswhere` version if the repository should be built via desktop `msbuild
   }
 ```
 
-`/nuget.config` file is present and specifies the MyGet feed to retrieve `RoslynTools.RepoToolset` SDK from like so:
+`/nuget.config` file is present and specifies the Azure Artifacts feed to retrieve `RoslynTools.RepoToolset` SDK from like so:
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
@@ -218,7 +218,7 @@ Include `vswhere` version if the repository should be built via desktop `msbuild
   <!-- Only specify feed for RepoToolset SDK (see https://github.com/Microsoft/msbuild/issues/2982) -->
   <packageSources>
     <clear />
-    <add key="roslyn-tools" value="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
+    <add key="roslyn-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
   </packageSources>
 </configuration>
 ```
@@ -398,4 +398,4 @@ RepoToolset expects MicroBuild to set the following environment variables:
 
 Shipping packages and their content must be signed. 
 Windows PDBs are produced and published to symbol servers for binaries in shipping packages. 
-Shipping packages can be published to NuGet, non-shipping packages can only be published to MyGet or Azure tool feeds.
+Shipping packages can be published to NuGet, non-shipping packages can only be published Azure tool feeds.

--- a/src/RepoToolset/tools/DefaultVersions.props
+++ b/src/RepoToolset/tools/DefaultVersions.props
@@ -77,14 +77,11 @@
 
   <PropertyGroup Condition="'$(DotNetBuildOffline)' != 'true'">
     <RestoreSources>$(RestoreSources);https://api.nuget.org/v3/index.json</RestoreSources>
-    <RestoreSources Condition="'$(UsingToolXliff)' == 'true' and $(XliffTasksVersion.Contains('-'))">$(RestoreSources);https://dotnet.myget.org/F/dotnet-core/api/v3/index.json</RestoreSources>
-    <RestoreSources Condition="'$(UsingToolMicrosoftNetCompilers)' == 'true' and $(MicrosoftNetCompilersVersion.Contains('-'))">$(RestoreSources);https://dotnet.myget.org/F/roslyn/api/v3/index.json</RestoreSources>
-    <RestoreSources Condition="'$(UsingToolNetFrameworkReferenceAssemblies)' == 'true'">$(RestoreSources);https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json</RestoreSources>
+    <RestoreSources Condition="'$(UsingToolXliff)' == 'true' and $(XliffTasksVersion.Contains('-'))">$(RestoreSources);https://dotnetmygetlegacy.blob.core.windows.net/dotnet-core/index.json</RestoreSources>
+    <RestoreSources Condition="'$(UsingToolMicrosoftNetCompilers)' == 'true' and $(MicrosoftNetCompilersVersion.Contains('-'))">$(RestoreSources);https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json</RestoreSources>
+    <RestoreSources Condition="'$(UsingToolNetFrameworkReferenceAssemblies)' == 'true'">$(RestoreSources);https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json</RestoreSources>
     <RestoreSources Condition="$(XUnitVersion.Contains('-')) or $(XUnitRunnerVisualStudioVersion.Contains('-')) or $(XUnitRunnerVisualStudioVersion.Contains('-'))">$(RestoreSources);https://www.myget.org/F/xunit/api/v3/index.json</RestoreSources>
-    <RestoreSources Condition="$(MicrosoftSourceLinkVersion.Contains('-'))">$(RestoreSources);https://dotnet.myget.org/F/sourcelink/api/v3/index.json</RestoreSources>
-    
-    <!-- Using a private build of Microsoft.Net.Test.SDK to work around issue https://github.com/Microsoft/vstest/issues/373 -->
-    <RestoreSources Condition="'$(MicrosoftNETTestSdkVersion)' == '15.6.0-dev'">$(RestoreSources);https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json</RestoreSources>
+    <RestoreSources Condition="$(MicrosoftSourceLinkVersion.Contains('-'))">$(RestoreSources);https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json</RestoreSources>
 
     <!-- Add externally defined NuGet package restore sources. This property is set by Build.proj. -->
     <RestoreSources Condition="'$(__ExternalRestoreSources)' != ''">$(__ExternalRestoreSources);$(RestoreSources)</RestoreSources>

--- a/src/RepoToolset/tools/Tools.proj
+++ b/src/RepoToolset/tools/Tools.proj
@@ -27,15 +27,15 @@
     <RestoreSources>
       $(RestoreSources);
       https://api.nuget.org/v3/index.json;
-      https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json
     </RestoreSources>
     <RestoreSources Condition="'$(UsingToolSymbolUploader)' == 'true'">
       $(RestoreSources);
-      https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json
     </RestoreSources>
     <RestoreSources Condition="'$(UsingToolPdbConverter)' == 'true' and $(MicrosoftDiaSymReaderPdb2PdbVersion.Contains('-'))">
       $(RestoreSources);
-      https://dotnet.myget.org/F/symreader-converter/api/v3/index.json
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json
     </RestoreSources>
     <RestoreSources Condition="'$(PublishingToBlobStorage)' == 'true'">
       $(RestoreSources);


### PR DESCRIPTION
- Change usages of dotnet-core feed to https://dotnetmygetlegacy.blob.core.windows.net/dotnet-core/index.json
- Change usages of roslyn feed to https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
- Change usages of roslyn-tools feed to https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json
- Change usage of other feeds under dotnet.myget.org to https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json

PTAL @dmonroym @garath 