### PR TITLE
Simplify Roslyn code flow

### DIFF
--- a/src/GitHubCreateMergePRs/config.xml
+++ b/src/GitHubCreateMergePRs/config.xml
@@ -1,37 +1,20 @@
 <config>
   <repo owner="dotnet" name="roslyn">
-    <!-- Roslyn servicing branches -->
-    <merge from="dev15.9.x" to="dev16.0-vs-deps" />
-    <merge from="dev16.0-vs-deps" to="release/dev16.3" />
+    <!-- Roslyn servicing branches (flowing between releases) -->
+    <merge from="dev15.9.x" to="release/dev16.4-vs-deps" />
+    <merge from="release/dev16.4-vs-deps" to="release/dev16.7-vs-deps" />
+    <merge from="release/dev16.7-vs-deps" to="release/dev16.9-vs-deps" />
+      
+    <!-- Roslyn last servicing branch into current non-vs-deps branch -->
+    <merge from="release/dev16.9-vs-deps" to="release/dev16.10" />
 
-    <!-- Roslyn branches (non-vs-deps) (flowing between releases) -->
-    <merge from="release/dev16.3" to="release/dev16.4" />
-    <merge from="release/dev16.4" to="release/dev16.5" />
-    <merge from="release/dev16.5" to="release/dev16.6" />
-    <merge from="release/dev16.6" to="release/dev16.7" />
-    <merge from="release/dev16.7" to="release/dev16.8" />
-    <merge from="release/dev16.8" to="release/dev16.9" />
-    <merge from="release/dev16.9" to="release/dev16.10" />
-    <merge from="release/dev16.10" to="main" />
+    <!-- Roslyn non-vs-deps branches (flowing between releases) -->
+    <merge from="release/dev16.10" to="main" /> 
 
-    <!-- Roslyn branches (between vs-deps branches) -->
-    <merge from="release/dev16.3-vs-deps" to="release/dev16.4-vs-deps" />
-    <merge from="release/dev16.4-vs-deps" to="release/dev16.5-vs-deps" />
-    <merge from="release/dev16.5-vs-deps" to="release/dev16.6-vs-deps" />
-    <merge from="release/dev16.6-vs-deps" to="release/dev16.7-vs-deps" />
-    <merge from="release/dev16.7-vs-deps" to="release/dev16.8-vs-deps" />
-    <merge from="release/dev16.8-vs-deps" to="release/dev16.9-vs-deps" />
-    <merge from="release/dev16.9-vs-deps" to="release/dev16.10-vs-deps" />
+    <!-- Roslyn vs-deps branches (flowing between releases) -->
     <merge from="release/dev16.10-vs-deps" to="main-vs-deps" />
 
     <!-- Roslyn branches (from non-vs-deps to vs-deps) -->
-    <merge from="release/dev16.3" to="release/dev16.3-vs-deps" />
-    <merge from="release/dev16.4" to="release/dev16.4-vs-deps" />
-    <merge from="release/dev16.5" to="release/dev16.5-vs-deps" />
-    <merge from="release/dev16.6" to="release/dev16.6-vs-deps" />
-    <merge from="release/dev16.7" to="release/dev16.7-vs-deps" />
-    <merge from="release/dev16.8" to="release/dev16.8-vs-deps" />
-    <merge from="release/dev16.9" to="release/dev16.9-vs-deps" />
     <merge from="release/dev16.10" to="release/dev16.10-vs-deps" />
     <merge from="main" to="main-vs-deps" />
 

--- a/src/GitHubCreateMergePRs/config.xml
+++ b/src/GitHubCreateMergePRs/config.xml
@@ -1,6 +1,6 @@
 <config>
   <repo owner="dotnet" name="roslyn" mergeOwners="RikkiGibson">
-    <!-- For a list of VS versions under services, see https://docs.microsoft.com/en-us/visualstudio/releases/2019/servicing#support-options-for-enterprise-and-professional-customers -->
+    <!-- For a list of VS versions under servicing, see https://docs.microsoft.com/en-us/visualstudio/releases/2019/servicing#support-options-for-enterprise-and-professional-customers -->
     <!-- Roslyn servicing branches (flowing between releases) -->
     <merge from="dev15.9.x" to="release/dev16.4-vs-deps" />
     <merge from="release/dev16.4-vs-deps" to="release/dev16.7-vs-deps" />

--- a/src/GitHubCreateMergePRs/config.xml
+++ b/src/GitHubCreateMergePRs/config.xml
@@ -1,11 +1,12 @@
 <config>
   <repo owner="dotnet" name="roslyn">
+    <!-- For a list of VS versions under services, see https://docs.microsoft.com/en-us/visualstudio/releases/2019/servicing#support-options-for-enterprise-and-professional-customers -->
     <!-- Roslyn servicing branches (flowing between releases) -->
     <merge from="dev15.9.x" to="release/dev16.4-vs-deps" />
     <merge from="release/dev16.4-vs-deps" to="release/dev16.7-vs-deps" />
     <merge from="release/dev16.7-vs-deps" to="release/dev16.9-vs-deps" />
       
-    <!-- Roslyn last servicing branch into current non-vs-deps branch -->
+    <!-- Roslyn last servicing branch (flowing into current branch) -->
     <merge from="release/dev16.9-vs-deps" to="release/dev16.10" />
 
     <!-- Roslyn non-vs-deps branches (flowing between releases) -->


### PR DESCRIPTION
We only need to maintain the LTS vs-deps release branches and the current release branches.