### PR TITLE
Handle exceptions when package props file is not present

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool/CoreXT.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/CoreXT.cs
@@ -354,7 +354,7 @@ namespace Roslyn.Insertion
             return pair;
         }
 
-        private static async Task<bool> IsFilePresent(
+        private static async Task<bool> IsFilePresentAsync(
             GitHttpClient gitClient,
             GitVersionDescriptor versionDescriptor,
             string filePath)
@@ -380,7 +380,7 @@ namespace Roslyn.Insertion
         {
             var versionDescriptor = new GitVersionDescriptor { VersionType = GitVersionType.Commit, Version = commitId };
 
-            var packagePropsFile = IsFilePresent(gitClient, versionDescriptor, PackagePropsPath)
+            var packagePropsFile = await IsFilePresentAsync(gitClient, versionDescriptor, PackagePropsPath)
                 ? PackagePropsPath
                 : LegacyPackagePropsPath;
 

--- a/src/RoslynInsertionTool/RoslynInsertionTool/CoreXT.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/CoreXT.cs
@@ -354,7 +354,7 @@ namespace Roslyn.Insertion
             return pair;
         }
 
-        private static Task<bool> IsFilePresent(
+        private static async Task<bool> IsFilePresent(
             GitHttpClient gitClient,
             GitVersionDescriptor versionDescriptor,
             string filePath)


### PR DESCRIPTION
Fixes failure when generating insertions for servicing branches.

```
Using artifacts provided in BuildDropPath: D:\a\_work\1\VSSetup
##[error] Microsoft.VisualStudio.Services.Common.VssServiceException: TF401174: The item 'Directory.Packages.props' could not be found in the repository 'VS' at the version specified by '<Commit: 7e73b799c3e113339d4e2d2456d8b71c08b89ac5 >' (resolved to commit '7e73b799c3e113339d4e2d2456d8b71c08b89ac5')
   at Microsoft.VisualStudio.Services.WebApi.VssHttpClientBase.<HandleResponseAsync>d__53.MoveNext()
```

Failing insertion: https://dev.azure.com/dnceng/internal/_build/results?buildId=1811662&view=logs&j=7ae71e7c-d4fe-51ea-64cd-240849b77ab1&t=e2756d63-0606-58d5-0f0d-91c79a5ba922 (microsoft)