### PR TITLE
Change LegacyProjects.props throw to warning

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool/CoreXT.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/CoreXT.cs
@@ -154,7 +154,7 @@ namespace Roslyn.Insertion
 
         internal void AddNewPackage(PackageInfo packageInfo)
         {
-            throw new NotSupportedException("Adding a new package is not supported until we also update for LegacyProjects.props");
+            Console.WriteLine("##vso[task.logissue type=warning] Adding a new package is not supported until we also update for LegacyProjects.props");
 
 #pragma warning disable CS0162 // Unreachable code detected
             var followingElement = GetClosestFollowingPackageElement(packageInfo);


### PR DESCRIPTION
Attempting to mitigate this issue:
https://dev.azure.com/dnceng/internal/_build/results?buildId=1473406&view=logs&j=7ae71e7c-d4fe-51ea-64cd-240849b77ab1&t=e2756d63-0606-58d5-0f0d-91c79a5ba922&l=75

```
##[error] System.NotSupportedException: Adding a new package is not supported until we also update for LegacyProjects.props
   at Roslyn.Insertion.CoreXT.AddNewPackage(PackageInfo packageInfo)
   at Roslyn.Insertion.RoslynInsertionTool.UpdatePackages(BuildVersion buildVersion, CoreXT coreXT, String packagesDir, ImmutableArray`1 packagesToBeIgnored, CancellationToken cancellationToken)
   at Roslyn.Insertion.RoslynInsertionTool.<PerformInsertionAsync>d__13.MoveNext()
```