### PR TITLE
Remove deprecated compilers packages from nuget publishing.

### DIFF
--- a/src/dotnet-roslyn-tools/NuGet/NuGetPrepare.cs
+++ b/src/dotnet-roslyn-tools/NuGet/NuGetPrepare.cs
@@ -31,9 +31,7 @@ namespace Microsoft.RoslynTools.NuGet
                 "Microsoft.CodeAnalysis.VisualBasic.Workspaces",
                 "Microsoft.CodeAnalysis.Workspaces.Common",
                 "Microsoft.CodeAnalysis.Workspaces.MSBuild",
-                "Microsoft.Net.Compilers",
                 "Microsoft.Net.Compilers.Toolset",
-                "Microsoft.NETCore.Compilers",
                 "Microsoft.VisualStudio.LanguageServices"
             };
 

--- a/src/dotnet-roslyn-tools/NuGet/NuGetPublish.cs
+++ b/src/dotnet-roslyn-tools/NuGet/NuGetPublish.cs
@@ -33,9 +33,7 @@ namespace Microsoft.RoslynTools.NuGet
                 "Microsoft.CodeAnalysis.VisualBasic.Workspaces",
                 "Microsoft.CodeAnalysis.Workspaces.Common",
                 "Microsoft.CodeAnalysis.Workspaces.MSBuild",
-                "Microsoft.Net.Compilers",
                 "Microsoft.Net.Compilers.Toolset",
-                "Microsoft.NETCore.Compilers",
                 "Microsoft.VisualStudio.LanguageServices"
             };
 


### PR DESCRIPTION
Microsoft.Net.Compilers.Toolset is the one true Roslyn compilers package. Remove the older packages from publishing.