### PR TITLE
Generate commit log for AzDO repos

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/RoslynInsertionToolCommandline.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/RoslynInsertionToolCommandline.cs
@@ -290,7 +290,7 @@ partial class RoslynInsertionToolCommandline
             {
                 Console.Error.WriteLine("No password provided and no client secret for KeyVault provided.");
                 Console.Error.WriteLine("If you want to develop the tool locally, do the following:");
-                Console.Error.WriteLine("1. Go to https://devdiv.visualstudio.com/_usersSettings/tokens and generate a token.");
+                Console.Error.WriteLine("1. Go to https://devdiv.visualstudio.com/_usersSettings/tokens and generate a token with the following scopes: vso.build_execute,vso.code_full,vso.release_execute,vso.packaging");
                 Console.Error.WriteLine("2. Add the command line arguments `/username=myusername@microsoft.com /password=myauthtoken`");
                 return false;
             }
@@ -316,8 +316,8 @@ partial class RoslynInsertionToolCommandline
             {
                 Console.Error.WriteLine("No password provided and no client secret for KeyVault provided.");
                 Console.Error.WriteLine("If you want to develop the tool locally, do the following:");
-                Console.Error.WriteLine("1. Go to https://devdiv.visualstudio.com/_usersSettings/tokens and generate a token.");
-                Console.Error.WriteLine("2. Add the command line arguments `/username=myusername@microsoft.com /password=myauthtoken`");
+                Console.Error.WriteLine("1. Go to https://dnceng.visualstudio.com/_usersSettings/tokens and generate a token with the following scopes: vso.build_execute,vso.code_full,vso.release_execute,vso.packaging");
+                Console.Error.WriteLine("2. Add the command line arguments `/componentbuildazdousername=myusername@microsoft.com /componentbuildazdopassword=myauthtoken`");
                 return false;
             }
         }

--- a/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/RoslynInsertionToolCommandline.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/RoslynInsertionToolCommandline.cs
@@ -301,7 +301,7 @@ partial class RoslynInsertionToolCommandline
             }
         }
 
-        if (string.IsNullOrEmpty(options.ComponentBuildAzdoPassword))
+        if (!string.IsNullOrEmpty(options.ComponentBuildAzdoUri) && string.IsNullOrEmpty(options.ComponentBuildAzdoPassword))
         {
             if (!string.IsNullOrEmpty(options.ClientId) && !string.IsNullOrEmpty(options.ClientSecret))
             {

--- a/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/RoslynInsertionToolCommandline.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/RoslynInsertionToolCommandline.cs
@@ -117,6 +117,11 @@ partial class RoslynInsertionToolCommandline
                 componentBranchName => options = options.WithComponentBranchName(componentBranchName)
             },
             {
+                "componentgithubreponame=",
+                "The github repo name that hosts the component's source code.",
+                componentGitHubRepoName => options = options.WithComponentGitHubRepoName(componentGitHubRepoName)
+            },
+            {
                 "nbn=|newbranchname=|insertionbranchname=",
                 $"The name of the branch we create when staging our insertion. Will have the current date and insertion branch appended to it. If empty a new branch and pull request are not created (for local testing purposes only). Defaults to \"{options.InsertionBranchName}\".",
                 insertionBranchName => options = options.WithInsertionBranchName(insertionBranchName)

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
@@ -14,11 +14,13 @@ using System.Threading.Tasks;
 
 using Microsoft.TeamFoundation.Build.WebApi;
 using Microsoft.TeamFoundation.Client;
+using Microsoft.TeamFoundation.Client.Reporting;
 using Microsoft.TeamFoundation.Policy.WebApi;
 using Microsoft.TeamFoundation.SourceControl.WebApi;
 using Microsoft.VisualStudio.Services.Common;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Task = System.Threading.Tasks.Task;
 
 namespace Roslyn.Insertion
 {
@@ -552,27 +554,69 @@ namespace Roslyn.Insertion
 
         internal static async Task<(List<GitCommit> changes, string diffLink)> GetChangesBetweenBuildsAsync(Build fromBuild, Build tobuild, CancellationToken cancellationToken)
         {
-            var repoId = tobuild.Repository.Id; // e.g. dotnet/roslyn when GitHub, 7b863b8d-8cc3-431d-b06b-7136cc32bbe6 when AzDO
+            var repoId = !string.IsNullOrEmpty(Options.ComponentGitHubRepoName)
+                ? Options.ComponentGitHubRepoName
+                : tobuild.Repository.Id; // e.g. dotnet/roslyn when GitHub, 7b863b8d-8cc3-431d-b06b-7136cc32bbe6 when AzDO
 
             var fromSHA = fromBuild.SourceVersion;
             var toSHA = tobuild.SourceVersion;
 
-            if (tobuild.Repository.Type == "GitHub")
+            if (tobuild.Repository.Type == "GitHub" || !string.IsNullOrEmpty(Options.ComponentGitHubRepoName))
             {
+                return await GetChangesBetweenBuildsFromGitHubAsync(repoId, fromSHA, toSHA);
+            }
+            else if (tobuild.Repository.Type == "TfsGit")
+            {
+                return await GetChangesBetweenBuildsFromAzDOAsync(tobuild, repoId, fromSHA, toSHA);
+            }
 
-                var restEndpoint = $"https://api.github.com/repos/{repoId}/compare/{fromSHA}...{toSHA}";
-                var client = new HttpClient();
-                var request = new HttpRequestMessage(HttpMethod.Get, restEndpoint);
-                request.Headers.Add("User-Agent", "RoslynInsertionTool");
+            throw new NotSupportedException("Only builds created from GitHub & AzDO repos support enumerating commits.");
+        }
 
-                var response = await client.SendAsync(request);
-                var content = await response.Content.ReadAsStringAsync();
-
-                // https://developer.github.com/v3/repos/commits/
-                var data = JsonConvert.DeserializeAnonymousType(content, new
+        private static async Task<(List<GitCommit> changes, string diffLink)> GetChangesBetweenBuildsFromAzDOAsync(Build tobuild, string repoId, string fromSHA, string toSHA)
+        {
+            var gitClient = ComponentBuildConnection.GetClient<GitHttpClient>();
+            var getCommits = (await gitClient.GetCommitsAsync(
+                repoId,
+                new GitQueryCommitsCriteria()
                 {
-                    commits = new[]
+                    ItemVersion = new GitVersionDescriptor() { Version = fromSHA, VersionType = GitVersionType.Commit },
+                    CompareVersion = new GitVersionDescriptor() { Version = toSHA, VersionType = GitVersionType.Commit }
+                }))
+                // AzDO does not provide the full commit message, so we must query for each commit to provide better messages for PR merge commits.
+                .Select(c => gitClient.GetCommitAsync(c.CommitId, repoId));
+            var commits = (await Task.WhenAll(getCommits))
+                .Select(c =>
+                    new GitCommit()
                     {
+                        Author = c.Author.Name,
+                        Committer = c.Committer.Name,
+                        CommitDate = c.Committer.Date,
+                        Message = c.Comment,
+                        CommitId = c.CommitId,
+                        RemoteUrl = c.Links.Links["web"].ToString()
+                    })
+                .ToList();
+
+            // AzDO does not have a UI for comparing two commits. Instead generate the REST API call to retrieve commits between two SHAs.
+            return (commits, $"{tobuild.Repository.Url.OriginalString.Replace("_git", "_apis/git/repositories")}/commits?searchCriteria.itemVersion.version={fromSHA}&searchCriteria.itemVersion.versionType=commit&searchCriteria.compareVersion.version={toSHA}&searchCriteria.compareVersion.versionType=commit");
+        }
+
+        private static async Task<(List<GitCommit> changes, string diffLink)> GetChangesBetweenBuildsFromGitHubAsync(string repoId, string fromSHA, string toSHA)
+        {
+            var restEndpoint = $"https://api.github.com/repos/{repoId}/compare/{fromSHA}...{toSHA}";
+            var client = new HttpClient();
+            var request = new HttpRequestMessage(HttpMethod.Get, restEndpoint);
+            request.Headers.Add("User-Agent", "RoslynInsertionTool");
+
+            var response = await client.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+
+            // https://developer.github.com/v3/repos/commits/
+            var data = JsonConvert.DeserializeAnonymousType(content, new
+            {
+                commits = new[]
+                {
                         new
                         {
                             sha = "",
@@ -593,60 +637,25 @@ namespace Roslyn.Insertion
                             html_url = ""
                         }
                     }
-                });
+            });
 
-                var result = data.commits
-                    .Select(d =>
-                        new GitCommit()
-                        {
-                            Author = d.commit.author.name,
-                            Committer = d.commit.committer.name,
-                            CommitDate = DateTime.Parse(d.commit.author.date),
-                            Message = d.commit.message,
-                            CommitId = d.sha,
-                            RemoteUrl = d.html_url
-                        })
-                    // show HEAD first, base last
-                    .Reverse()
-                    .ToList();
-
-                return (result, $"//github.com/{repoId}/compare/{fromSHA}...{toSHA}?w=1");
-            }
-            else if (tobuild.Repository.Type == "TfsGit")
-            {
-                var gitClient = ComponentBuildConnection.GetClient<GitHttpClient>();
-                var getCommits = (await gitClient.GetCommitsAsync(
-                    repoId,
-                    new GitQueryCommitsCriteria()
+            var result = data.commits
+                .Select(d =>
+                    new GitCommit()
                     {
-                        ItemVersion = new GitVersionDescriptor() { Version = fromSHA, VersionType = GitVersionType.Commit },
-                        CompareVersion = new GitVersionDescriptor() { Version = toSHA, VersionType = GitVersionType.Commit }
-                    }))
-                    // AzDO does not provide the full commit message, so we must query for each commit to provide better messages for PR merge commits.
-                    .Select(c => gitClient.GetCommitAsync(c.CommitId, repoId));
-                var commits = (await Task.WhenAll(getCommits))
-                    .Select(c =>
-                        new GitCommit()
-                        {
-                            Author = c.Author.Name,
-                            Committer = c.Committer.Name,
-                            CommitDate = c.Committer.Date,
-                            Message = c.Comment,
-                            CommitId = c.CommitId,
-                            RemoteUrl = c.RemoteUrl
-                        })
-                    .ToList();
+                        Author = d.commit.author.name,
+                        Committer = d.commit.committer.name,
+                        CommitDate = DateTime.Parse(d.commit.author.date),
+                        Message = d.commit.message,
+                        CommitId = d.sha,
+                        RemoteUrl = d.html_url
+                    })
+                // show HEAD first, base last
+                .Reverse()
+                .ToList();
 
-                // AzDO does not have a UI for comparing two commits. Instead generate the REST API call to retrieve commits between two SHAs.
-                return (commits, $"{tobuild.Repository.Url.OriginalString.Replace("_git", "_apis/git/repositories")}/commits?searchCriteria.itemVersion.version={fromSHA}&searchCriteria.itemVersion.versionType=commit&searchCriteria.compareVersion.version={toSHA}&searchCriteria.compareVersion.versionType=commit");
-            }
-
-            throw new NotSupportedException("Only builds created from GitHub repos support enumerating commits.");
+            return (result, $"//github.com/{repoId}/compare/{fromSHA}...{toSHA}?w=1");
         }
-
-        private static readonly Regex IsReleaseFlowCommit = new Regex(@"^Merge pull request #\d+ from dotnet/merges/");
-        private static readonly Regex IsMergePRCommit = new Regex(@"^Merge pull request #(\d+) from");
-        private static readonly Regex IsSquashedPRCommit = new Regex(@"\(#(\d+)\)(?:\n|$)");
 
         internal static string AppendChangesToDescription(string prDescription, Build oldBuild, List<GitCommit> changes)
         {
@@ -659,7 +668,121 @@ namespace Roslyn.Insertion
 
             var description = new StringBuilder(prDescription + Environment.NewLine);
 
-            var repoURL = $"//github.com/{oldBuild.Repository.Id}";
+            var repoId = !string.IsNullOrEmpty(Options.ComponentGitHubRepoName)
+                ? Options.ComponentGitHubRepoName
+                : oldBuild.Repository.Id; // e.g. dotnet/roslyn when GitHub, 7b863b8d-8cc3-431d-b06b-7136cc32bbe6 when AzDO
+
+            if (oldBuild.Repository.Type == "GitHub" || !string.IsNullOrEmpty(Options.ComponentGitHubRepoName))
+            {
+                AppendGitHubChangesToDescription(changes, hardLimit, description, repoId);
+            }
+            else if (oldBuild.Repository.Type == "TfsGit")
+            {
+                AppendAzDOChangesToDescription(oldBuild, changes, hardLimit, description);
+            }
+
+            var result = description.ToString();
+            if (result.Length > hardLimit)
+            {
+                LogWarning($"PR description is {result.Length} characters long, but the limit is {hardLimit}.");
+                LogWarning(result);
+            }
+
+            return result;
+        }
+
+        private static readonly Regex IsAzDOMergePRCommit = new Regex(@"^Merged PR (\d+):");
+        public static string GetAzDOPullRequestUrl(string repoURL, string prNumber)
+            => $"{repoURL}/pullrequest/{prNumber}";
+
+        private static void AppendAzDOChangesToDescription(Build oldBuild, List<GitCommit> changes, int hardLimit, StringBuilder description)
+        {
+            var repoURL = oldBuild.Repository.Url.AbsoluteUri;
+
+            var commitHeaderAdded = false;
+            var mergePRHeaderAdded = false;
+            var mergePRFound = false;
+
+            // This needs to be updated with heuristics for determining merge commits which represent PRs being merged.
+            foreach (var commit in changes)
+            {
+                // Exclude arcade dependency updates
+                if (commit.Author == "DotNet Bot")
+                {
+                    mergePRFound = true;
+                    continue;
+                }
+
+                // Merge PR Messages are in the form "Merged PR 320820: Resolving encoding issue on test summary pane, using UTF8 now\n\nAdded a StreamWriterWrapper to resolve encoding issue"
+                string comment = commit.Message.Split('\n')[0];
+                string prNumber = string.Empty;
+
+                var match = IsAzDOMergePRCommit.Match(commit.Message);
+                if (match.Success)
+                {
+                    prNumber = match.Groups[1].Value;
+                    mergePRFound = true;
+                }
+                else
+                {
+                    // Todo: Determine if there is a format for AzDO squash merges that preserves the PR #
+                }
+
+                // We will print commit comments until we find the first merge PR
+                if (!match.Success && mergePRFound)
+                {
+                    continue;
+                }
+
+                string prLink;
+
+                if (match.Success)
+                {
+                    if (commitHeaderAdded && !mergePRHeaderAdded)
+                    {
+                        mergePRHeaderAdded = true;
+                        description.AppendLine("### Merged PRs:");
+                    }
+
+                    prLink = $@"- [{comment}]({GetAzDOPullRequestUrl(repoURL, prNumber)})";
+                }
+                else
+                {
+                    if (!commitHeaderAdded)
+                    {
+                        commitHeaderAdded = true;
+                        description.AppendLine("### Commits since last PR:");
+                    }
+
+                    var shortSHA = commit.CommitId.Substring(0, 7);
+                    prLink = $@"- [{comment} ({shortSHA})]({commit.RemoteUrl})";
+                }
+
+                const string limitMessage = "Changelog truncated due to description length limit.";
+
+                // we want to be able to fit this PR link, as well as the limit message (plus line breaks) in case the next PR link doesn't fit
+                int limit = hardLimit - (prLink.Length + Environment.NewLine.Length) - (limitMessage.Length + Environment.NewLine.Length);
+                if (description.Length > limit)
+                {
+                    description.AppendLine(limitMessage);
+                    break;
+                }
+                else
+                {
+                    description.AppendLine(prLink);
+                }
+            }
+        }
+
+        private static readonly Regex IsGitHubReleaseFlowCommit = new Regex(@"^Merge pull request #\d+ from dotnet/merges/");
+        private static readonly Regex IsGitHubMergePRCommit = new Regex(@"^Merge pull request #(\d+) from");
+        private static readonly Regex IsGitHubSquashedPRCommit = new Regex(@"\(#(\d+)\)(?:\n|$)");
+        public static string GetGitHubPullRequestUrl(string repoURL, string prNumber)
+            => $"{repoURL}/pull/{prNumber}";
+
+        private static void AppendGitHubChangesToDescription(List<GitCommit> changes, int hardLimit, StringBuilder description, string repoId)
+        {
+            var repoURL = $"//github.com/{repoId}";
 
             var commitHeaderAdded = false;
             var mergePRHeaderAdded = false;
@@ -681,7 +804,7 @@ namespace Roslyn.Insertion
                 }
 
                 // Exclude merge commits from auto code-flow PRs (e.g. merges/main-to-main-vs-deps)
-                if (IsReleaseFlowCommit.Match(commit.Message).Success)
+                if (IsGitHubReleaseFlowCommit.Match(commit.Message).Success)
                 {
                     mergePRFound = true;
                     continue;
@@ -690,7 +813,7 @@ namespace Roslyn.Insertion
                 string comment = string.Empty;
                 string prNumber = string.Empty;
 
-                var match = IsMergePRCommit.Match(commit.Message);
+                var match = IsGitHubMergePRCommit.Match(commit.Message);
                 if (match.Success)
                 {
                     prNumber = match.Groups[1].Value;
@@ -704,7 +827,7 @@ namespace Roslyn.Insertion
                 }
                 else
                 {
-                    match = IsSquashedPRCommit.Match(commit.Message);
+                    match = IsGitHubSquashedPRCommit.Match(commit.Message);
                     if (match.Success)
                     {
                         prNumber = match.Groups[1].Value;
@@ -769,19 +892,7 @@ namespace Roslyn.Insertion
                     description.AppendLine(prLink);
                 }
             }
-
-            var result = description.ToString();
-            if (result.Length > hardLimit)
-            {
-                LogWarning($"PR description is {result.Length} characters long, but the limit is {hardLimit}.");
-                LogWarning(result);
-            }
-
-            return result;
         }
-
-        public static string GetGitHubPullRequestUrl(string repoURL, string prNumber)
-            => $"{repoURL}/pull/{prNumber}";
 
         internal struct GitCommit
         {

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
@@ -691,6 +691,7 @@ namespace Roslyn.Insertion
             return result;
         }
 
+        private static readonly Regex IsAzDOReleaseFlowCommit = new Regex(@"^Merged PR \d+: Merging .* to ");
         private static readonly Regex IsAzDOMergePRCommit = new Regex(@"^Merged PR (\d+):");
         public static string GetAzDOPullRequestUrl(string repoURL, string prNumber)
             => $"{repoURL}/pullrequest/{prNumber}";
@@ -708,6 +709,20 @@ namespace Roslyn.Insertion
             {
                 // Exclude arcade dependency updates
                 if (commit.Author == "DotNet Bot")
+                {
+                    mergePRFound = true;
+                    continue;
+                }
+
+                // Exclude OneLoc localization PRs
+                if (commit.Author == "Project Collection Build Service (devdiv)")
+                {
+                    mergePRFound = true;
+                    continue;
+                }
+
+                // Exclude merge commits from auto code-flow PRs (e.g. main to Dev17)
+                if (IsAzDOReleaseFlowCommit.Match(commit.Message).Success)
                 {
                     mergePRFound = true;
                     continue;

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionToolOptions.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionToolOptions.cs
@@ -44,6 +44,7 @@ namespace Roslyn.Insertion
             string componentBuildProjectName,
             string componentBuildQueueName,
             string componentBranchName,
+            string componentGitHubRepoName,
             string buildConfig,
             string insertionBranchName,
             string buildDropPath,
@@ -82,6 +83,7 @@ namespace Roslyn.Insertion
             ComponentBuildProjectName = componentBuildProjectName;
             ComponentBuildQueueName = componentBuildQueueName;
             ComponentBranchName = componentBranchName;
+            ComponentGitHubRepoName = componentGitHubRepoName;
             BuildConfig = buildConfig;
             InsertionBranchName = insertionBranchName;
             BuildDropPath = buildDropPath;
@@ -122,6 +124,7 @@ namespace Roslyn.Insertion
             Optional<string> componentBuildProjectName = default,
             Optional<string> componentBuildQueueName = default,
             Optional<string> componentBranchName = default,
+            Optional<string> componentGitHubRepoName = default,
             Optional<string> buildConfig = default,
             Optional<string> insertionBranchName = default,
             Optional<string> buildDropPath = default,
@@ -161,6 +164,7 @@ namespace Roslyn.Insertion
                 componentBuildProjectName: componentBuildProjectName.ValueOrFallback(ComponentBuildProjectName),
                 componentBuildQueueName: componentBuildQueueName.ValueOrFallback(ComponentBuildQueueName),
                 componentBranchName: componentBranchName.ValueOrFallback(ComponentBranchName),
+                componentGitHubRepoName: componentGitHubRepoName.ValueOrFallback(ComponentGitHubRepoName),
                 buildConfig: buildConfig.ValueOrFallback(BuildConfig),
                 insertionBranchName: insertionBranchName.ValueOrFallback(InsertionBranchName),
                 buildDropPath: buildDropPath.ValueOrFallback(BuildDropPath),
@@ -222,6 +226,8 @@ namespace Roslyn.Insertion
         public RoslynInsertionToolOptions WithComponentBuildQueueName(string componentBuildQueueName) => Update(componentBuildQueueName: componentBuildQueueName);
 
         public RoslynInsertionToolOptions WithComponentBranchName(string componentBranchName) => Update(componentBranchName: componentBranchName);
+
+        public RoslynInsertionToolOptions WithComponentGitHubRepoName(string componentGitHubRepoName) => Update(componentGitHubRepoName: componentGitHubRepoName);
 
         public RoslynInsertionToolOptions WithBuildConfig(string buildConfig) => Update(buildConfig: buildConfig);
 
@@ -287,6 +293,8 @@ namespace Roslyn.Insertion
         public string ComponentBuildQueueName { get; }
 
         public string ComponentBranchName { get; }
+
+        public string ComponentGitHubRepoName { get; }
 
         public string BuildConfig { get; }
 

--- a/src/RoslynInsertionTool/scripts/HelperFunctions.ps1
+++ b/src/RoslynInsertionTool/scripts/HelperFunctions.ps1
@@ -29,6 +29,14 @@ function GetComponentProjectName([string] $componentProjectName) {
     }
 }
 
+function GetComponentGitHubRepoName([string] $componentGitHubRepoName) {
+    if (IsDefaultValue $componentGitHubRepoName) {
+      return ""
+    } else {
+      return "/componentgithubreponame=$componentGitHubRepoName"
+    }
+}
+
 function GetComponentUserName([string] $componentAzdoUri) {
     if (IsDefaultValue $componentAzdoUri) {
         return ""

--- a/src/RoslynInsertionTool/scripts/OneOffInsertion.ps1
+++ b/src/RoslynInsertionTool/scripts/OneOffInsertion.ps1
@@ -7,6 +7,7 @@ param([string] $clientId,
       [string] $componentProjectName,
       [string] $componentBranchName,
       [string] $componentName,
+      [string] $componentGitHubRepoName,
       [string] $dropPath,
       [string] $insertCore,
       [string] $insertDevDiv,
@@ -31,6 +32,7 @@ EnsureRequiredValue -friendlyName "VisualStudioBranchName" -value $visualStudioB
 
 $componentAzdoUri = GetComponentAzdoUri -componentAzdoUri $componentAzdoUri
 $componentProjectName = GetComponentProjectName -componentProjectName $componentProjectName
+$componentGitHubRepoName = GetComponentGitHubRepoName -componentGitHubRepoName $componentGitHubRepoName
 $componentUserName = GetComponentUserName -componentAzdoUri $componentAzdoUri
 $buildQueueName = GetBuildQueueName -componentName $componentName -buildQueueName $buildQueueName
 $dropPathFlag = GetDropPathFlag -componentName $componentName -dropPath $dropPath
@@ -50,5 +52,5 @@ if ($insertionCount -lt 1) {
 }
 
 for ($i = 0; $i -lt $insertionCount; $i++) {
-    & $PSScriptRoot\RIT.exe  "/in=$componentName" "/bn=$componentBranchName" "/bq=$buildQueueName" "/vsbn=$visualStudioBranchName" "/ic=$insertCore" "/id=$insertDevDiv" "/qv=$queueValidation" "/ua=$updateAssemblyVersions" "/uc=$updateCoreXTLibraries" "/u=vslsnap@microsoft.com" "/ci=$clientId" "/cs=$clientSecret" "/tp=$titlePrefix" "/wpr=$writePullRequest" "/ac=$autoComplete" "/dpr=$createDraftPR" $specificBuildFlag $toolsetFlag $dropPathFlag $cherryPick $componentAzdoUri $componentProjectName $componentUserName
+    & $PSScriptRoot\RIT.exe  "/in=$componentName" "/bn=$componentBranchName" "/bq=$buildQueueName" "/vsbn=$visualStudioBranchName" "/ic=$insertCore" "/id=$insertDevDiv" "/qv=$queueValidation" "/ua=$updateAssemblyVersions" "/uc=$updateCoreXTLibraries" "/u=vslsnap@microsoft.com" "/ci=$clientId" "/cs=$clientSecret" "/tp=$titlePrefix" "/wpr=$writePullRequest" "/ac=$autoComplete" "/dpr=$createDraftPR" $specificBuildFlag $toolsetFlag $dropPathFlag $cherryPick $componentAzdoUri $componentProjectName $componentGitHubRepoName $componentUserName
 }

--- a/src/RoslynInsertionTool/scripts/UpdateExistingPr.ps1
+++ b/src/RoslynInsertionTool/scripts/UpdateExistingPr.ps1
@@ -7,6 +7,7 @@ param([string] $clientId,
       [string] $componentProjectName,
       [string] $componentBranchName,
       [string] $componentName,
+      [string] $componentGitHubRepoName,
       [string] $dropPath,
       [string] $existingPr,
       [string] $insertCore,
@@ -31,6 +32,7 @@ EnsureRequiredValue -friendlyName "ExistingPR" -value $existingPr
 
 $componentAzdoUri = GetComponentAzdoUri -componentAzdoUri $componentAzdoUri
 $componentProjectName = GetComponentProjectName -componentProjectName $componentProjectName
+$componentGitHubRepoName = GetComponentGitHubRepoName -componentGitHubRepoName $componentGitHubRepoName
 $componentUserName = GetComponentUserName -componentAzdoUri $componentAzdoUri
 $buildQueueName = GetBuildQueueName -componentName $componentName -buildQueueName $buildQueueName
 $dropPathFlag = GetDropPathFlag -componentName $componentName -dropPath $dropPath
@@ -49,4 +51,4 @@ if($overwritePR)
   $overwritePrflag = "/overwritepr"
 }
 
-& $PSScriptRoot\RIT.exe "/in=$componentName" "/bn=$componentBranchName" "/bq=$buildQueueName" "/vsbn=$visualStudioBranchName" "/ic=$insertCore" "/id=$insertDevDiv" "/qv=$queueValidation" "/updateexistingpr=$existingPr" $overwritePrflag "/ua=$updateAssemblyVersions" "/uc=$updateCoreXTLibraries" "/u=vslsnap@microsoft.com" "/ci=$clientId" "/cs=$clientSecret" "/wpr=$writePullRequest" "/ac=$autoComplete" "/dpr=$createDraftPR" $specificBuildFlag $toolsetFlag $dropPathFlag $componentAzdoUri $componentProjectName $componentUserName
+& $PSScriptRoot\RIT.exe "/in=$componentName" "/bn=$componentBranchName" "/bq=$buildQueueName" "/vsbn=$visualStudioBranchName" "/ic=$insertCore" "/id=$insertDevDiv" "/qv=$queueValidation" "/updateexistingpr=$existingPr" $overwritePrflag "/ua=$updateAssemblyVersions" "/uc=$updateCoreXTLibraries" "/u=vslsnap@microsoft.com" "/ci=$clientId" "/cs=$clientSecret" "/wpr=$writePullRequest" "/ac=$autoComplete" "/dpr=$createDraftPR" $specificBuildFlag $toolsetFlag $dropPathFlag $componentAzdoUri $componentProjectName $componentGitHubRepoName $componentUserName


### PR DESCRIPTION
Add new command line argument for specifying a GitHub repo name for the component being inserted. This allows us to generate a commit log for components that live on GitHub but build from an AzDO mirror.
Adds simple support for generating a commit log for components that live and build from AzDO repos.