### PR TITLE
Create NugetDependencyFinder app

### DIFF
--- a/RoslynTools.sln
+++ b/RoslynTools.sln
@@ -76,6 +76,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CreateTagsForVSRelease", "s
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VSBranchInfo", "src\VSBranchInfo\VSBranchInfo.csproj", "{D10CCD63-A7F6-4310-81AA-0D00526320D1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NugetDependencyFinder", "src\NugetDependencyFinder\NugetDependencyFinder.csproj", "{7A6963D6-1F40-4CC6-9941-7F912252F877}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -410,6 +412,18 @@ Global
 		{D10CCD63-A7F6-4310-81AA-0D00526320D1}.Release|x64.Build.0 = Release|Any CPU
 		{D10CCD63-A7F6-4310-81AA-0D00526320D1}.Release|x86.ActiveCfg = Release|Any CPU
 		{D10CCD63-A7F6-4310-81AA-0D00526320D1}.Release|x86.Build.0 = Release|Any CPU
+		{7A6963D6-1F40-4CC6-9941-7F912252F877}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7A6963D6-1F40-4CC6-9941-7F912252F877}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7A6963D6-1F40-4CC6-9941-7F912252F877}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7A6963D6-1F40-4CC6-9941-7F912252F877}.Debug|x64.Build.0 = Debug|Any CPU
+		{7A6963D6-1F40-4CC6-9941-7F912252F877}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7A6963D6-1F40-4CC6-9941-7F912252F877}.Debug|x86.Build.0 = Debug|Any CPU
+		{7A6963D6-1F40-4CC6-9941-7F912252F877}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7A6963D6-1F40-4CC6-9941-7F912252F877}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7A6963D6-1F40-4CC6-9941-7F912252F877}.Release|x64.ActiveCfg = Release|Any CPU
+		{7A6963D6-1F40-4CC6-9941-7F912252F877}.Release|x64.Build.0 = Release|Any CPU
+		{7A6963D6-1F40-4CC6-9941-7F912252F877}.Release|x86.ActiveCfg = Release|Any CPU
+		{7A6963D6-1F40-4CC6-9941-7F912252F877}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -438,6 +452,7 @@ Global
 		{44B80D37-F395-40CF-8BB6-9AAEB5606672} = {821F3F43-E221-4507-95BD-64843868AC11}
 		{DAD4C83F-8C86-4099-AA2A-EFCF1F5D5459} = {54B3835F-17DD-4749-B40D-1533BD81D36C}
 		{15BE78E3-355F-4B15-ABB4-FA750B2D846B} = {54B3835F-17DD-4749-B40D-1533BD81D36C}
+		{7A6963D6-1F40-4CC6-9941-7F912252F877} = {732A897A-76AE-41E3-A7E4-55F16C1D56EB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {738CC66D-49E2-4B21-835F-94170D22A29D}

--- a/src/NugetDependencyFinder/NugetDependencyFinder.csproj
+++ b/src/NugetDependencyFinder/NugetDependencyFinder.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NuGet.Protocol" Version="6.0.0-rc.262" />
+  </ItemGroup>
+
+</Project>

--- a/src/NugetDependencyFinder/Program.cs
+++ b/src/NugetDependencyFinder/Program.cs
@@ -1,0 +1,122 @@
+using System.Text.RegularExpressions;
+using NuGet.Common;
+using NuGet.Packaging.Core;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+
+var (verbose, packageFolder) = ParseCommandLine();
+
+if (packageFolder is null)
+{
+    Console.WriteLine("Usage: NugetDependencyFinder [-v] <nupkg directory>");
+    return;
+}
+
+var packages = from file in Directory.EnumerateFiles(packageFolder, "*.nupkg")
+               let fileName = Path.GetFileName(file)
+               let regex = Regex.Match(fileName, @"^(.*?)\.((?:\.?[0-9]+){3,}(?:[-a-z]+)?)\.nupkg$")
+               where regex.Success
+               select regex.Groups[1].Value;
+
+var logger = NullLogger.Instance;
+var cache = new SourceCacheContext();
+
+var nugetOrg = Repository.Factory.GetCoreV3("https://api.nuget.org/v3/index.json");
+var nugetOrgFinder = await nugetOrg.GetResourceAsync<FindPackageByIdResource>().ConfigureAwait(false);
+
+await foreach (var dependency in GetAllDependenciesAsync())
+{
+    if (packages.Contains(dependency.Id))
+    {
+        Write(dependency, "One of our packages, so versioned uniformly.", verboseOnly: true);
+        continue;
+    }
+    else if (!dependency.VersionRange.MinVersion.IsPrerelease)
+    {
+        Write(dependency, "Already using a released version.", verboseOnly: true);
+        continue;
+    }
+
+    if (!await nugetOrgFinder.DoesPackageExistAsync(dependency.Id, dependency.VersionRange.MinVersion, cache, logger, CancellationToken.None).ConfigureAwait(false))
+    {
+        Write(dependency, "Doesn't exist on nuget.org, nothing to do.");
+        continue;
+    }
+
+    var versions = await nugetOrgFinder.GetAllVersionsAsync(dependency.Id, cache, logger, CancellationToken.None).ConfigureAwait(false);
+
+    var desiredVersion = (from v in versions
+                          where !v.IsPrerelease
+                          where v.Version > dependency.VersionRange.MinVersion.Version
+                          select v).FirstOrDefault();
+
+    if (desiredVersion is null)
+    {
+        Write(dependency, "No released version to upgrade to on nuget.org.", ConsoleColor.Cyan);
+        continue;
+    }
+
+    Write(dependency, $"Upgrade to {desiredVersion}.", ConsoleColor.Yellow);
+}
+
+void Write(PackageDependency dependency, string message, ConsoleColor? color = null, bool verboseOnly = false)
+{
+    if (verboseOnly && !verbose)
+    {
+        return;
+    }
+
+    Console.Write($"{dependency.Id}, {dependency.VersionRange.MinVersion}: ");
+    if (color is not null)
+    {
+        Console.ForegroundColor = color.Value;
+    }
+    Console.Write(message);
+    Console.ResetColor();
+
+    Console.WriteLine();
+}
+
+async IAsyncEnumerable<PackageDependency> GetAllDependenciesAsync()
+{
+    var local = Repository.Factory.GetCoreV3(packageFolder);
+    var localFinder = await local.GetResourceAsync<FindPackageByIdResource>().ConfigureAwait(false);
+    var foundPackages = new HashSet<string>();
+
+    foreach (var package in packages)
+    {
+        var localVersions = await localFinder.GetAllVersionsAsync(package, cache, logger, CancellationToken.None).ConfigureAwait(false);
+        var dependencies = await localFinder.GetDependencyInfoAsync(package, localVersions.First(), cache, logger, CancellationToken.None).ConfigureAwait(false);
+
+        foreach (var group in dependencies.DependencyGroups)
+        {
+            foreach (var dependency in group.Packages)
+            {
+                if (foundPackages.Add(dependency.Id))
+                {
+                    yield return dependency;
+                }
+            }
+        }
+    }
+}
+
+(bool, string?) ParseCommandLine()
+{
+    if (args.Length == 0)
+    {
+        return (false, null);
+    }
+
+    if (args[0] == "-v")
+    {
+        if (args.Length == 1)
+        {
+            return (false, null);
+        }
+
+        return (true, args[1]);
+    }
+
+    return (false, args[0]);
+}


### PR DESCRIPTION
A little app that goes through a folder of `.nupkg` files and tells you which dependencies of those packages need to be updated to as released version.

Sample output:
![image](https://user-images.githubusercontent.com/754264/136483940-7c976336-d052-4e83-8832-444ec1ad3edb.png)
