### PR TITLE
Re-enable project system merges

### DIFF
--- a/src/GitHubCreateMergePRs/config.xml
+++ b/src/GitHubCreateMergePRs/config.xml
@@ -39,10 +39,10 @@
   </repo>
 
   <!-- Project System repo -->
-  <!-- <repo owner="dotnet" name="project-system">
+  <repo owner="dotnet" name="project-system">
     <merge from="dev16.11.x" to="main" />
     <merge from="dev17.0.x" to="main" />
-  </repo> -->
+  </repo>
   
   <!-- NuGet.BuildTasks repo -->
   <repo owner="dotnet" name="NuGet.BuildTasks">


### PR DESCRIPTION
Since the PRs that I wanted to ignore are merged now, we can re-enable the automerging.
- https://github.com/dotnet/project-system/pull/7692
- https://github.com/dotnet/project-system/pull/7691