### PR TITLE
Create VSBranchInfo tool

### DIFF
--- a/RoslynTools.sln
+++ b/RoslynTools.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29411.138
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31710.301
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ModifyVsixManifest", "src\ModifyVsixManifest\ModifyVsixManifest.csproj", "{0EAEBB0A-EE12-4929-8B0A-6953B0E852F9}"
 EndProject
@@ -72,7 +72,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GitHubCreateMergePRs", "src
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PRFinder", "src\RoslynInsertionTool\PRFinder\PRFinder.csproj", "{15BE78E3-355F-4B15-ABB4-FA750B2D846B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CreateTagsForVSRelease", "src\CreateTagsForVSRelease\CreateTagsForVSRelease.csproj", "{08AAEF36-C81B-4BAE-8172-EA0D3139B0BE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CreateTagsForVSRelease", "src\CreateTagsForVSRelease\CreateTagsForVSRelease.csproj", "{08AAEF36-C81B-4BAE-8172-EA0D3139B0BE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VSBranchInfo", "src\VSBranchInfo\VSBranchInfo.csproj", "{D10CCD63-A7F6-4310-81AA-0D00526320D1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -396,6 +398,18 @@ Global
 		{08AAEF36-C81B-4BAE-8172-EA0D3139B0BE}.Release|x64.Build.0 = Release|Any CPU
 		{08AAEF36-C81B-4BAE-8172-EA0D3139B0BE}.Release|x86.ActiveCfg = Release|Any CPU
 		{08AAEF36-C81B-4BAE-8172-EA0D3139B0BE}.Release|x86.Build.0 = Release|Any CPU
+		{D10CCD63-A7F6-4310-81AA-0D00526320D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D10CCD63-A7F6-4310-81AA-0D00526320D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D10CCD63-A7F6-4310-81AA-0D00526320D1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D10CCD63-A7F6-4310-81AA-0D00526320D1}.Debug|x64.Build.0 = Debug|Any CPU
+		{D10CCD63-A7F6-4310-81AA-0D00526320D1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D10CCD63-A7F6-4310-81AA-0D00526320D1}.Debug|x86.Build.0 = Debug|Any CPU
+		{D10CCD63-A7F6-4310-81AA-0D00526320D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D10CCD63-A7F6-4310-81AA-0D00526320D1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D10CCD63-A7F6-4310-81AA-0D00526320D1}.Release|x64.ActiveCfg = Release|Any CPU
+		{D10CCD63-A7F6-4310-81AA-0D00526320D1}.Release|x64.Build.0 = Release|Any CPU
+		{D10CCD63-A7F6-4310-81AA-0D00526320D1}.Release|x86.ActiveCfg = Release|Any CPU
+		{D10CCD63-A7F6-4310-81AA-0D00526320D1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/VSBranchInfo/AzDOConnection.cs
+++ b/src/VSBranchInfo/AzDOConnection.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the License.txt file in the project root for more information.
+using Microsoft.TeamFoundation.Build.WebApi;
+using Microsoft.TeamFoundation.SourceControl.WebApi;
+using Microsoft.VisualStudio.Services.Common;
+using Microsoft.VisualStudio.Services.WebApi;
+using System;
+using System.Net.Http;
+using System.Net;
+using Azure.Security.KeyVault.Secrets;
+using Microsoft.VisualStudio.Services.FileContainer.Client;
+using Microsoft.TeamFoundation.Core.WebApi;
+
+namespace VSBranchInfo
+{
+    internal sealed class AzDOConnection : IDisposable
+    {
+        private bool _disposed = false;
+
+        public string BuildProjectName { get; }
+        public string BuildDefinitionName { get; }
+        private VssConnection Connection { get; }
+        public GitHttpClient GitClient { get; }
+        public BuildHttpClient BuildClient { get; }
+        public FileContainerHttpClient ContainerClient { get; }
+        public ProjectHttpClient ProjectClient { get; }
+
+        public AzDOConnection(string azdoUrl, string projectName, string buildDefinitionName, SecretClient client, string secretName)
+        {
+            BuildProjectName = projectName;
+            BuildDefinitionName = buildDefinitionName;
+
+            var azureDevOpsSecret = client.GetSecret(secretName);
+            var credential = new NetworkCredential("vslsnap", azureDevOpsSecret.Value.Value);
+
+            Connection = new VssConnection(new Uri(azdoUrl), new WindowsCredential(credential));
+
+            GitClient = Connection.GetClient<GitHttpClient>();
+            BuildClient = Connection.GetClient<BuildHttpClient>();
+
+            ContainerClient = Connection.GetClient<FileContainerHttpClient>();
+
+            ProjectClient = Connection.GetClient<ProjectHttpClient>();
+        }
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _disposed = true;
+
+                Connection.Dispose();
+                GitClient.Dispose();
+                BuildClient.Dispose();
+                ContainerClient.Dispose();
+            }
+        }
+    }
+}

--- a/src/VSBranchInfo/Program.cs
+++ b/src/VSBranchInfo/Program.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Azure.Identity;
+using Azure.Security.KeyVault.Secrets;
+using Microsoft.TeamFoundation.Build.WebApi;
+using Microsoft.TeamFoundation.SourceControl.WebApi;
+using Microsoft.VisualStudio.Services.WebApi;
+using Newtonsoft.Json.Linq;
+
+namespace VSBranchInfo
+{
+    public static class Program
+    {
+        // TODO: Look at the VS repo and compute these dynamically
+        private static readonly string[] s_visualStudioBranches = new[] { "rel/d16.11", "rel/d17.0", "main" };
+
+        public static async Task Main(string[] args)
+        {
+            if (args.Length == 0)
+            {
+                args = s_visualStudioBranches;
+                Console.WriteLine("Using default branch names. Specify branches to check as command line parameters.");
+                Console.WriteLine();
+            }
+
+            var client = new SecretClient(
+                 vaultUri: new Uri("https://roslyninfra.vault.azure.net:443"),
+                 credential: new DefaultAzureCredential(includeInteractiveCredentials: true));
+
+            using var devdivConnection = new AzDOConnection("https://devdiv.visualstudio.com/DefaultCollection", "DevDiv", "Roslyn-Signed", client, "vslsnap-vso-auth-token");
+            using var dncengConnection = new AzDOConnection("https://dnceng.visualstudio.com/DefaultCollection", "internal", "dotnet-roslyn CI", client, "vslsnap-build-auth-token");
+
+            foreach (var branch in args)
+            {
+                WriteHeader(branch);
+                try
+                {
+                    await WriteRoslynBuildInfo(branch, devdivConnection, dncengConnection);
+                }
+                catch (Exception ex)
+                {
+                    WriteError(ex);
+                }
+            }
+        }
+
+        private static async Task WriteRoslynBuildInfo(string branch, AzDOConnection devdiv, AzDOConnection dnceng)
+        {
+            var (packageVersion, buildNumber) = await GetRoslynPackageInfo(branch, devdiv);
+
+            // Try getting build info from dnceng first
+            var builds = await TryGetBuilds(dnceng, buildNumber);
+            var buildConnection = dnceng;
+            if (builds == null || builds.Count == 0)
+            {
+                // otherwise fallback to devdiv, where things used to be
+                builds = await TryGetBuilds(devdiv, buildNumber);
+                buildConnection = devdiv;
+            }
+
+            if (builds is null or { Count: 0 })
+            {
+                throw new Exception($"Couldn't find build for package version: {packageVersion}, build number: {buildNumber}");
+            }
+
+            foreach (var build in builds)
+            {
+                WriteNameAndValue("Package Version", packageVersion);
+                WriteNameAndValue("Commit Sha", build.SourceVersion);
+                WriteNameAndValue("Source branch", build.SourceBranch.Replace("refs/heads/", ""));
+                WriteNameAndValue("Build", ((ReferenceLink)build.Links.Links["web"]).Href);
+
+                await WriteArtifactInfo(buildConnection, build);
+
+                Console.WriteLine();
+            }
+        }
+
+        private static async Task<(string packageVersion, string buildNumber)> GetRoslynPackageInfo(string branch, AzDOConnection devdiv)
+        {
+            var commit = new GitVersionDescriptor { VersionType = GitVersionType.Branch, Version = branch };
+            GitRepository vsRepository = await devdiv.GitClient.GetRepositoryAsync("DevDiv", "VS");
+
+            using var componentsJsonStream = await devdiv.GitClient.GetItemContentAsync(
+                vsRepository.Id,
+                @".corext\Configs\dotnetcodeanalysis-components.json",
+                download: true,
+                versionDescriptor: commit);
+
+            var fileContents = await new StreamReader(componentsJsonStream).ReadToEndAsync();
+            var componentsJson = JObject.Parse(fileContents);
+
+            var languageServicesUrlAndManifestName = componentsJson["Components"]?["Microsoft.CodeAnalysis.LanguageServices"]?["url"]?.ToString();
+
+            var parts = languageServicesUrlAndManifestName?.Split(';');
+            if (parts?.Length != 2)
+            {
+                throw new Exception($"Couldn't get URL and manifest. Got: {parts}");
+            }
+
+            if (!parts[1].EndsWith(".vsman"))
+            {
+                throw new Exception($"Couldn't get URL and manifest. Not a vsman file? Got: {parts}");
+            }
+
+            using var defaultConfigStream = await devdiv.GitClient.GetItemContentAsync(
+                vsRepository.Id,
+                @".corext\Configs\default.config",
+                download: true,
+                versionDescriptor: commit);
+
+            fileContents = await new StreamReader(defaultConfigStream).ReadToEndAsync();
+            var defaultConfig = XDocument.Parse(fileContents);
+
+            var packageVersion = defaultConfig.Root?.Descendants("package").Where(p => p.Attribute("id")?.Value == "VS.ExternalAPIs.Roslyn").Select(p => p.Attribute("version")?.Value).FirstOrDefault();
+
+            if (packageVersion is null)
+            {
+                throw new Exception($"Couldn't find the Roslyn external APIs pacakge for branch: {branch}");
+            }
+
+            var buildNumber = new Uri(parts[0]).Segments.Last();
+
+            return (packageVersion, buildNumber);
+        }
+
+        private static async Task<List<Build>?> TryGetBuilds(AzDOConnection connection, string buildNumber)
+        {
+            try
+            {
+                var buildDefinition = (await connection.BuildClient.GetDefinitionsAsync(connection.BuildProjectName, name: connection.BuildDefinitionName)).Single();
+                var builds = await connection.BuildClient.GetBuildsAsync(buildDefinition.Project.Id, definitions: new[] { buildDefinition.Id }, buildNumber: buildNumber);
+                return builds;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        // Inspired by Mitch Denny: https://dev.azure.com/mseng/AzureDevOps/_git/ArtifactTool?path=/src/ArtifactTool/Commands/PipelineArtifacts/PipelineArtifactDownloadCommand.cs&version=GBusers/midenn/fcs-integration&line=68&lineEnd=69&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents
+        // Note: He wishes not to have his name attached to it.
+        private static async Task WriteArtifactInfo(AzDOConnection connection, Build build)
+        {
+            var artifact = await connection.BuildClient.GetArtifactAsync(build.Project.Id, build.Id, "PackageArtifacts");
+
+            var (id, name) = ParseContainerId(artifact.Resource.Data);
+
+            var projectId = (await connection.ProjectClient.GetProject(connection.BuildProjectName)).Id;
+
+            var items = await connection.ContainerClient.QueryContainerItemsAsync(id, projectId, name);
+
+            var links = from i in items
+                        where i.ItemType == Microsoft.VisualStudio.Services.FileContainer.ContainerItemType.Folder
+                        where i.Path == "PackageArtifacts/PreRelease" ||
+                              i.Path == "PackageArtifacts/Release"
+                        select (i.Path.Split('/').Last(), i.ContentLocation + "&%24format=zip&saveAbsolutePath=false"); // %24 == $
+
+            WriteNamesAndValues("Packages", links);
+
+            static (long id, string name) ParseContainerId(string resourceData)
+            {
+                // Example of resourceData: "#/7029766/artifacttool-alpine-x64-Debug"
+                var segments = resourceData.Split('/');
+
+                long containerId;
+                if (segments.Length == 3 && segments[0] == "#" && long.TryParse(segments[1], out containerId))
+                {
+                    return (containerId, segments[2]);
+                }
+
+                throw new Exception($"Resource data value '{resourceData}' was not in expected format.");
+            }
+        }
+
+        private static void WriteError(Exception ex)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.WriteLine($"Error: {ex.Message}");
+            Console.ResetColor();
+            Console.WriteLine();
+        }
+
+        private static void WriteHeader(string branch)
+        {
+            Console.ForegroundColor = ConsoleColor.Cyan;
+            Console.WriteLine($"{branch}:");
+            Console.ResetColor();
+        }
+
+        private static void WriteNameAndValue(string name, string value, string indent = "  ")
+        {
+            Console.Write($"{indent}{name}: ");
+            Console.ForegroundColor = ConsoleColor.White;
+            Console.WriteLine(value);
+            Console.ResetColor();
+        }
+
+        private static void WriteNamesAndValues(string header, IEnumerable<(string, string)> values)
+        {
+            Console.WriteLine($"  {header}:");
+            foreach (var (name, value) in values)
+            {
+                WriteNameAndValue(name, value, "    ");
+            }
+        }
+    }
+}

--- a/src/VSBranchInfo/README.md
+++ b/src/VSBranchInfo/README.md
@@ -1,0 +1,16 @@
+## VS Branch Info
+
+Displays information about the Roslyn packages used by specific branches of Visual Studio
+
+eg.
+```
+$ dotnet run -- rel/d16.11
+rel/d16.11:
+  Package Version: 3.11.0-4.21403.6
+  Commit Sha: ae1fff344d46976624e68ae17164e0607ab68b10
+  Source branch: release/dev16.11-vs-deps
+  Build: https://dnceng.visualstudio.com/7ea9116e-9fac-403d-b258-b31fcf1bb293/_build/results?buildId=1272921
+  Packages:
+    PreRelease: https://dnceng.visualstudio.com/_apis/resources/Containers/7771452?itemPath=PackageArtifacts%2FPreRelease&%24format=zip&saveAbsolutePath=false
+    Release: https://dnceng.visualstudio.com/_apis/resources/Containers/7771452?itemPath=PackageArtifacts%2FRelease&%24format=zip&saveAbsolutePath=false
+```

--- a/src/VSBranchInfo/VSBranchInfo.csproj
+++ b/src/VSBranchInfo/VSBranchInfo.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.5.0-beta.1" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.2.0-beta.5" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.185.0-preview" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="16.185.0-preview" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This is a tool I wrote and have been using to help with VS Mac insertions for a while, but yesterday I added some package info stuff to it, for nuget publishing, and figured it should probably graduate to a proper repository.

It shows info about the currently inserted Roslyn bits for Visual Studio branches.

Output looks like this:
![image](https://user-images.githubusercontent.com/754264/133169233-633eddb3-eb49-4d2d-9c61-d06d2d3c0223.png)

Most of it was stolen from the CreateTagsForVSRelease tool in this repo anyway, so there is certainly room for improvements/amalgamation.