### PR TITLE
Update Microsoft.VisualStudio.Threading resolution path

### DIFF
--- a/src/VSIXExpInstaller/Program.cs
+++ b/src/VSIXExpInstaller/Program.cs
@@ -157,7 +157,7 @@ namespace VsixExpInstaller
 
                 var assemblyResolutionPaths = new string[] {
                     // Microsoft.VisualStudio.Threading, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
-                    Path.Combine(vsInstallDir, @"Common7\IDE\PublicAssemblies\Microsoft.VisualStudio.Threading.17.0"),
+                    Path.Combine(vsInstallDir, @"Common7\IDE\PublicAssemblies\Microsoft.VisualStudio.Threading.17.x"),
                     // Newtonsoft.Json, Version=12.0.0.2, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed
                     Path.Combine(vsInstallDir, @"Common7\IDE\PrivateAssemblies\Newtonsoft.Json.12.0.0.2"),
                     Path.Combine(vsInstallDir, @"Common7\IDE"),

--- a/src/VSIXExpInstaller/Program.cs
+++ b/src/VSIXExpInstaller/Program.cs
@@ -157,7 +157,7 @@ namespace VsixExpInstaller
 
                 var assemblyResolutionPaths = new string[] {
                     // Microsoft.VisualStudio.Threading, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
-                    Path.Combine(vsInstallDir, @"Common7\IDE\PublicAssemblies\Microsoft.VisualStudio.Threading.16.0"),
+                    Path.Combine(vsInstallDir, @"Common7\IDE\PublicAssemblies\Microsoft.VisualStudio.Threading.17.0"),
                     // Newtonsoft.Json, Version=12.0.0.2, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed
                     Path.Combine(vsInstallDir, @"Common7\IDE\PrivateAssemblies\Newtonsoft.Json.12.0.0.2"),
                     Path.Combine(vsInstallDir, @"Common7\IDE"),


### PR DESCRIPTION
In VS 17.0 Preview 3 the path to the Microsoft.VisualStudio.Threading library has changed. Without the updated path the 15.8 version of this library is discovered. 