### PR TITLE
Remove semantic snippets from merge list

### DIFF
--- a/src/GitHubCreateMergePRs/config.xml
+++ b/src/GitHubCreateMergePRs/config.xml
@@ -24,7 +24,6 @@
     <merge from="main" to="features/RawStringLiterals" owners="CyrusNajmabadi" frequency="daily" />
     <merge from="main" to="features/snappy/nodelay" owners="CyrusNajmabadi" frequency="weekly" />
     <merge from="main" to="features/vs2022-theme" owners="joerobich" frequency="weekly" />
-    <merge from="main" to="features/semantic-snippets" owners="jmarolf,akhera99" frequency="weekly" />
     <merge from="main" to="features/DocumentOutline" owners="jmarolf,emilyanas2323" frequency="weekly" />
     <merge from="main" to="features/FixAllNamingViolation" owners="Cosifne" frequency="weekly" />
   </repo>


### PR DESCRIPTION
The branch will no longer be needed once the feature gets merged to main.