### PR TITLE
Resume dev17 codeflow

### DIFF
--- a/src/GitHubCreateMergePRs/config.xml
+++ b/src/GitHubCreateMergePRs/config.xml
@@ -11,11 +11,11 @@
 
     <!-- Roslyn non-vs-deps branches (flowing between releases) -->
     <merge from="release/dev16.10" to="main" />
-    <!--merge from="main" to="release/dev17.0" /-->
+    <merge from="main" to="release/dev17.0" />
 
     <!-- Roslyn vs-deps branches (flowing between releases) -->
     <merge from="release/dev16.10-vs-deps" to="main-vs-deps" />
-    <!--merge from="main-vs-deps" to="release/dev17.0-vs-deps" /-->
+    <merge from="main-vs-deps" to="release/dev17.0-vs-deps" />
 
     <!-- Roslyn branches (from non-vs-deps to vs-deps) -->
     <merge from="release/dev16.10" to="release/dev16.10-vs-deps" />

--- a/src/GitHubCreateMergePRs/config.xml
+++ b/src/GitHubCreateMergePRs/config.xml
@@ -16,6 +16,7 @@
     <!-- Roslyn vs-deps branches (flowing between releases) -->
     <merge from="release/dev16.10-vs-deps" to="main-vs-deps" />
     <merge from="main-vs-deps" to="release/dev17.0-vs-deps" />
+    <merge from="release/dev17.0-preview1-vs-deps" to="release/dev17.0-vs-deps" />      
 
     <!-- Roslyn branches (from non-vs-deps to vs-deps) -->
     <merge from="release/dev16.10" to="release/dev16.10-vs-deps" />


### PR DESCRIPTION
Now release/dev17.0 is targeting preview 2, we should resume the codeflow from main.

@sharwell @JoeRobich @dibarbet 