### PR TITLE
Add paths to assemblies not in standard locations

### DIFF
--- a/src/VSIXExpInstaller/Program.cs
+++ b/src/VSIXExpInstaller/Program.cs
@@ -154,6 +154,10 @@ namespace VsixExpInstaller
                 devenvPath = GetDevenvPath(vsInstallDir);
 
                 var assemblyResolutionPaths = new string[] {
+                    // Microsoft.VisualStudio.Threading, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+                    Path.Combine(vsInstallDir, @"Common7\IDE\PublicAssemblies\Microsoft.VisualStudio.Threading.16.0"),
+                    // Newtonsoft.Json, Version=12.0.0.2, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed
+                    Path.Combine(vsInstallDir, @"Common7\IDE\PrivateAssemblies\Newtonsoft.Json.12.0.0.2"),
                     Path.Combine(vsInstallDir, @"Common7\IDE"),
                     Path.Combine(vsInstallDir, @"Common7\IDE\PrivateAssemblies"),
                     Path.Combine(vsInstallDir, @"Common7\IDE\PublicAssemblies")


### PR DESCRIPTION
Avoids the need for workarounds in dotnet/roslyn.