### PR TITLE
Update the version to avoid restoring System.Net.Http

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -23,7 +23,7 @@
     <!-- Libs -->
     <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
     <MoqVersion>4.5.21</MoqVersion>
-    <NuGetVersioningVersion>4.4.0</NuGetVersioningVersion>
+    <NuGetVersioningVersion>5.11.0</NuGetVersioningVersion>
     <MicrosoftAzureKeyVaultVersion>3.0.0</MicrosoftAzureKeyVaultVersion>
     <MicrosoftBuildVersion>15.6.82</MicrosoftBuildVersion>
     <MicrosoftBuildTasksCoreVersion>15.6.82</MicrosoftBuildTasksCoreVersion>

--- a/src/BuildTasks.Tests/RoslynTools.BuildTasks.UnitTests.csproj
+++ b/src/BuildTasks.Tests/RoslynTools.BuildTasks.UnitTests.csproj
@@ -8,6 +8,6 @@
     <ProjectReference Include="..\BuildTasks\RoslynTools.BuildTasks.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" />
   </ItemGroup>
 </Project>

--- a/src/BuildTasks.Tests/RoslynTools.BuildTasks.UnitTests.csproj
+++ b/src/BuildTasks.Tests/RoslynTools.BuildTasks.UnitTests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
@@ -6,5 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\BuildTasks\RoslynTools.BuildTasks.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 </Project>

--- a/src/CreateTagsForVSRelease/CreateTagsForVSRelease.csproj
+++ b/src/CreateTagsForVSRelease/CreateTagsForVSRelease.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.153.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
 </Project>

--- a/src/CreateTagsForVSRelease/CreateTagsForVSRelease.csproj
+++ b/src/CreateTagsForVSRelease/CreateTagsForVSRelease.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.153.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/VSBranchInfo/VSBranchInfo.csproj
+++ b/src/VSBranchInfo/VSBranchInfo.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -11,6 +11,7 @@
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.2.0-beta.5" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.185.0-preview" />
     <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="16.185.0-preview" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
 </Project>

--- a/src/VSBranchInfo/VSBranchInfo.csproj
+++ b/src/VSBranchInfo/VSBranchInfo.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.2.0-beta.5" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.185.0-preview" />
     <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="16.185.0-preview" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Issue: https://devdiv.visualstudio.com/DevDiv/_componentGovernance/112189/alert/2974928?typeId=6256257

The root reason is many of the packages are referencing NetStandard.Library 1.6.0, which is referencing System.Net.Http 4.1.0
For example:
![image](https://user-images.githubusercontent.com/24360909/133821463-25c39add-c3fc-4688-890e-2051e40c858c.png)

Updating the version of this package would resolve the problem.

For other packages, which the updated version still referencing NetStandard.Library 1.6.0, explicitly referencing System.Net.Http 4.3.4