### PR TITLE
Change occurrences of master to main

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -11,7 +11,6 @@ variables:
 
 # Branches that trigger a build on commit
 trigger:
-- master
 - main
 
 stages:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ Builds are available in the dotnet-tools Azure Package feed: https://dev.azure.c
 
 [//]: # (Begin current test results)
 
-[![Build Status](https://dev.azure.com/dnceng/public/_apis/build/status/roslyn-tools-CI?branchName=master)](https://dev.azure.com/dnceng/public/_build/latest?definitionId=216)
+[![Build Status](https://dev.azure.com/dnceng/public/_apis/build/status/roslyn-tools-CI?branchName=main)](https://dev.azure.com/dnceng/public/_build/latest?definitionId=216)
 
 [//]: # (End current test results)

--- a/docs/RepoToolset.md
+++ b/docs/RepoToolset.md
@@ -165,7 +165,7 @@ The toolset defines a set of tools (or features) that each repo can opt into or 
 
 The toolset also defines default versions for various tools and dependencies, such as MicroBuild, XUnit, VSSDK, etc. These defaults can be overridden in the Versions.props file.
 
-See [DefaultVersions](https://github.com/dotnet/roslyn-tools/blob/master/src/RepoToolset/DefaultVersions.props]) for a list of *UsingTool* properties and default versions.
+See [DefaultVersions](https://github.com/dotnet/roslyn-tools/blob/main/src/RepoToolset/DefaultVersions.props]) for a list of *UsingTool* properties and default versions.
 
 #### /eng/FixedVersions.props (Orchestrated Build)
 

--- a/merge-pr-pipeline.yml
+++ b/merge-pr-pipeline.yml
@@ -11,9 +11,8 @@ variables:
 # Make sure the pipeline doesn't build on commits.
 trigger: none
 
-# Trigger dryrun on PRs to master.
+# Trigger dryrun on PRs to main.
 pr:
-- master
 - main
 
 schedules:
@@ -21,7 +20,6 @@ schedules:
   displayName: Roslyn Merge Tool
   branches:
     include:
-    - master
     - main
   always: true
 

--- a/src/AzureFunctionPackage/Functions/Common/VstsPrConfig.xml
+++ b/src/AzureFunctionPackage/Functions/Common/VstsPrConfig.xml
@@ -1,5 +1,5 @@
 <config>
   <repo name="VSUnitTesting">
-    <merge from="dev16.2.x" to="master" />
+    <merge from="dev16.2.x" to="main" />
   </repo>
 </config>

--- a/src/GitHubCreateMergePRs/config.xml
+++ b/src/GitHubCreateMergePRs/config.xml
@@ -43,7 +43,7 @@
     <merge from="main" to="features/interpolated-string" owners="333fred" frequency="weekly" />
   </repo>
   <repo owner="dotnet" name="roslyn-sdk">
-    <merge from="dev16.0.x" to="master" />
+    <merge from="dev16.0.x" to="main" />
   </repo>
     
   <!-- Project System repo -->
@@ -82,12 +82,12 @@
 
   <!-- roslyn-analyzer branches -->
   <repo owner="dotnet" name="roslyn-analyzers">
-    <merge from="2.9.x" to="master" />
+    <merge from="2.9.x" to="main" />
     <merge from="release/5.0.1xx" to="release/5.0.2xx" />
     <merge from="release/5.0.2xx" to="release/6.0.1xx-preview1" />
     <merge from="release/6.0.1xx-preview1" to="release/6.0.1xx-preview2" />
     <merge from="release/6.0.1xx-preview2" to="release/6.0.1xx-preview3" />
-    <merge from="master" to="release/6.0.1xx-preview3" />
+    <merge from="main" to="release/6.0.1xx-preview3" />
   </repo>
 
   <!-- testimpact branches -->

--- a/src/RoslynInsertionTool/README.md
+++ b/src/RoslynInsertionTool/README.md
@@ -2,21 +2,21 @@
 
 ## Example Usage
 
-Inserting the Roslyn `master` branch into the VS `lab/vsuml` branch:
+Inserting the Roslyn `main` branch into the VS `lab/vsuml` branch:
 
-`rit.exe /in=Roslyn /bn=master /vsbn=lab/vsuml /bq=Roslyn-Signed /ic=true /id=true /t`
+`rit.exe /in=Roslyn /bn=main /vsbn=lab/vsuml /bq=Roslyn-Signed /ic=true /id=true /t`
 
 Inserting the Roslyn `dev16` branch into the VS `lab/ml` branch:
 
 `rit.exe /in=Roslyn /bn=dev16 /vsbn=lab/ml /bq=Roslyn-Signed /ic=true /id=true /t`
 
-Inserting the TestImpact `master` branch into the VS `lab/vsuml` branch: 
+Inserting the TestImpact `main` branch into the VS `lab/vsuml` branch: 
 
-`rit.exe /in="Live Unit Testing" /bn=master /vsbn=lab/vsuml /bq=TestImpact-Signed /ic=false /id=false`
+`rit.exe /in="Live Unit Testing" /bn=main /vsbn=lab/vsuml /bq=TestImpact-Signed /ic=false /id=false`
 
-Inserting the Project System `master` branch into the VS `rel/d15rel` branch, including a validation build:
+Inserting the Project System `main` branch into the VS `rel/d15rel` branch, including a validation build:
 
-`rit.exe /in="Project System" /bn=master /vsbn=rel/d15rel /bq=DotNet-Project-System /ic=false /id=false /qv=true`
+`rit.exe /in="Project System" /bn=main /vsbn=rel/d15rel /bq=DotNet-Project-System /ic=false /id=false /qv=true`
 
 ## Arguments
 
@@ -28,7 +28,7 @@ At a bare minimum the following arguments must be provided on the command line.
 
 | Short Name | Full Name | Description |
 | --- | --- | --- |
-| **/bn**=master | **/branchname**=master | The branch we are inserting *from*. |
+| **/bn**=main | **/branchname**=main | The branch we are inserting *from*. |
 | **/vsbn**=lab/vsuml | **visualstudiobranchname**=lab/vsuml | The Visual Studio branch we are inserting *into*. |
 
 ### Common Arguments
@@ -77,4 +77,4 @@ The default values for these (again, from app.config) are almost always what you
 
 To test locally one can set the /roslyndroppath to a local bin directory and /newbranchname to empty string. The insertion tool then applies necessary changes to the local enlistment without creating a branch and pull request, fetching the source binaries from the specified local bin directory.
 
-```D:\Roslyn\Closed\Tools\Source\RoslynInsertionTool\RoslynInsertionTool.Commandline\bin\Debug\RIT.exe /vsbn=lab/vsuml /bn=Roslyn-Master-Signed-Release /ep=D:\vsuml /rdp=D:\Roslyn\Open\Binaries\Debug /nbn=""```
+```D:\Roslyn\Closed\Tools\Source\RoslynInsertionTool\RoslynInsertionTool.Commandline\bin\Debug\RIT.exe /vsbn=lab/vsuml /bn=Roslyn-Main-Signed-Release /ep=D:\vsuml /rdp=D:\Roslyn\Open\Binaries\Debug /nbn=""```

--- a/src/RoslynInsertionTool/RoslynInsertionTool/LegacyInsertionArtifacts.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/LegacyInsertionArtifacts.cs
@@ -31,7 +31,7 @@ namespace Roslyn.Insertion
 
         public override string GetPackagesDirectory()
         {
-            // For example: "\\cpvsbuild\drops\Roslyn\Roslyn-Master-Signed-Release\20160315.3\DevDivPackages"
+            // For example: "\\cpvsbuild\drops\Roslyn\Roslyn-Main-Signed-Release\20160315.3\DevDivPackages"
             var devDivPackagesPath = Path.Combine(_binariesDirectory, "DevDivPackages");
             if (Directory.Exists(devDivPackagesPath))
             {

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
@@ -602,7 +602,7 @@ namespace Roslyn.Insertion
                     continue;
                 }
 
-                // Exclude merge commits from auto code-flow PRs (e.g. merges/master-to-master-vs-deps)
+                // Exclude merge commits from auto code-flow PRs (e.g. merges/main-to-main-vs-deps)
                 if (IsReleaseFlowCommit.Match(commit.Message).Success)
                 {
                     mergePRFound = true;

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
@@ -89,7 +89,7 @@ namespace Roslyn.Insertion
                 Build latestBuild = null;
                 bool retainBuild = false;
 
-                // Get the version from DevOps Pipelines queue, e.g. Roslyn-Master-Signed-Release.
+                // Get the version from DevOps Pipelines queue, e.g. Roslyn-Main-Signed-Release.
                 if (string.IsNullOrEmpty(Options.SpecificBuild))
                 {
                     buildToInsert = await GetLatestPassedBuildAsync(cancellationToken);

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionToolOptions.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionToolOptions.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace Roslyn.Insertion
 {
-    // borrowed from https://github.com/dotnet/roslyn/blob/master/src/Compilers/Core/Portable/Optional.cs
+    // borrowed from https://github.com/dotnet/roslyn/blob/main/src/Compilers/Core/Portable/Optional.cs
     public readonly struct Optional<T>
     {
         public bool HasValue { get; }

--- a/src/SignTool/README.md
+++ b/src/SignTool/README.md
@@ -44,9 +44,9 @@ Part of the sign tool verification process is to ensure every file is properly a
 
 Example configuration files:
 
-- [Roslyn](https://github.com/dotnet/roslyn/blob/master/build/config/SignToolData.json)
-- [DiaSym Reader](https://github.com/dotnet/symreader/blob/master/build/Signing/SignToolData.json)
-- [SDK](https://github.com/dotnet/sdk/blob/master/build/Signing/SignToolConfig.json)
+- [Roslyn](https://github.com/dotnet/roslyn/blob/main/build/config/SignToolData.json)
+- [DiaSym Reader](https://github.com/dotnet/symreader/blob/main/build/Signing/SignToolData.json)
+- [SDK](https://github.com/dotnet/sdk/blob/main/build/Signing/SignToolConfig.json)
 
 ## Arguments
 


### PR DESCRIPTION
(Not quite ready to merge yet)

Switches occurrences of master to main and removes master from the yml pipeline. Some links to other dotnet repos will be broken, but since all dotnet repos are scheduled to switch over to main this sprint, this should be temporary.
`eng/common` files have been left purposely untouched since it appears modifying them may break things.

Some merge paths in config.xml are also left untouched since those repos have not made the switch yet from master-> main and I didn't want to break them.
