### PR TITLE
Delete release/dev17.1-vs-deps from merge PR flow

### DIFF
--- a/src/GitHubCreateMergePRs/config.xml
+++ b/src/GitHubCreateMergePRs/config.xml
@@ -12,11 +12,10 @@
     <merge from="release/dev17.0-vs-deps" to="release/dev17.1" />
 
     <!-- Roslyn branches (from non-vs-deps to vs-deps) -->
-    <merge from="release/dev17.1" to="release/dev17.1-vs-deps" />
     <merge from="main" to="main-vs-deps" />
 
     <!-- Roslyn release branches (flowing between releases) -->
-    <merge from="release/dev17.1-vs-deps" to="release/dev17.2" />
+    <merge from="release/dev17.1" to="release/dev17.2" />
     <merge from="release/dev17.2" to="main" />
     <merge from="main" to="release/dev17.3" />
 


### PR DESCRIPTION
We've deleted release/dev17.1-vs-deps in Roslyn, so any merge PRs to/from the branch are unnecessary.