### PR TITLE
Recurse through Packages subdirectories

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool/CoreXT.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/CoreXT.cs
@@ -360,7 +360,7 @@ namespace Roslyn.Insertion
             var versionDescriptor = new GitVersionDescriptor { VersionType = GitVersionType.Commit, Version = commitId };
             var propsFiles = await gitClient.GetItemsAsync(RoslynInsertionTool.VSRepoId,
                 scopePath: PackagePropsDir,
-                recursionLevel: VersionControlRecursionType.OneLevel,
+                recursionLevel: VersionControlRecursionType.Full,
                 download: true,
                 versionDescriptor: versionDescriptor);
 


### PR DESCRIPTION
The Roslyn Insertion Tool already tries to update `PackageReference` items in files under src/ConfigData/Packages in the VS repo. However, it only looks at files within that directory, and does not examine files in subdirectories. This means it fails to find and update Packages/Wizard/Packages.props and Packages/ProjectSystem/Managed.props when inserting builds of dotnet/project-system.

The fix is to retrieve **all** items under src/ConfigData/Packages when building a mapping from the package name to the .props file with the corresponding `PackageReference`, not just the top-level items.