### PR TITLE
Add titleSuffix argument to insertion tool

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/RoslynInsertionToolCommandline.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/RoslynInsertionToolCommandline.cs
@@ -234,6 +234,11 @@ partial class RoslynInsertionToolCommandline
                 titlePrefix => options = options with { TitlePrefix = titlePrefix }
             },
             {
+                "ts=|titlesuffix=",
+                "Append the generated pull request's title with the specified value.",
+                titleSuffix => options = options with { TitleSuffix = titleSuffix }
+            },
+            {
                 "dpr=|createdraftpr=",
                 "Create an insertion PR that is marked as a draft.",
                 createDraftPr => options = options with { CreateDraftPr = bool.Parse(createDraftPr) }

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.Git.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.Git.cs
@@ -58,7 +58,6 @@ namespace Roslyn.Insertion
                 branchName,
                 $"PLACEHOLDER INSERTION FOR {Options.InsertionName}",
                 "Not Specified",
-                Options.TitlePrefix,
                 reviewerId: Options.ReviewerGUID,
                 cancellationToken);
         }

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
@@ -420,7 +420,7 @@ namespace Roslyn.Insertion
                     {
                         if (Options.OverwritePr)
                         {
-                            pullRequest = await OverwritePullRequestAsync(pullRequestId, prDescriptionMarkdown, buildVersion.ToString(), options.TitlePrefix, cancellationToken);
+                            pullRequest = await OverwritePullRequestAsync(pullRequestId, prDescriptionMarkdown, buildVersion.ToString(), cancellationToken);
                         }
                         pullRequestId = pullRequest.PullRequestId;
                     }
@@ -449,7 +449,7 @@ namespace Roslyn.Insertion
                             ? buildToInsert.RequestedBy.Id
                             : Options.ReviewerGUID;
 
-                        pullRequest = await CreateVSPullRequestAsync(insertionBranchName, prDescriptionMarkdown, buildVersion.ToString(), options.TitlePrefix, reviewerId, cancellationToken);
+                        pullRequest = await CreateVSPullRequestAsync(insertionBranchName, prDescriptionMarkdown, buildVersion.ToString(), reviewerId, cancellationToken);
                         if (pullRequest == null)
                         {
                             LogError($"Unable to create pull request for '{insertionBranchName}'");

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionToolOptions.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionToolOptions.cs
@@ -53,6 +53,7 @@ namespace Roslyn.Insertion
         public string ClientId { get; init; }
         public string ClientSecret { get; init; }
         public string TitlePrefix { get; init; }
+        public string TitleSuffix { get; init; }
         public bool SetAutoComplete { get; init; }
         public ImmutableArray<string> CherryPick { get; init; }
         public string ReviewerGUID { get; init; }

--- a/src/RoslynInsertionTool/scripts/OneOffInsertion.ps1
+++ b/src/RoslynInsertionTool/scripts/OneOffInsertion.ps1
@@ -18,6 +18,7 @@ param([string] $clientId,
       [string] $updateCoreXTLibraries,
       [string] $visualStudioBranchName,
       [string] $titlePrefix,
+      [string] $titleSuffix,
       [string] $writePullRequest,
       [int] $insertionCount,
       [string] $autoComplete,
@@ -56,5 +57,5 @@ if ($insertionCount -lt 1) {
 }
 
 for ($i = 0; $i -lt $insertionCount; $i++) {
-    & $PSScriptRoot\RIT.exe  "/in=$componentName" "/bn=$componentBranchName" "/bq=$buildQueueName" "/vsbn=$visualStudioBranchName" "/ic=$insertCore" "/id=$insertDevDiv" "/qv=$queueValidation" "/ua=$updateAssemblyVersions" "/uc=$updateCoreXTLibraries" "/u=vslsnap@microsoft.com" "/ci=$clientId" "/cs=$clientSecret" "/tp=$titlePrefix" "/wpr=$writePullRequest" "/ac=$autoComplete" "/dpr=$createDraftPR" "/reviewerGUID=$reviewerGUID" $specificBuildFlag $toolsetFlag $dropPathFlag $cherryPick $skipCoreXTPackages $componentAzdoUri $componentProjectName $componentGitHubRepoName $componentUserName
+    & $PSScriptRoot\RIT.exe  "/in=$componentName" "/bn=$componentBranchName" "/bq=$buildQueueName" "/vsbn=$visualStudioBranchName" "/ic=$insertCore" "/id=$insertDevDiv" "/qv=$queueValidation" "/ua=$updateAssemblyVersions" "/uc=$updateCoreXTLibraries" "/u=vslsnap@microsoft.com" "/ci=$clientId" "/cs=$clientSecret" "/tp=$titlePrefix" "/ts=$titleSuffix" "/wpr=$writePullRequest" "/ac=$autoComplete" "/dpr=$createDraftPR" "/reviewerGUID=$reviewerGUID" $specificBuildFlag $toolsetFlag $dropPathFlag $cherryPick $skipCoreXTPackages $componentAzdoUri $componentProjectName $componentGitHubRepoName $componentUserName
 }


### PR DESCRIPTION
This allows people to specify suffixes like `[Skip-SymbolCheck]` which will automatically skip symbol checks on the insertion without cluttering up the title prefix.

insertion generated with this change: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/335632
insertion manually edited to have `[Skip-SymbolCheck]` suffix: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/335602