### PR TITLE
Add ability to query builds from a separate AzDO instance

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/App.config
+++ b/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/App.config
@@ -18,13 +18,10 @@
   </runtime>
   <applicationSettings>
     <RoslynInsertionTool.Settings>
-      <setting name="UserName" serializeAs="String">
+      <setting name="VisualStudioRepoAzdoUserName" serializeAs="String">
         <value>vslsnap@microsoft.com</value>
       </setting>
-      <setting name="VisualStudioAzdoUri" serializeAs="String">
-        <value>https://devdiv.visualstudio.com/DefaultCollection</value>
-      </setting>
-      <setting name="VisualStudioProjectName" serializeAs="String">
+      <setting name="VisualStudioRepoProjectName" serializeAs="String">
         <value>DevDiv</value>
       </setting>
       <setting name="BuildDropPath" serializeAs="String">
@@ -33,7 +30,7 @@
       <setting name="InsertionBranchName" serializeAs="String">
         <value>dev/vslsnap/insertions/</value>
       </setting>
-      <setting name="BuildQueueName" serializeAs="String">
+      <setting name="ComponentBuildQueueName" serializeAs="String">
         <value>Roslyn-Signed</value>
       </setting>
       <setting name="BuildConfig" serializeAs="String">
@@ -57,7 +54,7 @@
       <setting name="KeyVaultUrl" serializeAs="String">
         <value>https://roslyninfra.vault.azure.net:443</value>
       </setting>
-      <setting name="VsoSecretName" serializeAs="String">
+      <setting name="VisualStudioRepoSecretName" serializeAs="String">
         <value>vslsnap-vso-auth-token</value>
       </setting>
       <setting name="ApplicationId" serializeAs="String">
@@ -84,8 +81,11 @@
       <setting name="CreateDraftPr" serializeAs="String">
         <value>False</value>
       </setting>
-      <setting name="BuildSecretName" serializeAs="String">
+      <setting name="ComponentBuildSecretName" serializeAs="String">
         <value>vslsnap-build-auth-token</value>
+      </setting>
+      <setting name="VisualStudioRepoAzdoUri" serializeAs="String">
+        <value>https://devdiv.visualstudio.com/DefaultCollection</value>
       </setting>
     </RoslynInsertionTool.Settings>
   </applicationSettings>

--- a/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/App.config
+++ b/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/App.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
     <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
@@ -21,16 +21,16 @@
       <setting name="UserName" serializeAs="String">
         <value>vslsnap@microsoft.com</value>
       </setting>
-      <setting name="VSTSUrl" serializeAs="String">
+      <setting name="VisualStudioAzdoUri" serializeAs="String">
         <value>https://devdiv.visualstudio.com/DefaultCollection</value>
       </setting>
-      <setting name="TFSProjectName" serializeAs="String">
+      <setting name="VisualStudioProjectName" serializeAs="String">
         <value>DevDiv</value>
       </setting>
       <setting name="BuildDropPath" serializeAs="String">
         <value>\\cpvsbuild\drops\Roslyn</value>
       </setting>
-      <setting name="NewBranchName" serializeAs="String">
+      <setting name="InsertionBranchName" serializeAs="String">
         <value>dev/vslsnap/insertions/</value>
       </setting>
       <setting name="BuildQueueName" serializeAs="String">
@@ -83,6 +83,9 @@
       </setting>
       <setting name="CreateDraftPr" serializeAs="String">
         <value>False</value>
+      </setting>
+      <setting name="BuildSecretName" serializeAs="String">
+        <value>vslsnap-build-auth-token</value>
       </setting>
     </RoslynInsertionTool.Settings>
   </applicationSettings>

--- a/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/Settings.Designer.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/Settings.Designer.cs
@@ -26,27 +26,27 @@ namespace Roslyn.Insertion {
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("vslsnap@microsoft.com")]
-        public string UserName {
+        public string VisualStudioRepoAzdoUserName {
             get {
-                return ((string)(this["UserName"]));
+                return ((string)(this["VisualStudioRepoAzdoUserName"]));
             }
         }
 
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("https://devdiv.visualstudio.com/DefaultCollection")]
-        public string VisualStudioAzdoUri {
+        public string VisualStudioRepoAzdoUri {
             get {
-                return ((string)(this["VisualStudioAzdoUri"]));
+                return ((string)(this["VisualStudioRepoAzdoUri"]));
             }
         }
 
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("DevDiv")]
-        public string VisualStudioProjectName {
+        public string VisualStudioRepoProjectName {
             get {
-                return ((string)(this["VisualStudioProjectName"]));
+                return ((string)(this["VisualStudioRepoProjectName"]));
             }
         }
 
@@ -170,20 +170,20 @@ namespace Roslyn.Insertion {
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("vslsnap-vso-auth-token")]
-        public string VsoSecretName {
+        public string VisualStudioRepoSecretName {
             get {
-                return ((string)(this["VsoSecretName"]));
+                return ((string)(this["VisualStudioRepoSecretName"]));
             }
         }
 
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("vslsnap-build-auth-token")]
-        public string BuildSecretName
+        public string ComponentBuildSecretName
         {
             get
             {
-                return ((string)(this["BuildSecretName"]));
+                return ((string)(this["ComponentBuildSecretName"]));
             }
         }
 

--- a/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/Settings.Designer.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/Settings.Designer.cs
@@ -35,18 +35,18 @@ namespace Roslyn.Insertion {
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("https://devdiv.visualstudio.com/DefaultCollection")]
-        public string VSTSUrl {
+        public string VisualStudioAzdoUri {
             get {
-                return ((string)(this["VSTSUrl"]));
+                return ((string)(this["VisualStudioAzdoUri"]));
             }
         }
 
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("DevDiv")]
-        public string TFSProjectName {
+        public string VisualStudioProjectName {
             get {
-                return ((string)(this["TFSProjectName"]));
+                return ((string)(this["VisualStudioProjectName"]));
             }
         }
 
@@ -62,9 +62,9 @@ namespace Roslyn.Insertion {
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("dev/vslsnap/insertions/")]
-        public string NewBranchName {
+        public string InsertionBranchName {
             get {
-                return ((string)(this["NewBranchName"]));
+                return ((string)(this["InsertionBranchName"]));
             }
         }
 
@@ -173,6 +173,17 @@ namespace Roslyn.Insertion {
         public string VsoSecretName {
             get {
                 return ((string)(this["VsoSecretName"]));
+            }
+        }
+
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("vslsnap-build-auth-token")]
+        public string BuildSecretName
+        {
+            get
+            {
+                return ((string)(this["BuildSecretName"]));
             }
         }
 

--- a/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/Settings.settings
+++ b/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/Settings.settings
@@ -5,16 +5,16 @@
     <Setting Name="UserName" Type="System.String" Scope="Application">
       <Value Profile="(Default)">vslsnap@microsoft.com</Value>
     </Setting>
-    <Setting Name="VSTSUrl" Type="System.String" Scope="Application">
-      <Value Profile="(Default)">https://devdiv.visualstudio.com/DefaultCollection</Value>
+    <Setting Name="VisualStudioAzdoUri" Type="System.String" Scope="Application">
+      <Value Profile="(Default)">https://dev.azure.com/devdiv</Value>
     </Setting>
-    <Setting Name="TFSProjectName" Type="System.String" Scope="Application">
+    <Setting Name="VisualStudioProjectName" Type="System.String" Scope="Application">
       <Value Profile="(Default)">DevDiv</Value>
     </Setting>
     <Setting Name="BuildDropPath" Type="System.String" Scope="Application">
       <Value Profile="(Default)">\\cpvsbuild\drops\Roslyn</Value>
     </Setting>
-    <Setting Name="NewBranchName" Type="System.String" Scope="Application">
+    <Setting Name="InsertionBranchName" Type="System.String" Scope="Application">
       <Value Profile="(Default)">dev/vslsnap/insertions/</Value>
     </Setting>
     <Setting Name="BuildQueueName" Type="System.String" Scope="Application">
@@ -66,7 +66,10 @@
       <Value Profile="(Default)" />
     </Setting>
     <Setting Name="CreateDraftPr" Type="System.Boolean" Scope="Application">
-        <Value Profile="(Default)">False</Value>
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="BuildSecretName" Type="System.String" Scope="Application">
+      <Value Profile="(Default)">vslsnap-build-auth-token</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/Settings.settings
+++ b/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/Settings.settings
@@ -2,13 +2,10 @@
 <SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="RoslynInsertionTool" GeneratedClassName="Settings">
   <Profiles />
   <Settings>
-    <Setting Name="UserName" Type="System.String" Scope="Application">
+    <Setting Name="VisualStudioRepoAzdoUserName" Type="System.String" Scope="Application">
       <Value Profile="(Default)">vslsnap@microsoft.com</Value>
     </Setting>
-    <Setting Name="VisualStudioAzdoUri" Type="System.String" Scope="Application">
-      <Value Profile="(Default)">https://dev.azure.com/devdiv</Value>
-    </Setting>
-    <Setting Name="VisualStudioProjectName" Type="System.String" Scope="Application">
+    <Setting Name="VisualStudioRepoProjectName" Type="System.String" Scope="Application">
       <Value Profile="(Default)">DevDiv</Value>
     </Setting>
     <Setting Name="BuildDropPath" Type="System.String" Scope="Application">
@@ -17,7 +14,7 @@
     <Setting Name="InsertionBranchName" Type="System.String" Scope="Application">
       <Value Profile="(Default)">dev/vslsnap/insertions/</Value>
     </Setting>
-    <Setting Name="BuildQueueName" Type="System.String" Scope="Application">
+    <Setting Name="ComponentBuildQueueName" Type="System.String" Scope="Application">
       <Value Profile="(Default)">Roslyn-Signed</Value>
     </Setting>
     <Setting Name="BuildConfig" Type="System.String" Scope="Application">
@@ -41,7 +38,7 @@
     <Setting Name="KeyVaultUrl" Type="System.String" Scope="Application">
       <Value Profile="(Default)">https://roslyninfra.vault.azure.net:443</Value>
     </Setting>
-    <Setting Name="VsoSecretName" Type="System.String" Scope="Application">
+    <Setting Name="VisualStudioRepoSecretName" Type="System.String" Scope="Application">
       <Value Profile="(Default)">vslsnap-vso-auth-token</Value>
     </Setting>
     <Setting Name="ApplicationId" Type="System.String" Scope="Application">
@@ -68,8 +65,11 @@
     <Setting Name="CreateDraftPr" Type="System.Boolean" Scope="Application">
       <Value Profile="(Default)">False</Value>
     </Setting>
-    <Setting Name="BuildSecretName" Type="System.String" Scope="Application">
+    <Setting Name="ComponentBuildSecretName" Type="System.String" Scope="Application">
       <Value Profile="(Default)">vslsnap-build-auth-token</Value>
+    </Setting>
+    <Setting Name="VisualStudioRepoAzdoUri" Type="System.String" Scope="Application">
+      <Value Profile="(Default)">https://devdiv.visualstudio.com/DefaultCollection</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.Git.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.Git.cs
@@ -13,13 +13,13 @@ namespace Roslyn.Insertion
 {
     static partial class RoslynInsertionTool
     {
-        private static string GetNewBranchName() => $"{Options.NewBranchName}{Options.VisualStudioBranchName.Split('/').Last()}.{DateTime.Now:yyyyMMddHHmmss}";
+        private static string GetNewBranchName() => $"{Options.InsertionBranchName}{Options.VisualStudioBranchName.Split('/').Last()}.{DateTime.Now:yyyyMMddHHmmss}";
 
-        private static async Task<GitPullRequest> CreatePlaceholderBranchAsync(CancellationToken cancellationToken)
+        private static async Task<GitPullRequest> CreatePlaceholderVSBranchAsync(CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var gitClient = ProjectCollection.GetClient<GitHttpClient>();
-            var repository = await gitClient.GetRepositoryAsync(project: Options.TFSProjectName, repositoryId: "VS", cancellationToken: cancellationToken);
+            var gitClient = VsConnection.GetClient<GitHttpClient>();
+            var repository = await gitClient.GetRepositoryAsync(project: Options.VisualStudioProjectName, repositoryId: "VS", cancellationToken: cancellationToken);
 
             var refs = await gitClient.GetRefsAsync(
                 repository.Id,
@@ -54,7 +54,7 @@ namespace Roslyn.Insertion
                 },
             }, repository.Id, cancellationToken: cancellationToken);
 
-            return await CreatePullRequestAsync(
+            return await CreateVSPullRequestAsync(
                 branchName,
                 $"PLACEHOLDER INSERTION FOR {Options.InsertionName}",
                 "Not Specified",

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.Git.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.Git.cs
@@ -18,8 +18,8 @@ namespace Roslyn.Insertion
         private static async Task<GitPullRequest> CreatePlaceholderVSBranchAsync(CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var gitClient = VsConnection.GetClient<GitHttpClient>();
-            var repository = await gitClient.GetRepositoryAsync(project: Options.VisualStudioProjectName, repositoryId: "VS", cancellationToken: cancellationToken);
+            var gitClient = VisualStudioRepoConnection.GetClient<GitHttpClient>();
+            var repository = await gitClient.GetRepositoryAsync(project: Options.VisualStudioRepoProjectName, repositoryId: "VS", cancellationToken: cancellationToken);
 
             var refs = await gitClient.GetRefsAsync(
                 repository.Id,

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
@@ -42,19 +42,36 @@ namespace Roslyn.Insertion
 
             try
             {
-                Console.WriteLine($"Verifying given authentication for {Options.VSTSUri}");
+                Console.WriteLine($"Verifying given authentication for {Options.VisualStudioAzdoUri}");
                 try
                 {
-                    ProjectCollection.Authenticate();
+                    VsConnection.Authenticate();
                 }
                 catch (Exception ex)
                 {
-                    LogError($"Could not authenticate with {Options.VSTSUri}");
+                    LogError($"Could not authenticate with {Options.VisualStudioAzdoUri}");
                     LogError(ex);
                     return (false, 0);
                 }
 
-                Console.WriteLine($"Verification succeeded for {Options.VSTSUri}");
+                Console.WriteLine($"Verification succeeded for {Options.VisualStudioAzdoUri}");
+
+                if (BuildConnection != VsConnection)
+                {
+                    Console.WriteLine($"Verifying given authentication for {Options.BuildAzdoUri}");
+                    try
+                    {
+                        BuildConnection.Authenticate();
+                    }
+                    catch (Exception ex)
+                    {
+                        LogError($"Could not authenticate with {Options.BuildAzdoUri}");
+                        LogError(ex);
+                        return (false, 0);
+                    }
+
+                    Console.WriteLine($"Verification succeeded for {Options.BuildAzdoUri}");
+                }
 
                 // ********************** Create dummy PR *****************************
                 if (Options.CreateDummyPr)
@@ -62,7 +79,7 @@ namespace Roslyn.Insertion
                     GitPullRequest dummyPR;
                     try
                     {
-                        dummyPR = await CreatePlaceholderBranchAsync(cancellationToken);
+                        dummyPR = await CreatePlaceholderVSBranchAsync(cancellationToken);
                     }
                     catch (Exception ex)
                     {
@@ -98,12 +115,12 @@ namespace Roslyn.Insertion
 
                     //  Get the latest build, whether passed or failed.  If the buildToInsert has already been inserted but
                     //  there is a later failing build, then send an error
-                    latestBuild = await GetLatestBuildAsync(cancellationToken);
+                    latestBuild = await GetLatestComponentBuildAsync(cancellationToken);
                 }
                 else
                 {
                     buildVersion = BuildVersion.FromString(Options.SpecificBuild);
-                    buildToInsert = await GetSpecificBuildAsync(buildVersion, cancellationToken);
+                    buildToInsert = await GetSpecificComponentBuildAsync(buildVersion, cancellationToken);
                 }
 
                 var insertionArtifacts = await GetInsertionArtifactsAsync(buildToInsert, cancellationToken);
@@ -111,7 +128,7 @@ namespace Roslyn.Insertion
                 cancellationToken.ThrowIfCancellationRequested();
 
                 // *********** Look up existing PR ********************
-                var gitClient = ProjectCollection.GetClient<GitHttpClient>();
+                var gitClient = VsConnection.GetClient<GitHttpClient>();
                 var branches = await gitClient.GetRefsAsync(
                     VSRepoId,
                     filter: $"heads/{Options.VisualStudioBranchName}",
@@ -257,10 +274,7 @@ namespace Roslyn.Insertion
                 // ************* Ensure the build is retained on the servers *************
                 if (Options.RetainInsertedBuild && retainBuild && !buildToInsert.KeepForever.GetValueOrDefault())
                 {
-                    Console.WriteLine("Marking inserted build for retention.");
-                    buildToInsert.KeepForever = true;
-                    var buildClient = ProjectCollection.GetClient<BuildHttpClient>();
-                    await buildClient.UpdateBuildAsync(buildToInsert);
+                    await RetainComponentBuild(buildToInsert);
                 }
 
                 // ************* Bail out if there are no changes ************************
@@ -316,12 +330,13 @@ namespace Roslyn.Insertion
                         OntoRefName = $"refs/heads/{insertionBranchName}",
                         GeneratedRefName = $"refs/heads/{cherryPickBranchName}"
                     };
-                    var cherryPick = await gitClient.CreateCherryPickAsync(cherryPickArgs, Options.TFSProjectName, VSRepoId, cancellationToken: cancellationToken);
+                    // Cherry-pick VS commits into insertion branch.
+                    var cherryPick = await gitClient.CreateCherryPickAsync(cherryPickArgs, Options.VisualStudioProjectName, VSRepoId, cancellationToken: cancellationToken);
                     while (cherryPick.Status < GitAsyncOperationStatus.Completed)
                     {
                         Console.WriteLine($"Cherry-pick progress: {cherryPick.DetailedStatus?.Progress ?? 0:P}");
                         await Task.Delay(5000);
-                        cherryPick = await gitClient.GetCherryPickAsync(options.TFSProjectName, cherryPick.CherryPickId, VSRepoId, cancellationToken: cancellationToken);
+                        cherryPick = await gitClient.GetCherryPickAsync(options.VisualStudioProjectName, cherryPick.CherryPickId, VSRepoId, cancellationToken: cancellationToken);
                     }
                     Console.WriteLine($"Cherry-pick status: {cherryPick.Status}");
 
@@ -350,7 +365,7 @@ namespace Roslyn.Insertion
                 }
 
                 // ********************* Create pull request *****************************
-                var oldBuild = await GetSpecificBuildAsync(oldComponentVersion, cancellationToken);
+                var oldBuild = await GetSpecificComponentBuildAsync(oldComponentVersion, cancellationToken);
                 var prDescriptionMarkdown = CreatePullRequestDescription(oldBuild, buildToInsert, useMarkdown: true);
 
                 if (buildToInsert.Result == BuildResult.PartiallySucceeded)
@@ -418,7 +433,7 @@ namespace Roslyn.Insertion
                             ? buildToInsert.RequestedBy.Id
                             : MLInfraSwatUserId.ToString();
 
-                        pullRequest = await CreatePullRequestAsync(insertionBranchName, prDescriptionMarkdown, buildVersion.ToString(), options.TitlePrefix, reviewerId, cancellationToken);
+                        pullRequest = await CreateVSPullRequestAsync(insertionBranchName, prDescriptionMarkdown, buildVersion.ToString(), options.TitlePrefix, reviewerId, cancellationToken);
                         if (pullRequest == null)
                         {
                             LogError($"Unable to create pull request for '{insertionBranchName}'");
@@ -447,10 +462,10 @@ namespace Roslyn.Insertion
                             // When creating Draft PRs no policies are automatically started.
                             // If we do not queue a CloudBuild the Perf DDRITs request will
                             // spin waiting for a build to test against until it timesout.
-                            await QueueBuildPolicy(pullRequest, "CloudBuild - PR");
+                            await QueueVSBuildPolicy(pullRequest, "CloudBuild - PR");
                         }
 
-                        await QueueBuildPolicy(pullRequest, "Request Perf DDRITs");
+                        await QueueVSBuildPolicy(pullRequest, "Request Perf DDRITs");
                     }
                     catch (Exception ex)
                     {
@@ -461,9 +476,9 @@ namespace Roslyn.Insertion
                     if (Options.CreateDraftPr)
                     {
                         // When creating Draft PRs no policies are automatically started.
-                        await TryQueueBuildPolicy(pullRequest, "Insertion Hash Check", insertionBranchName);
-                        await TryQueueBuildPolicy(pullRequest, "Insertion Sign Check", insertionBranchName);
-                        await TryQueueBuildPolicy(pullRequest, "Insertion Symbol Check", insertionBranchName);
+                        await TryQueueVSBuildPolicy(pullRequest, "Insertion Hash Check", insertionBranchName);
+                        await TryQueueVSBuildPolicy(pullRequest, "Insertion Sign Check", insertionBranchName);
+                        await TryQueueVSBuildPolicy(pullRequest, "Insertion Symbol Check", insertionBranchName);
                     }
                 }
 

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionToolOptions.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionToolOptions.cs
@@ -33,17 +33,17 @@ namespace Roslyn.Insertion
         public RoslynInsertionToolOptions() { }
 
         private RoslynInsertionToolOptions(
-            string username,
-            string password,
-            string buildUsername,
-            string buildPassword,
-            string visualStudioAzdoUri,
-            string visualStudioProjectName,
+            string visualStudioRepoAzdoUsername,
+            string visualStudioRepoAzdoPassword,
+            string visualStudioRepoAzdoUri,
+            string visualStudioRepoProjectName,
             string visualStudioBranchName,
-            string buildAzdoUri,
-            string buildProjectName,
-            string buildQueueName,
-            string branchName,
+            string componentBuildAzdoUsername,
+            string componentBuildAzdoPassword,
+            string componentBuildAzdoUri,
+            string componentBuildProjectName,
+            string componentBuildQueueName,
+            string componentBranchName,
             string buildConfig,
             string insertionBranchName,
             string buildDropPath,
@@ -71,18 +71,18 @@ namespace Roslyn.Insertion
             bool setAutoComplete,
             ImmutableArray<string> cherryPick)
         {
-            Username = username;
-            Password = password;
-            BuildUsername = buildUsername;
-            BuildPassword = buildPassword;
+            VisualStudioRepoAzdoUsername = visualStudioRepoAzdoUsername;
+            VisualStudioRepoAzdoPassword = visualStudioRepoAzdoPassword;
+            VisualStudioRepoAzdoUri = visualStudioRepoAzdoUri;
+            VisualStudioRepoProjectName = visualStudioRepoProjectName;
             VisualStudioBranchName = visualStudioBranchName;
-            BuildQueueName = buildQueueName;
-            BranchName = branchName;
+            ComponentBuildAzdoUsername = componentBuildAzdoUsername;
+            ComponentBuildAzdoPassword = componentBuildAzdoPassword;
+            ComponentBuildAzdoUri = componentBuildAzdoUri;
+            ComponentBuildProjectName = componentBuildProjectName;
+            ComponentBuildQueueName = componentBuildQueueName;
+            ComponentBranchName = componentBranchName;
             BuildConfig = buildConfig;
-            VisualStudioAzdoUri = visualStudioAzdoUri;
-            VisualStudioProjectName = visualStudioProjectName;
-            BuildAzdoUri = buildAzdoUri;
-            BuildProjectName = buildProjectName;
             InsertionBranchName = insertionBranchName;
             BuildDropPath = buildDropPath;
             SpecificBuild = specificBuild;
@@ -111,18 +111,18 @@ namespace Roslyn.Insertion
         }
 
         public RoslynInsertionToolOptions Update(
-            Optional<string> username = default,
-            Optional<string> password = default,
-            Optional<string> buildUsername = default,
-            Optional<string> buildPassword = default,
-            Optional<string> visualStudioBranchName = default,
-            Optional<string> buildQueueName = default,
-            Optional<string> branchName = default,
-            Optional<string> buildConfig = default,
-            Optional<string> vstsUri = default,
+            Optional<string> visualStudioRepoAzdoUsername = default,
+            Optional<string> visualStudioRepoAzdoPassword = default,
+            Optional<string> visualStudioRepoAzdoUri = default,
             Optional<string> visualStudioProjectName = default,
-            Optional<string> buildAzdoUri = default,
-            Optional<string> buildProjectName = default,
+            Optional<string> visualStudioBranchName = default,
+            Optional<string> componentBuildAzdoUsername = default,
+            Optional<string> componentBuildAzdoPassword = default,
+            Optional<string> componentBuildAzdoUri = default,
+            Optional<string> componentBuildProjectName = default,
+            Optional<string> componentBuildQueueName = default,
+            Optional<string> componentBranchName = default,
+            Optional<string> buildConfig = default,
             Optional<string> insertionBranchName = default,
             Optional<string> buildDropPath = default,
             Optional<string> specificBuild = default,
@@ -150,18 +150,18 @@ namespace Roslyn.Insertion
             Optional<ImmutableArray<string>> cherryPick = default)
         {
             return new RoslynInsertionToolOptions(
-                username: username.ValueOrFallback(Username),
-                password: password.ValueOrFallback(Password),
-                buildUsername: buildUsername.ValueOrFallback(BuildUsername),
-                buildPassword: buildPassword.ValueOrFallback(BuildPassword),
+                visualStudioRepoAzdoUsername: visualStudioRepoAzdoUsername.ValueOrFallback(VisualStudioRepoAzdoUsername),
+                visualStudioRepoAzdoPassword: visualStudioRepoAzdoPassword.ValueOrFallback(VisualStudioRepoAzdoPassword),
+                visualStudioRepoAzdoUri: visualStudioRepoAzdoUri.ValueOrFallback(VisualStudioRepoAzdoUri),
+                visualStudioRepoProjectName: visualStudioProjectName.ValueOrFallback(VisualStudioRepoProjectName),
                 visualStudioBranchName: visualStudioBranchName.ValueOrFallback(VisualStudioBranchName),
-                buildQueueName: buildQueueName.ValueOrFallback(BuildQueueName),
-                branchName: branchName.ValueOrFallback(BranchName),
+                componentBuildAzdoUsername: componentBuildAzdoUsername.ValueOrFallback(ComponentBuildAzdoUsername),
+                componentBuildAzdoPassword: componentBuildAzdoPassword.ValueOrFallback(ComponentBuildAzdoPassword),
+                componentBuildAzdoUri: componentBuildAzdoUri.ValueOrFallback(ComponentBuildAzdoUri),
+                componentBuildProjectName: componentBuildProjectName.ValueOrFallback(ComponentBuildProjectName),
+                componentBuildQueueName: componentBuildQueueName.ValueOrFallback(ComponentBuildQueueName),
+                componentBranchName: componentBranchName.ValueOrFallback(ComponentBranchName),
                 buildConfig: buildConfig.ValueOrFallback(BuildConfig),
-                visualStudioAzdoUri: vstsUri.ValueOrFallback(VisualStudioAzdoUri),
-                visualStudioProjectName: visualStudioProjectName.ValueOrFallback(VisualStudioProjectName),
-                buildAzdoUri: buildAzdoUri.ValueOrFallback(BuildAzdoUri),
-                buildProjectName: buildProjectName.ValueOrFallback(BuildProjectName),
                 insertionBranchName: insertionBranchName.ValueOrFallback(InsertionBranchName),
                 buildDropPath: buildDropPath.ValueOrFallback(BuildDropPath),
                 specificBuild: specificBuild.ValueOrFallback(SpecificBuild),
@@ -201,27 +201,27 @@ namespace Roslyn.Insertion
 
         public RoslynInsertionToolOptions WithInsertedBuildRetained(bool retainInsertedBuild) => Update(retainInsertedBuild: retainInsertedBuild);
 
-        public RoslynInsertionToolOptions WithUsername(string username) => Update(username: username);
+        public RoslynInsertionToolOptions WithVisualStudioRepoAzdoUsername(string visualStudioRepoAzdoUsername) => Update(visualStudioRepoAzdoUsername: visualStudioRepoAzdoUsername);
 
-        public RoslynInsertionToolOptions WithBuildUsername(string buildUsername) => Update(buildUsername: buildUsername);
+        public RoslynInsertionToolOptions WithVisualStudioRepoAzdoPassword(string visualStudioRepoAzdoPassword) => Update(visualStudioRepoAzdoPassword: visualStudioRepoAzdoPassword);
 
-        public RoslynInsertionToolOptions WithPassword(string password) => Update(password: password);
+        public RoslynInsertionToolOptions WithVisualStudioRepoAzdoUri(string visualStudioRepoAzdoUri) => Update(visualStudioRepoAzdoUri: visualStudioRepoAzdoUri);
 
-        public RoslynInsertionToolOptions WithBuildPassword(string buildPassword) => Update(buildPassword: buildPassword);
-
-        public RoslynInsertionToolOptions WithVisualStudioAzdoUri(string visualStudioAzdoUri) => Update(vstsUri: visualStudioAzdoUri);
-
-        public RoslynInsertionToolOptions WithVisualStudioProjectName(string visualStudioProjectName) => Update(visualStudioProjectName: visualStudioProjectName);
+        public RoslynInsertionToolOptions WithVisualStudioRepoProjectName(string visualStudioProjectName) => Update(visualStudioProjectName: visualStudioProjectName);
 
         public RoslynInsertionToolOptions WithVisualStudioBranchName(string visualStudioBranchName) => Update(visualStudioBranchName: visualStudioBranchName);
 
-        public RoslynInsertionToolOptions WithBuildAzdoUri(string buildAzdoUri) => Update(buildAzdoUri: buildAzdoUri);
+        public RoslynInsertionToolOptions WithComponentBuildAzdoUsername(string componentBuildAzdoUsername) => Update(componentBuildAzdoUsername: componentBuildAzdoUsername);
 
-        public RoslynInsertionToolOptions WithBuildProjectName(string buildProjectName) => Update(buildProjectName: buildProjectName);
+        public RoslynInsertionToolOptions WithComponentBuildAzdoPassword(string componentBuildAzdoPassword) => Update(componentBuildAzdoPassword: componentBuildAzdoPassword);
 
-        public RoslynInsertionToolOptions WithBuildQueueName(string buildQueueName) => Update(buildQueueName: buildQueueName);
+        public RoslynInsertionToolOptions WithComponentBuildAzdoUri(string componentBuildAzdoUri) => Update(componentBuildAzdoUri: componentBuildAzdoUri);
 
-        public RoslynInsertionToolOptions WithBranchName(string branchName) => Update(branchName: branchName);
+        public RoslynInsertionToolOptions WithComponentBuildProjectName(string componentBuildProjectName) => Update(componentBuildProjectName: componentBuildProjectName);
+
+        public RoslynInsertionToolOptions WithComponentBuildQueueName(string componentBuildQueueName) => Update(componentBuildQueueName: componentBuildQueueName);
+
+        public RoslynInsertionToolOptions WithComponentBranchName(string componentBranchName) => Update(componentBranchName: componentBranchName);
 
         public RoslynInsertionToolOptions WithBuildConfig(string buildConfig) => Update(buildConfig: buildConfig);
 
@@ -263,27 +263,30 @@ namespace Roslyn.Insertion
 
         public RoslynInsertionToolOptions WithCherryPick(ImmutableArray<string> cherryPick) => Update(cherryPick: cherryPick);
 
-        public string Username { get; }
+        public string VisualStudioRepoAzdoUsername { get; }
 
-        public string Password { get; }
+        public string VisualStudioRepoAzdoPassword { get; }
 
-        public string BuildUsername { get; }
+        public string VisualStudioRepoAzdoUri { get; }
 
-        public string BuildPassword { get; }
-
-        public string VisualStudioAzdoUri { get; }
-
-        public string VisualStudioProjectName { get; }
+        public string VisualStudioRepoProjectName { get; }
 
         public string VisualStudioBranchName { get; }
 
-        public string BuildAzdoUri { get; }
+        public string ComponentBuildAzdoUsername { get; }
 
-        public string BuildProjectName { get; }
+        public string ComponentBuildAzdoPassword { get; }
 
-        public string BuildQueueName { get; }
+        public string ComponentBuildAzdoUri { get; }
 
-        public string BranchName { get; }
+        public string ComponentBuildProjectName { get; }
+
+        public string ComponentBuildProjectNameOrFallback
+            => ComponentBuildProjectName ?? VisualStudioRepoProjectName;
+
+        public string ComponentBuildQueueName { get; }
+
+        public string ComponentBranchName { get; }
 
         public string BuildConfig { get; }
 
@@ -341,7 +344,7 @@ namespace Roslyn.Insertion
         {
             get
             {
-                if (BuildAzdoUri != null && (BuildUsername is null || BuildPassword is null))
+                if (ComponentBuildAzdoUri != null && (ComponentBuildAzdoUsername is null || ComponentBuildAzdoPassword is null))
                 {
                     // When the Build AzDO instance is separate from the VS AzDO instance, separate credentials must be specified.
                     return false;
@@ -363,22 +366,22 @@ namespace Roslyn.Insertion
                         !CreateDummyPr &&
                         (!CreateDraftPr || OverwritePr) && // Create draft PR can only be specified when overwriting an existing pr
                         !string.IsNullOrEmpty(InsertionName) &&
-                        !string.IsNullOrEmpty(BranchName) &&
+                        !string.IsNullOrEmpty(ComponentBranchName) &&
                         !string.IsNullOrEmpty(VisualStudioBranchName) &&
-                        !string.IsNullOrEmpty(BuildQueueName);
+                        !string.IsNullOrEmpty(ComponentBuildQueueName);
                 }
                 else
                 {
                     return
                         !OverwritePr &&
-                        !string.IsNullOrEmpty(Username) &&
-                        !string.IsNullOrEmpty(Password) &&
+                        !string.IsNullOrEmpty(VisualStudioRepoAzdoUsername) &&
+                        !string.IsNullOrEmpty(VisualStudioRepoAzdoPassword) &&
                         !string.IsNullOrEmpty(VisualStudioBranchName) &&
-                        !string.IsNullOrEmpty(BuildQueueName) &&
-                        !string.IsNullOrEmpty(BranchName) &&
+                        !string.IsNullOrEmpty(ComponentBuildQueueName) &&
+                        !string.IsNullOrEmpty(ComponentBranchName) &&
                         !string.IsNullOrEmpty(BuildConfig) &&
-                        !string.IsNullOrEmpty(VisualStudioAzdoUri) &&
-                        !string.IsNullOrEmpty(VisualStudioProjectName) &&
+                        !string.IsNullOrEmpty(VisualStudioRepoAzdoUri) &&
+                        !string.IsNullOrEmpty(VisualStudioRepoProjectName) &&
                         !string.IsNullOrEmpty(BuildDropPath);
                 }
             }
@@ -390,16 +393,16 @@ namespace Roslyn.Insertion
             {
                 var builder = new StringBuilder();
 
-                if (BuildAzdoUri != VisualStudioAzdoUri)
+                if (ComponentBuildAzdoUri != VisualStudioRepoAzdoUri)
                 {
-                    if (BuildUsername is null)
+                    if (ComponentBuildAzdoUsername is null)
                     {
-                        builder.AppendLine($"When {nameof(BuildAzdoUri)} is specified you must also specify the {nameof(BuildUsername)}.");
+                        builder.AppendLine($"When {nameof(ComponentBuildAzdoUri)} is specified you must also specify the {nameof(ComponentBuildAzdoUsername)}.");
                     }
 
-                    if (BuildPassword is null)
+                    if (ComponentBuildAzdoPassword is null)
                     {
-                        builder.AppendLine($"When {nameof(BuildAzdoUri)} is specified you must also specify the {nameof(BuildPassword)}.");
+                        builder.AppendLine($"When {nameof(ComponentBuildAzdoUri)} is specified you must also specify the {nameof(ComponentBuildAzdoPassword)}.");
                     }
                 }
 
@@ -440,9 +443,9 @@ namespace Roslyn.Insertion
                         builder.AppendLine($"{nameof(InsertionName).ToLowerInvariant()} is required");
                     }
 
-                    if (string.IsNullOrEmpty(BranchName))
+                    if (string.IsNullOrEmpty(ComponentBranchName))
                     {
-                        builder.AppendLine($"{nameof(BranchName).ToLowerInvariant()} is required");
+                        builder.AppendLine($"{nameof(ComponentBranchName).ToLowerInvariant()} is required");
                     }
 
                     if (string.IsNullOrEmpty(VisualStudioBranchName))
@@ -450,9 +453,9 @@ namespace Roslyn.Insertion
                         builder.AppendLine($"{nameof(VisualStudioBranchName).ToLowerInvariant()} is required");
                     }
 
-                    if (string.IsNullOrEmpty(BuildQueueName))
+                    if (string.IsNullOrEmpty(ComponentBuildQueueName))
                     {
-                        builder.AppendLine($"{nameof(BuildQueueName).ToLowerInvariant()} is required");
+                        builder.AppendLine($"{nameof(ComponentBuildQueueName).ToLowerInvariant()} is required");
                     }
                 }
                 else
@@ -463,14 +466,14 @@ namespace Roslyn.Insertion
                         builder.AppendLine($"{nameof(OverwritePr).ToLowerInvariant()} can only be used with {nameof(UpdateExistingPr).ToLowerInvariant()}.");
                     }
 
-                    if (string.IsNullOrEmpty(Username))
+                    if (string.IsNullOrEmpty(VisualStudioRepoAzdoUsername))
                     {
-                        builder.AppendLine($"{nameof(Username).ToLowerInvariant()} is required");
+                        builder.AppendLine($"{nameof(VisualStudioRepoAzdoUsername).ToLowerInvariant()} is required");
                     }
 
-                    if (string.IsNullOrEmpty(Password))
+                    if (string.IsNullOrEmpty(VisualStudioRepoAzdoPassword))
                     {
-                        builder.AppendLine($"{nameof(Password).ToLowerInvariant()} is required");
+                        builder.AppendLine($"{nameof(VisualStudioRepoAzdoPassword).ToLowerInvariant()} is required");
                     }
 
                     if (string.IsNullOrEmpty(VisualStudioBranchName))
@@ -478,14 +481,14 @@ namespace Roslyn.Insertion
                         builder.AppendLine($"{nameof(VisualStudioBranchName).ToLowerInvariant()} is required");
                     }
 
-                    if (string.IsNullOrEmpty(BuildQueueName))
+                    if (string.IsNullOrEmpty(ComponentBuildQueueName))
                     {
-                        builder.AppendLine($"{nameof(BuildQueueName).ToLowerInvariant()} is required");
+                        builder.AppendLine($"{nameof(ComponentBuildQueueName).ToLowerInvariant()} is required");
                     }
 
-                    if (string.IsNullOrEmpty(BranchName))
+                    if (string.IsNullOrEmpty(ComponentBranchName))
                     {
-                        builder.AppendLine($"{nameof(BranchName).ToLowerInvariant()} is required");
+                        builder.AppendLine($"{nameof(ComponentBranchName).ToLowerInvariant()} is required");
                     }
 
                     if (string.IsNullOrEmpty(BuildConfig))
@@ -493,14 +496,14 @@ namespace Roslyn.Insertion
                         builder.AppendLine($"{nameof(BuildConfig).ToLowerInvariant()} is required");
                     }
 
-                    if (string.IsNullOrEmpty(VisualStudioAzdoUri))
+                    if (string.IsNullOrEmpty(VisualStudioRepoAzdoUri))
                     {
-                        builder.AppendLine($"{nameof(VisualStudioAzdoUri).ToLowerInvariant()} is required");
+                        builder.AppendLine($"{nameof(VisualStudioRepoAzdoUri).ToLowerInvariant()} is required");
                     }
 
-                    if (string.IsNullOrEmpty(VisualStudioProjectName))
+                    if (string.IsNullOrEmpty(VisualStudioRepoProjectName))
                     {
-                        builder.AppendLine($"{nameof(VisualStudioProjectName).ToLowerInvariant()} is required");
+                        builder.AppendLine($"{nameof(VisualStudioRepoProjectName).ToLowerInvariant()} is required");
                     }
 
                     if (string.IsNullOrEmpty(BuildDropPath))

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionToolOptions.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionToolOptions.cs
@@ -35,13 +35,17 @@ namespace Roslyn.Insertion
         private RoslynInsertionToolOptions(
             string username,
             string password,
+            string buildUsername,
+            string buildPassword,
+            string visualStudioAzdoUri,
+            string visualStudioProjectName,
             string visualStudioBranchName,
+            string buildAzdoUri,
+            string buildProjectName,
             string buildQueueName,
             string branchName,
             string buildConfig,
-            string vstsUri,
-            string tfsProjectName,
-            string newBranchName,
+            string insertionBranchName,
             string buildDropPath,
             string specificBuild,
             bool insertCoreXTPackages,
@@ -69,13 +73,17 @@ namespace Roslyn.Insertion
         {
             Username = username;
             Password = password;
+            BuildUsername = buildUsername;
+            BuildPassword = buildPassword;
             VisualStudioBranchName = visualStudioBranchName;
             BuildQueueName = buildQueueName;
             BranchName = branchName;
             BuildConfig = buildConfig;
-            VSTSUri = vstsUri;
-            TFSProjectName = tfsProjectName;
-            NewBranchName = newBranchName;
+            VisualStudioAzdoUri = visualStudioAzdoUri;
+            VisualStudioProjectName = visualStudioProjectName;
+            BuildAzdoUri = buildAzdoUri;
+            BuildProjectName = buildProjectName;
+            InsertionBranchName = insertionBranchName;
             BuildDropPath = buildDropPath;
             SpecificBuild = specificBuild;
             InsertCoreXTPackages = insertCoreXTPackages;
@@ -105,13 +113,17 @@ namespace Roslyn.Insertion
         public RoslynInsertionToolOptions Update(
             Optional<string> username = default,
             Optional<string> password = default,
+            Optional<string> buildUsername = default,
+            Optional<string> buildPassword = default,
             Optional<string> visualStudioBranchName = default,
             Optional<string> buildQueueName = default,
             Optional<string> branchName = default,
             Optional<string> buildConfig = default,
             Optional<string> vstsUri = default,
-            Optional<string> tfsProjectName = default,
-            Optional<string> newBranchName = default,
+            Optional<string> visualStudioProjectName = default,
+            Optional<string> buildAzdoUri = default,
+            Optional<string> buildProjectName = default,
+            Optional<string> insertionBranchName = default,
             Optional<string> buildDropPath = default,
             Optional<string> specificBuild = default,
             Optional<bool> insertCoreXTPackages = default,
@@ -140,13 +152,17 @@ namespace Roslyn.Insertion
             return new RoslynInsertionToolOptions(
                 username: username.ValueOrFallback(Username),
                 password: password.ValueOrFallback(Password),
+                buildUsername: buildUsername.ValueOrFallback(BuildUsername),
+                buildPassword: buildPassword.ValueOrFallback(BuildPassword),
                 visualStudioBranchName: visualStudioBranchName.ValueOrFallback(VisualStudioBranchName),
                 buildQueueName: buildQueueName.ValueOrFallback(BuildQueueName),
                 branchName: branchName.ValueOrFallback(BranchName),
                 buildConfig: buildConfig.ValueOrFallback(BuildConfig),
-                vstsUri: vstsUri.ValueOrFallback(VSTSUri),
-                tfsProjectName: tfsProjectName.ValueOrFallback(TFSProjectName),
-                newBranchName: newBranchName.ValueOrFallback(NewBranchName),
+                visualStudioAzdoUri: vstsUri.ValueOrFallback(VisualStudioAzdoUri),
+                visualStudioProjectName: visualStudioProjectName.ValueOrFallback(VisualStudioProjectName),
+                buildAzdoUri: buildAzdoUri.ValueOrFallback(BuildAzdoUri),
+                buildProjectName: buildProjectName.ValueOrFallback(BuildProjectName),
+                insertionBranchName: insertionBranchName.ValueOrFallback(InsertionBranchName),
                 buildDropPath: buildDropPath.ValueOrFallback(BuildDropPath),
                 specificBuild: specificBuild.ValueOrFallback(SpecificBuild),
                 insertCoreXTPackages: insertCoreXTPackages.ValueOrFallback(InsertCoreXTPackages),
@@ -187,21 +203,29 @@ namespace Roslyn.Insertion
 
         public RoslynInsertionToolOptions WithUsername(string username) => Update(username: username);
 
+        public RoslynInsertionToolOptions WithBuildUsername(string buildUsername) => Update(buildUsername: buildUsername);
+
         public RoslynInsertionToolOptions WithPassword(string password) => Update(password: password);
+
+        public RoslynInsertionToolOptions WithBuildPassword(string buildPassword) => Update(buildPassword: buildPassword);
+
+        public RoslynInsertionToolOptions WithVisualStudioAzdoUri(string visualStudioAzdoUri) => Update(vstsUri: visualStudioAzdoUri);
+
+        public RoslynInsertionToolOptions WithVisualStudioProjectName(string visualStudioProjectName) => Update(visualStudioProjectName: visualStudioProjectName);
 
         public RoslynInsertionToolOptions WithVisualStudioBranchName(string visualStudioBranchName) => Update(visualStudioBranchName: visualStudioBranchName);
 
+        public RoslynInsertionToolOptions WithBuildAzdoUri(string buildAzdoUri) => Update(buildAzdoUri: buildAzdoUri);
+
+        public RoslynInsertionToolOptions WithBuildProjectName(string buildProjectName) => Update(buildProjectName: buildProjectName);
+
         public RoslynInsertionToolOptions WithBuildQueueName(string buildQueueName) => Update(buildQueueName: buildQueueName);
 
-        public RoslynInsertionToolOptions WithbranchName(string branchName) => Update(branchName: branchName);
+        public RoslynInsertionToolOptions WithBranchName(string branchName) => Update(branchName: branchName);
 
         public RoslynInsertionToolOptions WithBuildConfig(string buildConfig) => Update(buildConfig: buildConfig);
 
-        public RoslynInsertionToolOptions WithVSTSUrl(string vstsUri) => Update(vstsUri: vstsUri);
-
-        public RoslynInsertionToolOptions WithTFSProjectName(string tfsProjectName) => Update(tfsProjectName: tfsProjectName);
-
-        public RoslynInsertionToolOptions WithNewBranchName(string newBranchName) => Update(newBranchName: newBranchName);
+        public RoslynInsertionToolOptions WithInsertionBranchName(string insertionBranchName) => Update(insertionBranchName: insertionBranchName);
 
         public RoslynInsertionToolOptions WithBuildDropPath(string buildDropPath) => Update(buildDropPath: buildDropPath);
 
@@ -243,7 +267,19 @@ namespace Roslyn.Insertion
 
         public string Password { get; }
 
+        public string BuildUsername { get; }
+
+        public string BuildPassword { get; }
+
+        public string VisualStudioAzdoUri { get; }
+
+        public string VisualStudioProjectName { get; }
+
         public string VisualStudioBranchName { get; }
+
+        public string BuildAzdoUri { get; }
+
+        public string BuildProjectName { get; }
 
         public string BuildQueueName { get; }
 
@@ -251,11 +287,7 @@ namespace Roslyn.Insertion
 
         public string BuildConfig { get; }
 
-        public string VSTSUri { get; }
-
-        public string TFSProjectName { get; }
-
-        public string NewBranchName { get; }
+        public string InsertionBranchName { get; }
 
         public string BuildDropPath { get; }
 
@@ -309,6 +341,12 @@ namespace Roslyn.Insertion
         {
             get
             {
+                if (BuildAzdoUri != null && (BuildUsername is null || BuildPassword is null))
+                {
+                    // When the Build AzDO instance is separate from the VS AzDO instance, separate credentials must be specified.
+                    return false;
+                }
+
                 if (CreateDummyPr)
                 {
                     // only InsertionName and VisualStudioBranchName are required for creating a dummy pr
@@ -339,8 +377,8 @@ namespace Roslyn.Insertion
                         !string.IsNullOrEmpty(BuildQueueName) &&
                         !string.IsNullOrEmpty(BranchName) &&
                         !string.IsNullOrEmpty(BuildConfig) &&
-                        !string.IsNullOrEmpty(VSTSUri) &&
-                        !string.IsNullOrEmpty(TFSProjectName) &&
+                        !string.IsNullOrEmpty(VisualStudioAzdoUri) &&
+                        !string.IsNullOrEmpty(VisualStudioProjectName) &&
                         !string.IsNullOrEmpty(BuildDropPath);
                 }
             }
@@ -351,6 +389,19 @@ namespace Roslyn.Insertion
             get
             {
                 var builder = new StringBuilder();
+
+                if (BuildAzdoUri != VisualStudioAzdoUri)
+                {
+                    if (BuildUsername is null)
+                    {
+                        builder.AppendLine($"When {nameof(BuildAzdoUri)} is specified you must also specify the {nameof(BuildUsername)}.");
+                    }
+
+                    if (BuildPassword is null)
+                    {
+                        builder.AppendLine($"When {nameof(BuildAzdoUri)} is specified you must also specify the {nameof(BuildPassword)}.");
+                    }
+                }
 
                 if (CreateDummyPr)
                 {
@@ -442,14 +493,14 @@ namespace Roslyn.Insertion
                         builder.AppendLine($"{nameof(BuildConfig).ToLowerInvariant()} is required");
                     }
 
-                    if (string.IsNullOrEmpty(VSTSUri))
+                    if (string.IsNullOrEmpty(VisualStudioAzdoUri))
                     {
-                        builder.AppendLine($"{nameof(VSTSUri).ToLowerInvariant()} is required");
+                        builder.AppendLine($"{nameof(VisualStudioAzdoUri).ToLowerInvariant()} is required");
                     }
 
-                    if (string.IsNullOrEmpty(TFSProjectName))
+                    if (string.IsNullOrEmpty(VisualStudioProjectName))
                     {
-                        builder.AppendLine($"{nameof(TFSProjectName).ToLowerInvariant()} is required");
+                        builder.AppendLine($"{nameof(VisualStudioProjectName).ToLowerInvariant()} is required");
                     }
 
                     if (string.IsNullOrEmpty(BuildDropPath))


### PR DESCRIPTION
This allows RIT to query builds from an AzDO instance (`BuildConnection`) that is not the AzDO (`VSConnection`) the VS insertion will be created in. Specifying a separate connection is not necessary and by default the VSConnection will be used for both purposes. 

Updated option names and methods to better distinguish whether the VSConnection or the BuildConnection should be used. 