### PR TITLE
Add SkipCoreXTPackages option

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/App.config
+++ b/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/App.config
@@ -88,7 +88,7 @@
         <value>https://devdiv.visualstudio.com/DefaultCollection</value>
       </setting>
       <setting name="SkipCoreXTPackages" serializeAs="String">
-        <value>VS.Tools.Roslyn</value>
+        <value />
       </setting>
     </RoslynInsertionTool.Settings>
   </applicationSettings>

--- a/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/App.config
+++ b/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/App.config
@@ -87,6 +87,9 @@
       <setting name="VisualStudioRepoAzdoUri" serializeAs="String">
         <value>https://devdiv.visualstudio.com/DefaultCollection</value>
       </setting>
+      <setting name="SkipCoreXTPackages" serializeAs="String">
+        <value>VS.Tools.Roslyn</value>
+      </setting>
     </RoslynInsertionTool.Settings>
   </applicationSettings>
 </configuration>

--- a/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/RoslynInsertionToolCommandline.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/RoslynInsertionToolCommandline.cs
@@ -250,7 +250,7 @@ partial class RoslynInsertionToolCommandline
             },
             {
                 "skipcorextpackages=",
-                $"An optional comma-separated list of CoreXT packages to be skipped when inserting/updating. Defaults to \"{string.Join(",", options.SkipCoreXTPackages)}\".",
+                $"An optional comma-separated list of CoreXT packages to be skipped when inserting/updating.",
                 skipCoreXTPackages => options = options.WithSkipCoreXTPackages(skipCoreXTPackages)
             },
         };

--- a/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/RoslynInsertionToolCommandline.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/RoslynInsertionToolCommandline.cs
@@ -14,7 +14,6 @@ using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Mono.Options;
 
 using Roslyn.Insertion;
-
 using static Roslyn.Insertion.RoslynInsertionTool;
 
 partial class RoslynInsertionToolCommandline
@@ -42,7 +41,8 @@ partial class RoslynInsertionToolCommandline
             .WithRunDDRITsInValidation(settings.RunDDRITsInValidation)
             .WithRunRPSInValidation(settings.RunRPSInValidation)
             .WithLogFileLocation(settings.LogFileLocation)
-            .WithCreateDraftPr(settings.CreateDraftPr);
+            .WithCreateDraftPr(settings.CreateDraftPr)
+            .WithSkipCoreXTPackages(settings.SkipCoreXTPackages);
 
         // ************************ Process Arguments ****************************
         bool showHelp = false;
@@ -242,6 +242,11 @@ partial class RoslynInsertionToolCommandline
                 "cherrypick=",
                 $"An optional comma-separated list of VS commits to cherry-pick into the insertion.",
                 cherryPick => options = options.WithCherryPick(cherryPick.Split(',').Select(sha => sha.Trim()).ToImmutableArray())
+            },
+            {
+                "skipcorextpackages=",
+                $"An optional comma-separated list of CoreXT packages to be skipped when inserting/updating. Defaults to \"{string.Join(",", options.SkipCoreXTPackages)}\".",
+                skipCoreXTPackages => options = options.WithSkipCoreXTPackages(skipCoreXTPackages)
             },
         };
 

--- a/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/Settings.Designer.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/Settings.Designer.cs
@@ -261,5 +261,16 @@ namespace Roslyn.Insertion {
                 return ((bool)(this["CreateDraftPr"]));
             }
         }
+
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("VS.Tools.Roslyn")]
+        public string SkipCoreXTPackages
+        {
+            get
+            {
+                return ((string)(this["SkipCoreXTPackages"]));
+            }
+        }
     }
 }

--- a/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/Settings.Designer.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/Settings.Designer.cs
@@ -264,7 +264,7 @@ namespace Roslyn.Insertion {
 
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("VS.Tools.Roslyn")]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
         public string SkipCoreXTPackages
         {
             get

--- a/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/Settings.settings
+++ b/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/Settings.settings
@@ -71,5 +71,8 @@
     <Setting Name="VisualStudioRepoAzdoUri" Type="System.String" Scope="Application">
       <Value Profile="(Default)">https://devdiv.visualstudio.com/DefaultCollection</Value>
     </Setting>
+    <Setting Name="SkipCoreXTPackages" Type="System.String" Scope="Application">
+      <Value Profile="(Default)">VS.Tools.Roslyn</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/Settings.settings
+++ b/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/Settings.settings
@@ -72,7 +72,7 @@
       <Value Profile="(Default)">https://devdiv.visualstudio.com/DefaultCollection</Value>
     </Setting>
     <Setting Name="SkipCoreXTPackages" Type="System.String" Scope="Application">
-      <Value Profile="(Default)">VS.Tools.Roslyn</Value>
+      <Value Profile="(Default)" />
     </Setting>
   </Settings>
 </SettingsFile>

--- a/src/RoslynInsertionTool/RoslynInsertionTool/PackageInfo.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/PackageInfo.cs
@@ -31,6 +31,8 @@ namespace Roslyn.Insertion
 
         public bool IsRoslyn => LibraryName == "Roslyn";
 
+        public bool IsRoslynToolsetCompiler => PackageName == RoslynToolsetPackageName;
+
         public PackageInfo(string packageName, string libraryName, NuGetVersion version)
         {
             PackageName = packageName;

--- a/src/RoslynInsertionTool/RoslynInsertionTool/PackageInfo.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/PackageInfo.cs
@@ -31,8 +31,6 @@ namespace Roslyn.Insertion
 
         public bool IsRoslyn => LibraryName == "Roslyn";
 
-        public bool IsRoslynToolsetCompiler => PackageName == RoslynToolsetPackageName;
-
         public PackageInfo(string packageName, string libraryName, NuGetVersion version)
         {
             PackageName = packageName;

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.Packages.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.Packages.cs
@@ -2,7 +2,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using NuGet.Versioning;
 
@@ -30,6 +32,7 @@ namespace Roslyn.Insertion
             BuildVersion buildVersion,
             CoreXT coreXT,
             string packagesDir,
+            ImmutableArray<string> packagesToBeIgnored,
             CancellationToken cancellationToken)
         {
             bool shouldRetainBuild = false;
@@ -48,9 +51,8 @@ namespace Roslyn.Insertion
 
                 var package = PackageInfo.ParsePackageFileName(fileName);
 
-                if (package.IsRoslynToolsetCompiler)
+                if (packagesToBeIgnored.Any(p => p == package.PackageName))
                 {
-                    // The toolset compiler is inserted separately
                     continue;
                 }
 

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.Packages.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.Packages.cs
@@ -51,7 +51,7 @@ namespace Roslyn.Insertion
 
                 var package = PackageInfo.ParsePackageFileName(fileName);
 
-                if (packagesToBeIgnored.Any(p => p == package.PackageName))
+                if (package.IsRoslynToolsetCompiler || packagesToBeIgnored.Any(p => p == package.PackageName))
                 {
                     continue;
                 }

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
@@ -191,6 +191,7 @@ namespace Roslyn.Insertion
                         buildVersion,
                         coreXT,
                         insertionArtifacts.GetPackagesDirectory(),
+                        Options.SkipCoreXTPackages,
                         cancellationToken);
                     retainBuild |= success;
 

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionToolOptions.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionToolOptions.cs
@@ -275,7 +275,7 @@ namespace Roslyn.Insertion
         public RoslynInsertionToolOptions WithCherryPick(ImmutableArray<string> cherryPick) => Update(cherryPick: cherryPick);
 
         public RoslynInsertionToolOptions WithSkipCoreXTPackages(string skipCoreXTPackages) =>
-            Update(skipCoreXTPackages: skipCoreXTPackages.Split(',').Select(packageName => packageName.Trim()).Where(packageName => !string.IsNullOrEmpty(packageName)).ToImmutableArray());
+            Update(skipCoreXTPackages: (skipCoreXTPackages ?? string.Empty).Split(',').Select(packageName => packageName.Trim()).Where(packageName => !string.IsNullOrEmpty(packageName)).ToImmutableArray());
 
         public string VisualStudioRepoAzdoUsername { get; }
 

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionToolOptions.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionToolOptions.cs
@@ -274,7 +274,8 @@ namespace Roslyn.Insertion
 
         public RoslynInsertionToolOptions WithCherryPick(ImmutableArray<string> cherryPick) => Update(cherryPick: cherryPick);
 
-        public RoslynInsertionToolOptions WithSkipCoreXTPackages(string skipCoreXTPackages) => Update(skipCoreXTPackages: skipCoreXTPackages.Split(',').Select(packageName => packageName.Trim()).ToImmutableArray());
+        public RoslynInsertionToolOptions WithSkipCoreXTPackages(string skipCoreXTPackages) =>
+            Update(skipCoreXTPackages: skipCoreXTPackages.Split(',').Select(packageName => packageName.Trim()).Where(packageName => !string.IsNullOrEmpty(packageName)).ToImmutableArray());
 
         public string VisualStudioRepoAzdoUsername { get; }
 

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionToolOptions.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionToolOptions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using System.Linq;
 using System.Text;
 
 namespace Roslyn.Insertion
@@ -69,7 +70,8 @@ namespace Roslyn.Insertion
             string titlePrefix,
             bool createDraftPr,
             bool setAutoComplete,
-            ImmutableArray<string> cherryPick)
+            ImmutableArray<string> cherryPick,
+            ImmutableArray<string> skipCoreXTPackages)
         {
             VisualStudioRepoAzdoUsername = visualStudioRepoAzdoUsername;
             VisualStudioRepoAzdoPassword = visualStudioRepoAzdoPassword;
@@ -108,6 +110,7 @@ namespace Roslyn.Insertion
             CreateDraftPr = createDraftPr;
             SetAutoComplete = setAutoComplete;
             CherryPick = cherryPick;
+            SkipCoreXTPackages = skipCoreXTPackages;
         }
 
         public RoslynInsertionToolOptions Update(
@@ -147,7 +150,8 @@ namespace Roslyn.Insertion
             Optional<string> titlePrefix = default,
             Optional<bool> createDraftPr = default,
             Optional<bool> setAutoComplete = default,
-            Optional<ImmutableArray<string>> cherryPick = default)
+            Optional<ImmutableArray<string>> cherryPick = default,
+            Optional<ImmutableArray<string>> skipCoreXTPackages = default)
         {
             return new RoslynInsertionToolOptions(
                 visualStudioRepoAzdoUsername: visualStudioRepoAzdoUsername.ValueOrFallback(VisualStudioRepoAzdoUsername),
@@ -186,7 +190,8 @@ namespace Roslyn.Insertion
                 titlePrefix: titlePrefix.ValueOrFallback(TitlePrefix),
                 createDraftPr: createDraftPr.ValueOrFallback(CreateDraftPr),
                 setAutoComplete: setAutoComplete.ValueOrFallback(SetAutoComplete),
-                cherryPick: cherryPick.ValueOrFallback(CherryPick));
+                cherryPick: cherryPick.ValueOrFallback(CherryPick),
+                skipCoreXTPackages: skipCoreXTPackages.ValueOrFallback(SkipCoreXTPackages));
         }
 
         public RoslynInsertionToolOptions WithRunRPSInValidation(bool runRPSInValidation) => Update(runRPSInValidation: runRPSInValidation);
@@ -262,6 +267,8 @@ namespace Roslyn.Insertion
         public RoslynInsertionToolOptions WithSetAutoComplete(bool setAutoComplete) => Update(setAutoComplete: setAutoComplete);
 
         public RoslynInsertionToolOptions WithCherryPick(ImmutableArray<string> cherryPick) => Update(cherryPick: cherryPick);
+
+        public RoslynInsertionToolOptions WithSkipCoreXTPackages(string skipCoreXTPackages) => Update(skipCoreXTPackages: skipCoreXTPackages.Split(',').Select(packageName => packageName.Trim()).ToImmutableArray());
 
         public string VisualStudioRepoAzdoUsername { get; }
 
@@ -339,6 +346,8 @@ namespace Roslyn.Insertion
         public bool SetAutoComplete { get; }
 
         public ImmutableArray<string> CherryPick { get; }
+
+        public ImmutableArray<string> SkipCoreXTPackages { get; }
 
         public bool Valid
         {

--- a/src/RoslynInsertionTool/scripts/HelperFunctions.ps1
+++ b/src/RoslynInsertionTool/scripts/HelperFunctions.ps1
@@ -117,6 +117,14 @@ function GetCherryPick([string] $cherryPick) {
     }
 }
 
+function GetSkipCoreXTPackages([string] $skipCoreXTPackages) {
+    if (IsDefaultValue $skipCoreXTPackages) {
+        return ""
+    } else {
+        return "/skipcorextpackages=$skipCoreXTPackages"
+    }
+}
+
 function GetQueueValidation([string] $visualStudioBranchName, [string] $queueValidation) {
     if (IsDefaultValue $queueValidation) {
         if ($visualStudioBranchName -eq "lab/ml") {

--- a/src/RoslynInsertionTool/scripts/OneOffInsertion.ps1
+++ b/src/RoslynInsertionTool/scripts/OneOffInsertion.ps1
@@ -21,7 +21,8 @@ param([string] $clientId,
       [int] $insertionCount,
       [string] $autoComplete,
       [string] $createDraftPR,
-      [string] $cherryPick)
+      [string] $cherryPick,
+      [string] $skipCoreXTPackages)
 
 . $PSScriptRoot\HelperFunctions.ps1
 
@@ -44,11 +45,12 @@ $updateCoreXTLibraries = GetUpdateCoreXTLibraries -componentName $componentName 
 $autoComplete = GetAutoComplete -autoComplete $autoComplete
 $createDraftPR = GetCreateDraftPR -createDraftPR $createDraftPR
 $cherryPick = GetCherryPick -cherryPick $cherryPick
+$skipCoreXTPackages = GetSkipCoreXTPackages -skipCoreXTPackages $skipCoreXTPackages
 
 if ($insertionCount -lt 1) {
     $insertionCount = 1
 }
 
 for ($i = 0; $i -lt $insertionCount; $i++) {
-    & $PSScriptRoot\RIT.exe  "/in=$componentName" "/bn=$componentBranchName" "/bq=$buildQueueName" "/vsbn=$visualStudioBranchName" "/ic=$insertCore" "/id=$insertDevDiv" "/qv=$queueValidation" "/ua=$updateAssemblyVersions" "/uc=$updateCoreXTLibraries" "/u=vslsnap@microsoft.com" "/ci=$clientId" "/cs=$clientSecret" "/tp=$titlePrefix" "/wpr=$writePullRequest" "/ac=$autoComplete" "/dpr=$createDraftPR" $specificBuildFlag $toolsetFlag $dropPathFlag $cherryPick $componentAzdoUri $componentProjectName $componentUserName
+    & $PSScriptRoot\RIT.exe  "/in=$componentName" "/bn=$componentBranchName" "/bq=$buildQueueName" "/vsbn=$visualStudioBranchName" "/ic=$insertCore" "/id=$insertDevDiv" "/qv=$queueValidation" "/ua=$updateAssemblyVersions" "/uc=$updateCoreXTLibraries" "/u=vslsnap@microsoft.com" "/ci=$clientId" "/cs=$clientSecret" "/tp=$titlePrefix" "/wpr=$writePullRequest" "/ac=$autoComplete" "/dpr=$createDraftPR" $specificBuildFlag $toolsetFlag $dropPathFlag $cherryPick $skipCoreXTPackages $componentAzdoUri $componentProjectName $componentUserName
 }


### PR DESCRIPTION
This is adding possiblity to skip some packages from upgrading in corext.
Before this change there was hardcoded package VS.Tools.Roslyn which was not updating.
This change is adding setting SkipCoreXTPackages which is the list of packages to be skipped. By default it contains VS.Tools.Roslyn.