### PR TITLE
Added nuget-prepare and nuget-package subcommands to dotnet-roslyn

### DIFF
--- a/.azure-ci.yaml
+++ b/.azure-ci.yaml
@@ -1,7 +1,7 @@
 jobs:
 - job: Windows
   pool:
-    vmImage: vs2017-win2016
+    vmImage: windows-2019
   strategy:
     maxParallel: 2
     matrix:

--- a/RoslynTools.sln
+++ b/RoslynTools.sln
@@ -74,7 +74,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NugetDependencyFinder", "sr
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "dotnet-roslyn", "dotnet-roslyn", "{C68033E0-FB8F-4327-BFB5-B340A5A7778F}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Roslyn.Tool", "src\dotnet-roslyn\Microsoft.Roslyn.Tool.csproj", "{1D14C80C-B4C3-42C1-BA4C-8A81427CA44D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Roslyn", "src\dotnet-roslyn\Microsoft.Roslyn.csproj", "{1D14C80C-B4C3-42C1-BA4C-8A81427CA44D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/dotnet-roslyn/Commands/NuGetPrepareCommand.cs
+++ b/src/dotnet-roslyn/Commands/NuGetPrepareCommand.cs
@@ -1,0 +1,37 @@
+// Licensed to the.NET Foundation under one or more agreements.
+// The.NET Foundation licenses this file to you under the MIT license.
+// See the License.txt file in the project root for more information.
+
+using System.CommandLine.Invocation;
+using System.CommandLine;
+using Microsoft.Roslyn.Tool.NuGet;
+
+namespace Microsoft.Roslyn.Tool.Commands;
+
+using static CommonOptions;
+
+internal class NuGetPrepareCommand
+{
+    private static readonly NuGetPrepareCommandDefaultHandler s_nuGetPrepareCommandHandler = new ();
+
+    public static Symbol GetCommand()
+    {
+        var command = new Command ("nuget-prepare", "Prepares packages built from the Roslyn repo for validation.")
+        {
+            VerbosityOption
+        };
+        command.Handler = s_nuGetPrepareCommandHandler;
+        return command;
+    }
+
+    private class NuGetPrepareCommandDefaultHandler : ICommandHandler
+    {
+        public Task<int> InvokeAsync(InvocationContext context)
+        {
+            var logger = context.SetupLogging ();
+
+            return Task.FromResult(NuGetPrepare.Prepare(logger));
+        }
+    }
+}
+

--- a/src/dotnet-roslyn/Commands/NuGetPublishCommand.cs
+++ b/src/dotnet-roslyn/Commands/NuGetPublishCommand.cs
@@ -1,0 +1,54 @@
+// Licensed to the.NET Foundation under one or more agreements.
+// The.NET Foundation licenses this file to you under the MIT license.
+// See the License.txt file in the project root for more information.
+
+using System.CommandLine.Invocation;
+using System.CommandLine;
+using Microsoft.Roslyn.Tool.NuGet;
+
+namespace Microsoft.Roslyn.Tool.Commands;
+
+using static CommonOptions;
+
+internal class NuGetPublishCommand
+{
+    private static readonly NuGetPublishCommandDefaultHandler s_nuGetPublishCommandHandler = new();
+
+    internal static readonly string[] SupportedRepos = { NuGetPublish.RoslynRepo, NuGetPublish.RoslynSdkRepo };
+
+    internal static readonly Argument<string> RepoNameArgument = new Argument<string>("repo-name", () => NuGetPublish.RoslynRepo, "The name of the repo whose packages are being publishing.").FromAmong(SupportedRepos);
+
+    internal static readonly Option<string> SourceOption = new Option<string>(new[] { "--source", "-s" }, () => "https://www.nuget.org", "Package source (URL, UNC/folder path or package source name) to use.");
+    internal static readonly Option<string> ApiKeyOption = new Option<string>(new[] { "--api-key", "-k" }, "The API key for the server.") { IsRequired = true };
+    internal static readonly Option<bool> UnlistedOption = new Option<bool>(new[] { "--unlisted", "-u" }, "Whether to publish the packages as unlisted.");
+
+    public static Symbol GetCommand()
+    {
+        var command = new Command("nuget-publish", "Publishes packages built from a Roslyn repo.")
+        {
+            RepoNameArgument,
+            SourceOption,
+            ApiKeyOption,
+            UnlistedOption,
+            VerbosityOption
+        };
+        command.Handler = s_nuGetPublishCommandHandler;
+        return command;
+
+    }
+
+    private class NuGetPublishCommandDefaultHandler : ICommandHandler
+    {
+        public async Task<int> InvokeAsync(InvocationContext context)
+        {
+            var logger = context.SetupLogging();
+
+            var repoName = context.ParseResult.GetValueForArgument(RepoNameArgument)!;
+            var source = context.ParseResult.GetValueForOption(SourceOption)!;
+            var apiKey = context.ParseResult.GetValueForOption(ApiKeyOption)!;
+            var unlisted = context.ParseResult.GetValueForOption(UnlistedOption)!;
+
+            return await NuGetPublish.PublishAsync(repoName, source, apiKey, unlisted, logger);
+        }
+    }
+}

--- a/src/dotnet-roslyn/Commands/PRFinderCommand.cs
+++ b/src/dotnet-roslyn/Commands/PRFinderCommand.cs
@@ -37,7 +37,7 @@ internal static class PRFinderCommand
             var previousCommit = context.ParseResult.GetValueForOption(PreviousCommitShaOption)!;
             var currentCommit = context.ParseResult.GetValueForOption(CurrentCommitSHAOption)!;
 
-            return await PRFinder.PRFinder.FindPRs(previousCommit, currentCommit, logger);
+            return await PRFinder.PRFinder.FindPRsAsync(previousCommit, currentCommit, logger);
         }
     }
 }

--- a/src/dotnet-roslyn/Commands/RootRoslynCommand.cs
+++ b/src/dotnet-roslyn/Commands/RootRoslynCommand.cs
@@ -10,6 +10,8 @@ internal static class RootRoslynCommand
 {
     public static RootCommand GetRootCommand() => new RootCommand()
     {
-        PRFinderCommand.GetCommand()
+        PRFinderCommand.GetCommand(),
+        NuGetPrepareCommand.GetCommand(),
+        NuGetPublishCommand.GetCommand(),
     };
 }

--- a/src/dotnet-roslyn/Microsoft.Roslyn.csproj
+++ b/src/dotnet-roslyn/Microsoft.Roslyn.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
+    <ToolCommandName>roslyn</ToolCommandName>
     <Description>Command line tool for performing Roslyn infrastructure tasks.</Description>
 
     <IsPackable>true</IsPackable>

--- a/src/dotnet-roslyn/NuGet/NuGetPrepare.cs
+++ b/src/dotnet-roslyn/NuGet/NuGetPrepare.cs
@@ -1,0 +1,113 @@
+// Licensed to the.NET Foundation under one or more agreements.
+// The.NET Foundation licenses this file to you under the MIT license.
+// See the License.txt file in the project root for more information.
+
+using Microsoft.Extensions.Logging;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.Roslyn.Tool.NuGet
+{
+    internal class NuGetPrepare
+    {
+        private const string NotPublishedDirectoryName = "NotPublished";
+
+        private static readonly string[] RoslynPackageIds =
+            {
+                "Microsoft.CodeAnalysis",
+                "Microsoft.CodeAnalysis.Common",
+                "Microsoft.CodeAnalysis.Compilers",
+                "Microsoft.CodeAnalysis.CSharp",
+                "Microsoft.CodeAnalysis.CSharp.CodeStyle",
+                "Microsoft.CodeAnalysis.CSharp.Features",
+                "Microsoft.CodeAnalysis.CSharp.Scripting",
+                "Microsoft.CodeAnalysis.CSharp.Workspaces",
+                "Microsoft.CodeAnalysis.EditorFeatures.Text",
+                "Microsoft.CodeAnalysis.Features",
+                "Microsoft.CodeAnalysis.Scripting",
+                "Microsoft.CodeAnalysis.Scripting.Common",
+                "Microsoft.CodeAnalysis.VisualBasic",
+                "Microsoft.CodeAnalysis.VisualBasic.CodeStyle",
+                "Microsoft.CodeAnalysis.VisualBasic.Features",
+                "Microsoft.CodeAnalysis.VisualBasic.Workspaces",
+                "Microsoft.CodeAnalysis.Workspaces.Common",
+                "Microsoft.CodeAnalysis.Workspaces.MSBuild",
+                "Microsoft.Net.Compilers",
+                "Microsoft.Net.Compilers.Toolset",
+                "Microsoft.NETCore.Compilers",
+                "Microsoft.VisualStudio.LanguageServices"
+            };
+
+        internal static int Prepare(ILogger logger)
+        {
+            try
+            {
+                string? version;
+
+                var determinedVersion = TryDetermineRoslynPackageVersion(out version);
+
+                if (!determinedVersion)
+                {
+                    logger.LogError("Expected packages are missing. Unable to determine version.");
+                    return 1;
+                }
+
+                logger.LogInformation($"Moving {version} packages...");
+
+                var publishedPackages = RoslynPackageIds
+                    .Select(packageId => $"{packageId}.{version}.nupkg")
+                    .ToHashSet();
+
+                if (!Directory.Exists(NotPublishedDirectoryName))
+                {
+                    Directory.CreateDirectory(NotPublishedDirectoryName);
+                }
+
+                var packageFiles = Directory.GetFiles(Environment.CurrentDirectory, "*.nupkg");
+
+                foreach (var packageFile in packageFiles)
+                {
+                    if (IsPublishedPackage(packageFile, publishedPackages))
+                    {
+                        continue;
+                    }
+
+                    MovePackageAsync(packageFile);
+                }
+
+                logger.LogInformation("Packages moved.");
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return 1;
+            }
+
+            return 0;
+
+            static bool TryDetermineRoslynPackageVersion([NotNullWhen(returnValue: true)] out string? version)
+            {
+                var packageFileName = Directory.GetFiles(Environment.CurrentDirectory, "Microsoft.Net.Compilers.Toolset.*.nupkg").FirstOrDefault();
+                if (packageFileName is null)
+                {
+                    version = null;
+                    return false;
+                }
+
+                version = Path.GetFileNameWithoutExtension(packageFileName).Substring(32);
+                return true;
+            }
+
+            static bool IsPublishedPackage(string packagePath, HashSet<string> publishedPackages)
+            {
+                var packageFileName = Path.GetFileName(packagePath);
+                return publishedPackages.Contains(packageFileName);
+            }
+
+            static void MovePackageAsync(string packagePath)
+            {
+                var packageFileName = Path.GetFileName(packagePath);
+                File.Move(packagePath, Path.Combine(NotPublishedDirectoryName, packageFileName));
+            }
+        }
+    }
+}

--- a/src/dotnet-roslyn/NuGet/NuGetPublish.cs
+++ b/src/dotnet-roslyn/NuGet/NuGetPublish.cs
@@ -1,0 +1,164 @@
+// Licensed to the.NET Foundation under one or more agreements.
+// The.NET Foundation licenses this file to you under the MIT license.
+// See the License.txt file in the project root for more information.
+
+using Microsoft.Extensions.Logging;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Roslyn.Tool.Utilities;
+
+namespace Microsoft.Roslyn.Tool.NuGet
+{
+    internal class NuGetPublish
+    {
+        public const string RoslynRepo = "roslyn";
+        public const string RoslynSdkRepo = "roslyn-sdk";
+
+        private static readonly string[] RoslynPackageIds =
+            {
+                "Microsoft.CodeAnalysis",
+                "Microsoft.CodeAnalysis.Common",
+                "Microsoft.CodeAnalysis.Compilers",
+                "Microsoft.CodeAnalysis.CSharp",
+                "Microsoft.CodeAnalysis.CSharp.CodeStyle",
+                "Microsoft.CodeAnalysis.CSharp.Features",
+                "Microsoft.CodeAnalysis.CSharp.Scripting",
+                "Microsoft.CodeAnalysis.CSharp.Workspaces",
+                "Microsoft.CodeAnalysis.EditorFeatures.Text",
+                "Microsoft.CodeAnalysis.Features",
+                "Microsoft.CodeAnalysis.Scripting",
+                "Microsoft.CodeAnalysis.Scripting.Common",
+                "Microsoft.CodeAnalysis.VisualBasic",
+                "Microsoft.CodeAnalysis.VisualBasic.CodeStyle",
+                "Microsoft.CodeAnalysis.VisualBasic.Features",
+                "Microsoft.CodeAnalysis.VisualBasic.Workspaces",
+                "Microsoft.CodeAnalysis.Workspaces.Common",
+                "Microsoft.CodeAnalysis.Workspaces.MSBuild",
+                "Microsoft.Net.Compilers",
+                "Microsoft.Net.Compilers.Toolset",
+                "Microsoft.NETCore.Compilers",
+                "Microsoft.VisualStudio.LanguageServices"
+            };
+
+        private static readonly string[] RoslynSdkPackageIds =
+            {
+                "Microsoft.CodeAnalysis.Analyzer.Testing",
+                "Microsoft.CodeAnalysis.CodeFix.Testing",
+                "Microsoft.CodeAnalysis.CodeRefactoring.Testing",
+                "Microsoft.CodeAnalysis.CSharp.Analyzer.Testing",
+                "Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest",
+                "Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.NUnit",
+                "Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit",
+                "Microsoft.CodeAnalysis.CSharp.CodeFix.Testing",
+                "Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.MSTest",
+                "Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.NUnit",
+                "Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit",
+                "Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing",
+                "Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.MSTest",
+                "Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.NUnit",
+                "Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.XUnit",
+                "Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing",
+                "Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.MSTest",
+                "Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.NUnit",
+                "Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit",
+                "Microsoft.CodeAnalysis.SourceGenerators.Testing",
+                "Microsoft.CodeAnalysis.Testing.Verifiers.MSTest",
+                "Microsoft.CodeAnalysis.Testing.Verifiers.NUnit",
+                "Microsoft.CodeAnalysis.Testing.Verifiers.XUnit",
+                "Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing",
+                "Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.MSTest",
+                "Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.NUnit",
+                "Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.XUnit",
+                "Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing",
+                "Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.MSTest",
+                "Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.NUnit",
+                "Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit",
+                "Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing",
+                "Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.MSTest",
+                "Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.NUnit",
+                "Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.XUnit",
+                "Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing",
+                "Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing.MSTest",
+                "Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing.NUnit",
+                "Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing.XUnit"
+            };
+
+        internal static async Task<int> PublishAsync(string repoName, string source, string apiKey, bool unlisted, ILogger logger)
+        {
+            try
+            {
+                string? version;
+
+                var determinedVersion = repoName == RoslynRepo
+                    ? TryDetermineRoslynPackageVersion(out version)
+                    : TryDetermineRoslynSdkPackageVersion(out version);
+
+                if (!determinedVersion)
+                {
+                    logger.LogError("Expected packages are missing. Unable to determine version.");
+                    return 1;
+                }
+
+                var packageIds = repoName == RoslynRepo
+                    ? RoslynPackageIds
+                    : RoslynSdkPackageIds;
+
+                logger.LogInformation($"Publishing {version} packages...");
+
+                foreach (var packageId in packageIds)
+                {
+                    await PublishPackageAsync(packageId, version);
+
+                    if (unlisted)
+                    {
+                        await UnlistPackageAsync(packageId, version);
+                    }
+                }
+
+                logger.LogInformation("Packages published.");
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return 1;
+            }
+
+            return 0;
+ 
+            static bool TryDetermineRoslynPackageVersion([NotNullWhen(returnValue: true)] out string? version)
+            {
+                var packageFileName = Directory.GetFiles(Environment.CurrentDirectory, "Microsoft.Net.Compilers.Toolset.*.nupkg").FirstOrDefault();
+                if (packageFileName is null)
+                {
+                    version = null;
+                    return false;
+                }
+
+                version = Path.GetFileNameWithoutExtension(packageFileName).Substring(32);
+                return true;
+            }
+
+            static bool TryDetermineRoslynSdkPackageVersion([NotNullWhen(returnValue: true)] out string? version)
+            {
+                var packageFileName = Directory.GetFiles(Environment.CurrentDirectory, "Microsoft.CodeAnalysis.Analyzer.Testing.*.nupkg").FirstOrDefault();
+                if (packageFileName is null)
+                {
+                    version = null;
+                    return false;
+                }
+
+                version = Path.GetFileNameWithoutExtension(packageFileName).Substring(40);
+                return true;
+            }
+
+            Task<ProcessResult> PublishPackageAsync(string packageId, string? version)
+            {
+                return ProcessRunner.RunProcessAsync("dotnet", $"nuget push --source \"{source}\" --api-key \"{apiKey}\" \"{packageId}.{version}.nupkg\"");
+            }
+
+            Task<ProcessResult> UnlistPackageAsync(string packageId, string? version)
+            {
+                return ProcessRunner.RunProcessAsync("dotnet", $"nuget delete {packageId} {version} --source \"{source}\" --api-key \"{apiKey}\" --non-interactive");
+            }
+        }
+    }
+}

--- a/src/dotnet-roslyn/PRFinder/PRFinder.cs
+++ b/src/dotnet-roslyn/PRFinder/PRFinder.cs
@@ -19,7 +19,7 @@ internal class PRFinder
 
     const string RepoUrl = @"https://www.github.com/dotnet/roslyn";
 
-    public static async Task<int> FindPRs(string previousCommitSha, string currentCommitSha, ILogger logger)
+    public static async Task<int> FindPRsAsync(string previousCommitSha, string currentCommitSha, ILogger logger)
     {
         var previousCommitExists = (await ProcessRunner.RunProcessAsync("git", $"cat-file -t {previousCommitSha}")).ExitCode == 0;
         var currentCommitExists = (await ProcessRunner.RunProcessAsync("git", $"cat-file -t {currentCommitSha}")).ExitCode == 0;

--- a/src/dotnet-roslyn/readme.md
+++ b/src/dotnet-roslyn/readme.md
@@ -1,0 +1,30 @@
+# Microsoft.Roslyn
+
+`dotnet roslyn` is a command line tool for performing Roslyn infrastructure tasks.
+
+## How to Install
+
+You can install the latest build of the tool using the following command.
+
+```console
+dotnet tool install -g Microsoft.Roslyn --prerelease --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json
+```
+
+## How to Use
+
+`dotnet roslyn` functionality is broken up into subcommands.
+
+```
+Commands:
+  pr-finder                          Find PRs between two commits
+  nuget-prepare                      Prepares packages built from the Roslyn repo for validation.
+  nuget-publish <roslyn|roslyn-sdk>  Publishes packages built from a Roslyn repo. [default: roslyn]
+```
+
+## How to Uninstall
+
+You can uninstall the tool using the following command.
+
+```console
+dotnet tool uninstall -g Microsoft.Roslyn
+```


### PR DESCRIPTION
For the benefit of Roslyn acquisition duties. These are ports of powershell scripts I've been using.