### PR TITLE
Do not fail if the Insertion\OptProf folder does not exist

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool/ArcadeInsertionArtifacts.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/ArcadeInsertionArtifacts.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the License.txt file in the project root for more information.
 
@@ -47,6 +47,11 @@ namespace Roslyn.Insertion
             => Path.Combine(RootDirectory, "DevDivPackages", "DependentAssemblyVersions.csv");
 
         public override string[] GetOptProfPropertyFiles()
-            => Directory.EnumerateFiles(Path.Combine(RootDirectory, "Insertion", "OptProf"), "*.props", SearchOption.TopDirectoryOnly).ToArray();
+        {
+            var optProfPath = Path.Combine(RootDirectory, "Insertion", "OptProf");
+            return Directory.Exists(optProfPath)
+                ? Directory.EnumerateFiles(optProfPath, "*.props", SearchOption.TopDirectoryOnly).ToArray()
+                : Array.Empty<string>();
+        }
     }
 }

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
@@ -111,7 +111,7 @@ namespace Roslyn.Insertion
                 {
                     buildToInsert = await GetLatestPassedComponentBuildAsync(cancellationToken);
                     buildVersion = BuildVersion.FromTfsBuildNumber(buildToInsert.BuildNumber, Options.ComponentBuildQueueName);
-                    Console.WriteLine("Found build number " + buildVersion);
+                    Console.WriteLine("Found " + buildToInsert.Definition.Name + " build number " + buildVersion);
 
                     //  Get the latest build, whether passed or failed.  If the buildToInsert has already been inserted but
                     //  there is a later failing build, then send an error


### PR DESCRIPTION
When helping the TestPlatform get started with RIT, it was an unnecessary requirement to create this empty folder.