### PR TITLE
Remove 17.1 from Roslyn merge config

### DIFF
--- a/src/GitHubCreateMergePRs/config.xml
+++ b/src/GitHubCreateMergePRs/config.xml
@@ -1,6 +1,10 @@
 <config>
   <repo owner="dotnet" name="roslyn" mergeOwners="RikkiGibson">
-    <!-- For a list of VS versions under servicing, see https://docs.microsoft.com/en-us/visualstudio/releases/2019/servicing#support-options-for-enterprise-and-professional-customers -->
+    <!--
+      VS versions under servicing:
+        VS 2019: https://docs.microsoft.com/en-us/lifecycle/products/visual-studio-2019
+        VS 2022: https://docs.microsoft.com/en-us/lifecycle/products/visual-studio-2022
+    -->
     <!-- Roslyn servicing branches (flowing between releases) -->
     <merge from="dev15.9.x" to="release/dev16.9-vs-deps" />
     <merge from="release/dev16.9-vs-deps" to="release/dev16.11-vs-deps" />

--- a/src/GitHubCreateMergePRs/config.xml
+++ b/src/GitHubCreateMergePRs/config.xml
@@ -5,8 +5,7 @@
     <merge from="dev15.9.x" to="release/dev16.9-vs-deps" />
     <merge from="release/dev16.9-vs-deps" to="release/dev16.11-vs-deps" />
     <merge from="release/dev16.11-vs-deps" to="release/dev17.0-vs-deps" />
-    <merge from="release/dev17.0-vs-deps" to="release/dev17.1" />
-    <merge from="release/dev17.1" to="release/dev17.2" />
+    <merge from="release/dev17.0-vs-deps" to="release/dev17.2" />
 
     <!-- Roslyn last servicing branch (flowing into current branch) -->
     <merge from="release/dev17.2" to="release/dev17.3" />


### PR DESCRIPTION
17.1 is no longer supported so no need to manage auto-merges through it. Once we merge here let's also delete the branch on the Roslyn side and remove from PublishData.

cc @jasonmalinowski @JoeRobich 