### PR TITLE
Move from XliffTasks to Microsoft.DotNet.XliffTasks

### DIFF
--- a/src/RepoToolset/tools/DefaultVersions.props
+++ b/src/RepoToolset/tools/DefaultVersions.props
@@ -54,7 +54,7 @@
     <RoslynToolsModifyVsixManifestVersion Condition="'$(RoslynToolsModifyVsixManifestVersion)' == ''">1.0.0-beta2-63011-06</RoslynToolsModifyVsixManifestVersion>
     <RoslynToolsNuGetRepackVersion Condition="'$(RoslynToolsNuGetRepackVersion)' == ''">1.0.0-beta2-63011-06</RoslynToolsNuGetRepackVersion>
     <RoslynToolsSignToolVersion Condition="'$(RoslynToolsSignToolVersion)' == ''">1.0.0-beta2-63011-06</RoslynToolsSignToolVersion>
-    <XliffTasksVersion Condition="'$(XliffTasksVersion)' == ''">0.2.0-beta-63004-01</XliffTasksVersion>
+    <MicrosoftDotNetXliffTasksVersion Condition="'$(MicrosoftDotNetXliffTasksVersion)' == ''">1.0.0-beta.21376.1</MicrosoftDotNetXliffTasksVersion>
     <XUnitVersion Condition="'$(XUnitVersion)' == ''">2.3.1</XUnitVersion>
     <XUnitRunnerConsoleVersion Condition="'$(XUnitRunnerConsoleVersion)' == ''">$(XUnitVersion)</XUnitRunnerConsoleVersion>
     <XUnitRunnerVisualStudioVersion Condition="'$(XUnitRunnerVisualStudioVersion)' == ''">$(XUnitVersion)</XUnitRunnerVisualStudioVersion>
@@ -77,7 +77,7 @@
 
   <PropertyGroup Condition="'$(DotNetBuildOffline)' != 'true'">
     <RestoreSources>$(RestoreSources);https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json</RestoreSources>
-    <RestoreSources Condition="'$(UsingToolXliff)' == 'true' and $(XliffTasksVersion.Contains('-'))">$(RestoreSources);https://dotnetmygetlegacy.blob.core.windows.net/dotnet-core/index.json</RestoreSources>
+    <RestoreSources Condition="'$(UsingToolXliff)' == 'true' and $(MicrosoftDotNetXliffTasksVersion.Contains('-'))">$(RestoreSources);https://dotnetmygetlegacy.blob.core.windows.net/dotnet-core/index.json</RestoreSources>
     <RestoreSources Condition="'$(UsingToolMicrosoftNetCompilers)' == 'true' and $(MicrosoftNetCompilersVersion.Contains('-'))">$(RestoreSources);https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json</RestoreSources>
     <RestoreSources Condition="'$(UsingToolNetFrameworkReferenceAssemblies)' == 'true'">$(RestoreSources);https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json</RestoreSources>
     <RestoreSources Condition="$(XUnitVersion.Contains('-')) or $(XUnitRunnerVisualStudioVersion.Contains('-')) or $(XUnitRunnerVisualStudioVersion.Contains('-'))">$(RestoreSources);https://www.myget.org/F/xunit/api/v3/index.json</RestoreSources>

--- a/src/RepoToolset/tools/DefaultVersions.props
+++ b/src/RepoToolset/tools/DefaultVersions.props
@@ -77,7 +77,6 @@
 
   <PropertyGroup Condition="'$(DotNetBuildOffline)' != 'true'">
     <RestoreSources>$(RestoreSources);https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json</RestoreSources>
-    <RestoreSources Condition="'$(UsingToolXliff)' == 'true' and $(MicrosoftDotNetXliffTasksVersion.Contains('-'))">$(RestoreSources);https://dotnetmygetlegacy.blob.core.windows.net/dotnet-core/index.json</RestoreSources>
     <RestoreSources Condition="'$(UsingToolMicrosoftNetCompilers)' == 'true' and $(MicrosoftNetCompilersVersion.Contains('-'))">$(RestoreSources);https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json</RestoreSources>
     <RestoreSources Condition="'$(UsingToolNetFrameworkReferenceAssemblies)' == 'true'">$(RestoreSources);https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json</RestoreSources>
     <RestoreSources Condition="$(XUnitVersion.Contains('-')) or $(XUnitRunnerVisualStudioVersion.Contains('-')) or $(XUnitRunnerVisualStudioVersion.Contains('-'))">$(RestoreSources);https://www.myget.org/F/xunit/api/v3/index.json</RestoreSources>

--- a/src/RepoToolset/tools/Localization.targets
+++ b/src/RepoToolset/tools/Localization.targets
@@ -14,15 +14,15 @@
   <PropertyGroup>
     <UpdateXlfOnBuild Condition="'$(CIBuild)' != 'true'">true</UpdateXlfOnBuild>
 
-    <!-- 
+    <!--
       Use Satellite assembly generation task from Microsoft.NET.Sdk even when building with
       full Framework MSBuild. This will support public signing, is deterministic, and always
-      generates them as AnyCPU. 
+      generates them as AnyCPU.
     -->
     <GenerateSatelliteAssembliesForCore Condition="'$(GenerateSatelliteAssembliesForCore)' == ''">true</GenerateSatelliteAssembliesForCore>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="XliffTasks" Version="$(XliffTasksVersion)" PrivateAssets="all" IsImplicitlyDefined="true" Condition="'$(IsShipping)' == 'true'" />
+    <PackageReference Include="Microsoft.DotNet.XliffTasks" Version="$(MicrosoftDotNetXliffTasksVersion)" PrivateAssets="all" IsImplicitlyDefined="true" Condition="'$(IsShipping)' == 'true'" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The package name was changed to start with a reserved name (https://github.com/dotnet/xliff-tasks/issues/412)

However, I don't fully understand the flow with the very old default version. However, Arcade will stop setting the `XliffTasksVersion` property with the next update as it moved to `MicrosoftDotNetXliffTasksVersion` and this old version might come into action so we should update the package.

Resolves #1058 