### PR TITLE
Fix missing branch warnings in codeflow config.xml

### DIFF
--- a/src/GitHubCreateMergePRs/config.xml
+++ b/src/GitHubCreateMergePRs/config.xml
@@ -49,7 +49,7 @@
 
   <repo owner="dotnet" name="templates">
     <merge from="dev15.9.x" to="dev16.0.x" />
-    <merge from="dev16.0.x" to="master" />
+    <merge from="dev16.0.x" to="main" />
   </repo>
 
   <repo owner="dotnet" name="fsharp">
@@ -76,15 +76,9 @@
     <merge from="main" to="release/7.0.1xx" />
   </repo>
 
-  <!-- testimpact branches -->
-  <repo owner="dotnet" name="testimpact">
-    <merge from="dev16.7.x" to="master" />
-    <merge from="master" to="feature/vnext" />
-  </repo>
-
   <!-- msbuild language service branches -->
   <repo owner="dotnet" name="msbuild-language-service">
-    <merge from="master" to="dev/prototype" />
+    <merge from="main" to="dev/prototype" />
   </repo>
 
   <!-- dotnet-format service branches -->


### PR DESCRIPTION
Fixes the following by changing target branch from `master` to `main` for dotnet/templates.
```
Merging templates from dev16.0.x to master
##[warning]Error creating PR. GH response code: NotFound
##[warning]{"message":"Not Found","documentation_url":"https://docs.github.com/rest/reference/repos#compare-two-commits"}
```

Fixes the following by removing the configuration for dotnet/testimpact as it has been archived.
```
Merging testimpact from dev16.7.x to master
##[warning]Error creating PR. GH response code: NotFound
##[warning]{"message":"Not Found","documentation_url":"https://docs.github.com/rest/reference/repos#compare-two-commits"}
Merging testimpact from master to feature/vnext
##[warning]Error creating PR. GH response code: NotFound
##[warning]{"message":"Not Found","documentation_url":"https://docs.github.com/rest/reference/repos#compare-two-commits"}
```

Fixes the following by changing source branch from `master` to `main` for dotnet/msbuild-language-service.
```
Merging msbuild-language-service from master to dev/prototype
##[warning]Error creating PR. GH response code: NotFound
##[warning]{"message":"Not Found","documentation_url":"https://docs.github.com/rest/reference/repos#compare-two-commits"}
```