### PR TITLE
Show "Changes from .. to .." message when debug logging

### DIFF
--- a/src/dotnet-roslyn-tools/PRFinder/PRFinder.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/PRFinder.cs
@@ -80,6 +80,8 @@ internal class PRFinder
                 ExcludeReachableFrom = previousCommit
             });
 
+        logger.LogDebug($"### Changes from [{previousCommitSha}]({host.GetCommitUrl(repoUrl, previousCommitSha)}) to [{currentCommitSha}]({host.GetCommitUrl(repoUrl, currentCommitSha)}):");
+
         logger.LogInformation($"[View Complete Diff of Changes]({host.GetDiffUrl(repoUrl, previousCommitSha, currentCommitSha)})");
 
         var commitHeaderAdded = false;


### PR DESCRIPTION
This message was useful for VS Mac insertions. Putting it back in debug logging only, means I can add `-v:d` to the command line, but it should not affect roslyn CI builds (i hope!)