### PR TITLE
Read component version from local manifests when possible

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool/ArcadeInsertionArtifacts.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/ArcadeInsertionArtifacts.cs
@@ -10,11 +10,11 @@ namespace Roslyn.Insertion
     {
         public const string ArtifactName = "VSSetup";
 
-        private readonly string _vsSetupDirectory;
+        internal override string RootDirectory { get; }
 
         public ArcadeInsertionArtifacts(string vsSetupDirectory)
         {
-            _vsSetupDirectory = vsSetupDirectory;
+            RootDirectory = vsSetupDirectory;
         }
 
         public static bool TryCreateFromLocalBuild(string buildDirectory, out InsertionArtifacts artifacts)
@@ -32,7 +32,7 @@ namespace Roslyn.Insertion
 
         public override string GetPackagesDirectory()
         {
-            var devDivPackagesPath = Path.Combine(_vsSetupDirectory, "DevDivPackages");
+            var devDivPackagesPath = Path.Combine(RootDirectory, "DevDivPackages");
             if (Directory.Exists(devDivPackagesPath))
             {
                 return devDivPackagesPath;
@@ -42,9 +42,9 @@ namespace Roslyn.Insertion
         }
 
         public override string GetDependentAssemblyVersionsFile()
-            => Path.Combine(_vsSetupDirectory, "DevDivPackages", "DependentAssemblyVersions.csv");
+            => Path.Combine(RootDirectory, "DevDivPackages", "DependentAssemblyVersions.csv");
 
         public override string[] GetOptProfPropertyFiles()
-            => Directory.EnumerateFiles(Path.Combine(_vsSetupDirectory, "Insertion", "OptProf"), "*.props", SearchOption.TopDirectoryOnly).ToArray();
+            => Directory.EnumerateFiles(Path.Combine(RootDirectory, "Insertion", "OptProf"), "*.props", SearchOption.TopDirectoryOnly).ToArray();
     }
 }

--- a/src/RoslynInsertionTool/RoslynInsertionTool/ArcadeInsertionArtifacts.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/ArcadeInsertionArtifacts.cs
@@ -10,7 +10,7 @@ namespace Roslyn.Insertion
     {
         public const string ArtifactName = "VSSetup";
 
-        internal override string RootDirectory { get; }
+        public override string RootDirectory { get; }
 
         public ArcadeInsertionArtifacts(string vsSetupDirectory)
         {

--- a/src/RoslynInsertionTool/RoslynInsertionTool/InsertionArtifacts.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/InsertionArtifacts.cs
@@ -1,12 +1,22 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 
+using System.IO;
+using System.Linq;
+
 namespace Roslyn.Insertion
 {
     internal abstract class InsertionArtifacts
     {
+        internal abstract string RootDirectory { get; }
+
         public abstract string GetPackagesDirectory();
         public abstract string GetDependentAssemblyVersionsFile();
         public abstract string[] GetOptProfPropertyFiles();
+
+        public string FindFilePath(string fileName)
+        {
+            return Directory.EnumerateFiles(RootDirectory, fileName, SearchOption.AllDirectories).SingleOrDefault();
+        }
     }
 }

--- a/src/RoslynInsertionTool/RoslynInsertionTool/InsertionArtifacts.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/InsertionArtifacts.cs
@@ -1,22 +1,13 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-
-using System.IO;
-using System.Linq;
-
 namespace Roslyn.Insertion
 {
     internal abstract class InsertionArtifacts
     {
-        internal abstract string RootDirectory { get; }
+        public abstract string RootDirectory { get; }
 
         public abstract string GetPackagesDirectory();
         public abstract string GetDependentAssemblyVersionsFile();
         public abstract string[] GetOptProfPropertyFiles();
-
-        public string FindFilePath(string fileName)
-        {
-            return Directory.EnumerateFiles(RootDirectory, fileName, SearchOption.AllDirectories).SingleOrDefault();
-        }
     }
 }

--- a/src/RoslynInsertionTool/RoslynInsertionTool/LegacyInsertionArtifacts.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/LegacyInsertionArtifacts.cs
@@ -7,7 +7,7 @@ namespace Roslyn.Insertion
 {
     internal sealed class LegacyInsertionArtifacts : InsertionArtifacts
     {
-        internal override string RootDirectory { get; }
+        public override string RootDirectory { get; }
 
         public LegacyInsertionArtifacts(string binariesDirectory)
         {

--- a/src/RoslynInsertionTool/RoslynInsertionTool/LegacyInsertionArtifacts.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/LegacyInsertionArtifacts.cs
@@ -7,11 +7,11 @@ namespace Roslyn.Insertion
 {
     internal sealed class LegacyInsertionArtifacts : InsertionArtifacts
     {
-        private readonly string _binariesDirectory;
+        internal override string RootDirectory { get; }
 
         public LegacyInsertionArtifacts(string binariesDirectory)
         {
-            _binariesDirectory = binariesDirectory;
+            RootDirectory = binariesDirectory;
         }
 
         public static string GetArtifactName(string buildNumber) => buildNumber;
@@ -32,14 +32,14 @@ namespace Roslyn.Insertion
         public override string GetPackagesDirectory()
         {
             // For example: "\\cpvsbuild\drops\Roslyn\Roslyn-Main-Signed-Release\20160315.3\DevDivPackages"
-            var devDivPackagesPath = Path.Combine(_binariesDirectory, "DevDivPackages");
+            var devDivPackagesPath = Path.Combine(RootDirectory, "DevDivPackages");
             if (Directory.Exists(devDivPackagesPath))
             {
                 return devDivPackagesPath;
             }
 
             // For example: "\\cpvsbuild\drops\Roslyn\Roslyn-Project-System\DotNet-Project-System\20180111.1\packages"
-            var packagesPath = Path.Combine(_binariesDirectory, "packages");
+            var packagesPath = Path.Combine(RootDirectory, "packages");
             if (Directory.Exists(packagesPath))
             {
                 return packagesPath;
@@ -49,7 +49,7 @@ namespace Roslyn.Insertion
         }
 
         public override string GetDependentAssemblyVersionsFile()
-            => Path.Combine(_binariesDirectory, "DevDivInsertionFiles", "DependentAssemblyVersions.csv");
+            => Path.Combine(RootDirectory, "DevDivInsertionFiles", "DependentAssemblyVersions.csv");
 
         public override string[] GetOptProfPropertyFiles()
             => Array.Empty<string>();

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
@@ -423,7 +423,8 @@ namespace Roslyn.Insertion
 
                 var fileName = urlString.Split(';').Last();
                 var name = fileName.Remove(fileName.Length - 6, 6);
-                var localFilePath = buildArtifacts.FindFilePath(fileName);
+                // Search the build artifacts for a copy of the manifest file.
+                var localFilePath = Directory.EnumerateFiles(buildArtifacts.RootDirectory, fileName, SearchOption.AllDirectories).SingleOrDefault();
                 var version = localFilePath != null
                     ? GetComponentVersionFromFile(localFilePath)
                     : await GetComponentVersionFromUri(uri);

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
@@ -401,7 +401,7 @@ namespace Roslyn.Insertion
         {
             if (urls == null || urls.Length == 0)
             {
-                Console.WriteLine("GetComponentsFromUrl: No URLs specified.");
+                Console.WriteLine("GetComponentsFromManifests: No URLs specified.");
                 return Array.Empty<Component>();
             }
 
@@ -438,7 +438,6 @@ namespace Roslyn.Insertion
             Console.WriteLine($"GetComponentVersionFromFile: Opening manifest from {filePath}.");
             var manifestText = File.ReadAllText(filePath);
             return GetComponentVersionFromJson(manifestText);
-
         }
 
         private static async Task<string> GetComponentVersionFromUri(Uri uri)

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
@@ -389,19 +389,19 @@ namespace Roslyn.Insertion
             return Path.Combine(tempDirectory, artifact.Name);
         }
 
-        private static async Task<Component[]> GetLatestComponentsAsync(Build newestBuild, CancellationToken cancellationToken)
+        private static async Task<Component[]> GetLatestComponentsAsync(Build newestBuild, InsertionArtifacts buildArtifacts, CancellationToken cancellationToken)
         {
             var logText = await GetLogTextAsync(newestBuild, cancellationToken);
-            var urls = GetUrls(logText);
-            var components = await GetComponents(urls);
+            var urls = GetComponentManifestUrls(logText);
+            var components = await GetComponentsFromManifests(urls, buildArtifacts);
             return components;
         }
 
-        private static async Task<Component[]> GetComponents(string[] urls)
+        private static async Task<Component[]> GetComponentsFromManifests(string[] urls, InsertionArtifacts buildArtifacts)
         {
             if (urls == null || urls.Length == 0)
             {
-                Console.WriteLine("GetComponents: No URLs specified.");
+                Console.WriteLine("GetComponentsFromUrl: No URLs specified.");
                 return Array.Empty<Component>();
             }
 
@@ -423,31 +423,48 @@ namespace Roslyn.Insertion
 
                 var fileName = urlString.Split(';').Last();
                 var name = fileName.Remove(fileName.Length - 6, 6);
-                var version = await GetVersionFromComponentUrl(uri);
+                var localFilePath = buildArtifacts.FindFilePath(fileName);
+                var version = localFilePath != null
+                    ? GetComponentVersionFromFile(localFilePath)
+                    : await GetComponentVersionFromUri(uri);
                 result[i] = new Component(name, fileName, uri, version);
             }
 
             return result;
         }
 
-        private static async Task<string> GetVersionFromComponentUrl(Uri uri)
+        private static string GetComponentVersionFromFile(string filePath)
+        {
+            Console.WriteLine($"GetComponentVersionFromFile: Opening manifest from {filePath}.");
+            var manifestText = File.ReadAllText(filePath);
+            return GetComponentVersionFromJson(manifestText);
+
+        }
+
+        private static async Task<string> GetComponentVersionFromUri(Uri uri)
         {
             using (var client = new System.Net.WebClient())
             {
+                Console.WriteLine($"GetComponentVersionFromUri: Downloading manifest from {uri}.");
                 var manifestText = await client.DownloadStringTaskAsync(uri);
-                using (var stringStream = new MemoryStream(Encoding.UTF8.GetBytes(manifestText)))
-                using (var streamReader = new StreamReader(stringStream))
-                using (var reader = new JsonTextReader(streamReader))
-                {
-                    var jsonDocument = (JObject)JToken.ReadFrom(reader);
-                    var infoObject = (JObject)jsonDocument["info"];
-                    var version = infoObject.Value<string>("buildVersion"); // might not be present
-                    return version;
-                }
+                return GetComponentVersionFromJson(manifestText);
             }
         }
 
-        private static string[] GetUrls(string logText)
+        private static string GetComponentVersionFromJson(string json)
+        {
+            using (var stringStream = new MemoryStream(Encoding.UTF8.GetBytes(json)))
+            using (var streamReader = new StreamReader(stringStream))
+            using (var reader = new JsonTextReader(streamReader))
+            {
+                var jsonDocument = (JObject)JToken.ReadFrom(reader);
+                var infoObject = (JObject)jsonDocument["info"];
+                var version = infoObject.Value<string>("buildVersion"); // might not be present
+                return version;
+            }
+        }
+
+        private static string[] GetComponentManifestUrls(string logText)
         {
             const string startingString = "Manifest Url(s):";
             var manifestStart = logText.IndexOf(startingString);

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
@@ -232,7 +232,7 @@ namespace Roslyn.Insertion
                     cancellationToken.ThrowIfCancellationRequested();
                     Console.WriteLine($"Updating CoreXT components file");
 
-                    var components = await GetLatestComponentsAsync(buildToInsert, cancellationToken);
+                    var components = await GetLatestComponentsAsync(buildToInsert, insertionArtifacts, cancellationToken);
                     var shouldSave = false;
                     foreach (var newComponent in components)
                     {


### PR DESCRIPTION
As part of moving Roslyn's build, we will not have access to domain resources. We have been pulling copies of the component manifest when determining component version, but those same manifests are available from our insertion artifacts.