### PR TITLE
Mapping dnceng repo to github id

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
@@ -632,9 +632,14 @@ namespace Roslyn.Insertion
                 return prDescription;
             }
 
+
             var description = new StringBuilder(prDescription + Environment.NewLine);
 
-            var repoURL = $"//github.com/{oldBuild.Repository.Id}";
+            var repoId = oldBuild.Repository.Type == "GitHub"
+                ? oldBuild.Repository.Id
+                : dncengRepoNameToGitHubId[oldBuild.Repository.Name];
+
+            var repoURL = $"//github.com/{repoId}";
 
             var commitHeaderAdded = false;
             var mergePRHeaderAdded = false;

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
@@ -632,6 +632,10 @@ namespace Roslyn.Insertion
                 return prDescription;
             }
 
+            if (oldBuild.Repository.Type != "Github" && Options.ComponentBuildProjectName != "internal")
+            {
+                return prDescription;
+            }
 
             var description = new StringBuilder(prDescription + Environment.NewLine);
 


### PR DESCRIPTION
After we moved to dnceng, the diff change list is broken.

For example: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/VS/pullrequest/327472

The reason is, dnceng build from a minor of Roslyn, instead of Roslyn in Github. And our old code is supposing always get result from Github.

After this change:
https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/327644
