### PR TITLE
Remove 6.0.2xx from linker merges

### DIFF
--- a/src/GitHubCreateMergePRs/config.xml
+++ b/src/GitHubCreateMergePRs/config.xml
@@ -85,7 +85,6 @@
   </repo>
 
   <repo owner="dotnet" name="linker" mergeOwners="agocke,sbomer">
-    <merge from="release/6.0.2xx" to="main" />
     <merge from="main" to="feature/damAnalyzer" />
   </repo>
 </config>


### PR DESCRIPTION
We were planning to put regular changes into that branch, but now it's just a backporting release branch, so it doesn't need merge configuration.