### PR TITLE
Flow main-vs-deps to release/dev17.3

### DIFF
--- a/src/GitHubCreateMergePRs/config.xml
+++ b/src/GitHubCreateMergePRs/config.xml
@@ -17,7 +17,7 @@
     <!-- Roslyn release branches (flowing between releases) -->
     <merge from="release/dev17.1" to="release/dev17.2" />
     <merge from="release/dev17.2" to="main" />
-    <merge from="main" to="release/dev17.3" />
+    <merge from="main-vs-deps" to="release/dev17.3" />
 
     <!-- Roslyn feature branches -->
     <merge from="main" to="features/list-patterns" owners="333fred,jcouv" frequency="weekly" />


### PR DESCRIPTION
@RikkiGibson brought up a good point that main-vs-deps should probably flow into release/dev17.3, at least for now, since we don't know whether we'll still need the main-vs-deps branch once 17.3 starts shipping.