### PR TITLE
Add VS insertion PR tagger

### DIFF
--- a/src/dotnet-roslyn-tools/Commands/PRTaggerCommand.cs
+++ b/src/dotnet-roslyn-tools/Commands/PRTaggerCommand.cs
@@ -1,0 +1,48 @@
+// Licensed to the.NET Foundation under one or more agreements.
+// The.NET Foundation licenses this file to you under the MIT license.
+// See the License.txt file in the project root for more information.
+
+namespace Microsoft.RoslynTools.Commands;
+
+using System.CommandLine.Invocation;
+using System.CommandLine;
+
+internal static class PRTaggerCommand
+{
+    private static readonly PRTaggerCommandDefaultHandler s_prTaggerCommandHandler = new();
+
+    internal static readonly Option<string> VSBuild = new(new[] { "--build", "-b" }, "VS build number") { IsRequired = true };
+    internal static readonly Option<string> CommitId = new(new[] { "--commit", "-c" }, "VS build commit") { IsRequired = true };
+    internal static readonly Option<string> GitHubUsername = new(new[] { "--username", "-u" }, "GitHub username") { IsRequired = true };
+    internal static readonly Option<string> GitHubPassword = new(new[] { "--password", "-p" }, "GitHub password") { IsRequired = true };
+
+    public static Symbol GetCommand()
+    {
+        var command = new Command("pr-tagger", "Tags PRs inserted in a given VS build.")
+        {
+            CommitId,
+            GitHubUsername,
+            GitHubPassword,
+            CommonOptions.DevDivAzDOTokenOption,
+        };
+
+        command.Handler = s_prTaggerCommandHandler;
+        return command;
+    }
+
+    private class PRTaggerCommandDefaultHandler : ICommandHandler
+    {
+        public async Task<int> InvokeAsync(InvocationContext context)
+        {
+            var logger = context.SetupLogging();
+            var vsBuild = context.ParseResult.GetValueForOption(VSBuild)!;
+            var vsCommitSha = context.ParseResult.GetValueForOption(CommitId)!;
+            var gitHubUsername = context.ParseResult.GetValueForOption(GitHubUsername)!;
+            var gitHubPassword = context.ParseResult.GetValueForOption(GitHubPassword)!;
+            var settings = context.ParseResult.LoadSettings(logger);
+
+            return await PRTagger.PRTagger.TagPRs(
+                vsBuild, vsCommitSha, settings, gitHubUsername, gitHubPassword, logger, CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/dotnet-roslyn-tools/Commands/PRTaggerCommand.cs
+++ b/src/dotnet-roslyn-tools/Commands/PRTaggerCommand.cs
@@ -20,6 +20,7 @@ internal static class PRTaggerCommand
     {
         var command = new Command("pr-tagger", "Tags PRs inserted in a given VS build.")
         {
+            VSBuild,
             CommitId,
             GitHubUsername,
             GitHubPassword,

--- a/src/dotnet-roslyn-tools/Commands/RootRoslynCommand.cs
+++ b/src/dotnet-roslyn-tools/Commands/RootRoslynCommand.cs
@@ -14,6 +14,7 @@ internal static class RootRoslynCommand
         {
             AuthenticateCommand.GetCommand(),
             PRFinderCommand.GetCommand(),
+            PRTaggerCommand.GetCommand(),
             NuGetDependenciesCommand.GetCommand(),
             NuGetPrepareCommand.GetCommand(),
             NuGetPublishCommand.GetCommand(),

--- a/src/dotnet-roslyn-tools/Extensions/HttpClientExtensions.cs
+++ b/src/dotnet-roslyn-tools/Extensions/HttpClientExtensions.cs
@@ -1,0 +1,16 @@
+// Licensed to the.NET Foundation under one or more agreements.
+// The.NET Foundation licenses this file to you under the MIT license.
+// See the License.txt file in the project root for more information.
+
+namespace Microsoft.RoslynTools.Extensions;
+
+using System.Text;
+
+internal static class HttpClientExtensions
+{
+    public static Task<HttpResponseMessage> PostAsyncAsJson(this HttpClient client, string requestUri, string body)
+        => client.PostAsync(requestUri, new StringContent(body, Encoding.UTF8, "application/json"));
+
+    public static Task<HttpResponseMessage> PutAsyncAsJson(this HttpClient client, string requestUri, string body)
+        => client.PutAsync(requestUri, new StringContent(body, Encoding.UTF8, "application/json"));
+}

--- a/src/dotnet-roslyn-tools/Microsoft.RoslynTools.csproj
+++ b/src/dotnet-roslyn-tools/Microsoft.RoslynTools.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
@@ -27,7 +27,6 @@
     <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0175" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.201.0-preview" />
-    <PackageReference Include="Microsoft.TeamFoundationServer.ExtendedClient" Version="16.201.0-preview" />
     <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="16.201.0-preview" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NuGet.Protocol" Version="6.1.0" />

--- a/src/dotnet-roslyn-tools/Microsoft.RoslynTools.csproj
+++ b/src/dotnet-roslyn-tools/Microsoft.RoslynTools.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
@@ -27,6 +27,7 @@
     <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0175" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.201.0-preview" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.ExtendedClient" Version="16.201.0-preview" />
     <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="16.201.0-preview" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NuGet.Protocol" Version="6.1.0" />

--- a/src/dotnet-roslyn-tools/PRFinder/PRFinder.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/PRFinder.cs
@@ -2,13 +2,15 @@
 // The.NET Foundation licenses this file to you under the MIT license.
 // See the License.txt file in the project root for more information.
 
+namespace Microsoft.RoslynTools.PRFinder;
+
 using LibGit2Sharp;
 using Microsoft.Extensions.Logging;
-namespace Microsoft.RoslynTools.PRFinder;
+using System.Text;
 
 internal class PRFinder
 {
-    public static int FindPRs(string previousCommitSha, string currentCommitSha, ILogger logger)
+    public static int FindPRs(string previousCommitSha, string currentCommitSha, ILogger logger, StringBuilder? builder = null)
     {
         using var repo = new Repository(Environment.CurrentDirectory);
 
@@ -82,7 +84,7 @@ internal class PRFinder
 
         logger.LogDebug($"### Changes from [{previousCommitSha}]({host.GetCommitUrl(repoUrl, previousCommitSha)}) to [{currentCommitSha}]({host.GetCommitUrl(repoUrl, currentCommitSha)}):");
 
-        logger.LogInformation($"[View Complete Diff of Changes]({host.GetDiffUrl(repoUrl, previousCommitSha, currentCommitSha)})");
+        RecordLine($"[View Complete Diff of Changes]({host.GetDiffUrl(repoUrl, previousCommitSha, currentCommitSha)})", logger, builder);
 
         var commitHeaderAdded = false;
         var mergePRHeaderAdded = false;
@@ -107,7 +109,7 @@ internal class PRFinder
                 if (commitHeaderAdded && !mergePRHeaderAdded)
                 {
                     mergePRHeaderAdded = true;
-                    logger.LogInformation("### Merged PRs:");
+                    RecordLine("### Merged PRs:", logger, builder);
                 }
 
                 mergePRFound = true;
@@ -122,7 +124,7 @@ internal class PRFinder
                 if (!commitHeaderAdded)
                 {
                     commitHeaderAdded = true;
-                    logger.LogInformation("### Commits since last PR:");
+                    RecordLine("### Commits since last PR:", logger, builder);
                 }
 
                 var fullSHA = commit.Sha;
@@ -134,9 +136,15 @@ internal class PRFinder
                 prLink = $@"- [{comment}]({host.GetCommitUrl(repoUrl, fullSHA)})";
             }
 
-            logger.LogInformation(prLink);
+            RecordLine(prLink, logger, builder);
         }
 
         return 0;
+    }
+
+    private static void RecordLine(string line, ILogger logger, StringBuilder? builder)
+    {
+        logger.LogInformation(line);
+        builder?.AppendLine(line);
     }
 }

--- a/src/dotnet-roslyn-tools/PRFinder/PRFinder.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/PRFinder.cs
@@ -10,6 +10,14 @@ using System.Text;
 
 internal class PRFinder
 {
+    /// <summary>
+    /// Finds the PRs merged between two given commits.
+    /// </summary>
+    /// <param name="previousCommitSha">Previous commit SHA.</param>
+    /// <param name="currentCommitSha">Current commit SHA.</param>
+    /// <param name="logger">Logger where result will be output.</param>
+    /// <param name="builder">Optional if the caller wants result as a string.</param>
+    /// <returns></returns>
     public static int FindPRs(string previousCommitSha, string currentCommitSha, ILogger logger, StringBuilder? builder = null)
     {
         using var repo = new Repository(Environment.CurrentDirectory);

--- a/src/dotnet-roslyn-tools/PRTagger/PRTagger.cs
+++ b/src/dotnet-roslyn-tools/PRTagger/PRTagger.cs
@@ -1,0 +1,169 @@
+// Licensed to the.NET Foundation under one or more agreements.
+// The.NET Foundation licenses this file to you under the MIT license.
+// See the License.txt file in the project root for more information.
+
+namespace Microsoft.RoslynTools.PRTagger;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.RoslynTools.Authentication;
+using Microsoft.RoslynTools.Extensions;
+using Microsoft.RoslynTools.Products;
+using Microsoft.RoslynTools.Utilities;
+using Microsoft.TeamFoundation.SourceControl.WebApi;
+using Newtonsoft.Json;
+using System.Net.Http.Headers;
+using System.Text;
+
+internal class PRTagger
+{
+    private static readonly Roslyn s_roslynInfo = new();
+
+    // TO-DO: Catch potential exceptions
+    public static async Task<int> TagPRs(
+        string vsBuild,
+        string vsCommitSha,
+        RoslynToolsSettings settings,
+        string gitHubUsername,
+        string gitHubPassword,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        // Set up connection to DevDiv AzDo and get VS repo
+        using var devdivConnection = new AzDOConnection(settings.DevDivAzureDevOpsBaseUri, "DevDiv", settings.DevDivAzureDevOpsToken);
+        var vsRepository = await GetVSRepositoryAsync(devdivConnection.GitClient);
+
+        // Find previous VS commit SHA
+        var vsCommit = await devdivConnection.GitClient.GetCommitAsync(
+            vsCommitSha, vsRepository.Id, cancellationToken: cancellationToken).ConfigureAwait(false);
+        var previousVsCommitSha = vsCommit.Parents.First();
+
+        // Get associated Roslyn build for current and previous VS commit SHAs
+        var currentRoslynBuild = await TryGetRoslynBuildNumberForReleaseAsync(vsCommitSha, devdivConnection).ConfigureAwait(false);
+        var previousRoslynBuild = await TryGetRoslynBuildNumberForReleaseAsync(previousVsCommitSha, devdivConnection).ConfigureAwait(false);
+
+        if (currentRoslynBuild is null)
+        {
+            logger.LogError($"Roslyn build not found for VS commit SHA {currentRoslynBuild}");
+            return -1;
+        }
+
+        if (previousRoslynBuild is null)
+        {
+            logger.LogError($"Roslyn build not found for VS commit SHA {previousRoslynBuild}");
+            return -1;
+        }
+
+        // If builds are the same, there are no PRs to tag
+        if (currentRoslynBuild.Equals(previousRoslynBuild))
+        {
+            logger.LogInformation($"No PRs found to tag; Roslyn build numbers are equal: {currentRoslynBuild}");
+            return 0;
+        }
+
+        using var dncengConnection = new AzDOConnection(settings.DncEngAzureDevOpsBaseUri, "internal", settings.DncEngAzureDevOpsToken);
+        var previousRoslynCommitSha = await TryGetRoslynCommitShaFromBuildAsync(dncengConnection, previousRoslynBuild, logger).ConfigureAwait(false);
+        var currentRoslynCommitSha = await TryGetRoslynCommitShaFromBuildAsync(dncengConnection, currentRoslynBuild, logger).ConfigureAwait(false);
+
+        if (previousRoslynCommitSha is null || currentRoslynCommitSha is null)
+        {
+            logger.LogError($"Error retrieving Roslyn commit SHAs.");
+            return -1;
+        }
+
+        var prDescription = new StringBuilder();
+        var isSuccess = PRFinder.PRFinder.FindPRs(previousRoslynCommitSha, currentRoslynCommitSha, logger, prDescription);
+        if (isSuccess != 0)
+        {
+            return -1;
+        }
+        var issueCreated = await TryCreateIssue(vsBuild, prDescription.ToString(), gitHubUsername, gitHubPassword, logger);
+        return issueCreated ? 0 : 1;
+    }
+
+    private static async Task<GitRepository> GetVSRepositoryAsync(GitHttpClient gitClient)
+    {
+        return await gitClient.GetRepositoryAsync("DevDiv", "VS");
+    }
+
+    private static async Task<string?> TryGetRoslynBuildNumberForReleaseAsync(
+        string vsCommitSha,
+        AzDOConnection vsConnection)
+    {
+        var url = await VisualStudioRepository.GetUrlFromComponentJsonFileAsync(
+            vsCommitSha, GitVersionType.Commit, vsConnection, s_roslynInfo.ComponentJsonFileName, s_roslynInfo.ComponentName);
+        if (url is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            var buildNumber = VisualStudioRepository.GetBuildNumberFromUrl(url);
+            return buildNumber;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static async Task<string?> TryGetRoslynCommitShaFromBuildAsync(
+        AzDOConnection buildConnection,
+        string buildNumber)
+    {
+        var build = (await buildConnection.TryGetBuildsAsync(
+            s_roslynInfo.GetBuildPipelineName(buildConnection.BuildProjectName)!, buildNumber))?.SingleOrDefault();
+
+        if (build == null)
+        {
+            return null;
+        }
+
+        return build.SourceVersion;
+    }
+
+    private async static Task<bool> TryCreateIssue(
+        string vsBuildNumber,
+        string issueBody,
+        string gitHubUsername,
+        string gitHubPassword,
+        ILogger logger)
+    {
+        var client = new HttpClient
+        {
+            BaseAddress = new("https://api.github.com/")
+        };
+
+        var authArray = Encoding.ASCII.GetBytes($"{gitHubUsername}:{gitHubPassword}");
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Basic",
+            Convert.ToBase64String(authArray));
+        client.DefaultRequestHeaders.Add(
+            "user-agent",
+            "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.2;)");
+
+        // Needed to call the check-runs endpoint
+        client.DefaultRequestHeaders.Accept.Add(
+            new MediaTypeWithQualityHeaderValue("application/vnd.github.antiope-preview+json"));
+
+        // TO-DO: Generalize for other repos
+        // https://developer.github.com/v3/pulls/#create-a-pull-request
+        var response = await client.PostAsyncAsJson($"repos/dotnet/roslyn/issues", JsonConvert.SerializeObject(
+            new
+            {
+                title = $"[Automated] PRs in VS build {vsBuildNumber}",
+                body = issueBody,
+            }));
+
+        if (response.IsSuccessStatusCode)
+        {
+            logger.LogInformation("Successfully created issue.");
+            return true;
+        }
+        else
+        {
+            logger.LogInformation($"Issue creation failed with status code: {response.StatusCode}");
+            return false;
+        }
+    }
+}

--- a/src/dotnet-roslyn-tools/PRTagger/PRTagger.cs
+++ b/src/dotnet-roslyn-tools/PRTagger/PRTagger.cs
@@ -151,7 +151,7 @@ internal class PRTagger
         var response = await client.PostAsyncAsJson($"repos/dotnet/roslyn/issues", JsonConvert.SerializeObject(
             new
             {
-                title = $"[Automated] PRs in VS build {vsBuildNumber}",
+                title = $"[Automated] PRs inserted in VS build {vsBuildNumber}",
                 body = issueBody,
             }));
 

--- a/src/dotnet-roslyn-tools/PRTagger/PRTagger.cs
+++ b/src/dotnet-roslyn-tools/PRTagger/PRTagger.cs
@@ -195,7 +195,7 @@ internal class PRTagger
 
         if (!response.IsSuccessStatusCode)
         {
-            logger.LogInformation($"Issue creation failed with status code: {response.StatusCode}");
+            logger.LogError($"Issue creation failed with status code: {response.StatusCode}");
             return false;
         }
 

--- a/src/dotnet-roslyn-tools/PRTagger/PRTagger.cs
+++ b/src/dotnet-roslyn-tools/PRTagger/PRTagger.cs
@@ -61,8 +61,8 @@ internal class PRTagger
         }
 
         using var dncengConnection = new AzDOConnection(settings.DncEngAzureDevOpsBaseUri, "internal", settings.DncEngAzureDevOpsToken);
-        var previousRoslynCommitSha = await TryGetRoslynCommitShaFromBuildAsync(dncengConnection, previousRoslynBuild, logger).ConfigureAwait(false);
-        var currentRoslynCommitSha = await TryGetRoslynCommitShaFromBuildAsync(dncengConnection, currentRoslynBuild, logger).ConfigureAwait(false);
+        var previousRoslynCommitSha = await TryGetRoslynCommitShaFromBuildAsync(dncengConnection, previousRoslynBuild).ConfigureAwait(false);
+        var currentRoslynCommitSha = await TryGetRoslynCommitShaFromBuildAsync(dncengConnection, currentRoslynBuild).ConfigureAwait(false);
 
         if (previousRoslynCommitSha is null || currentRoslynCommitSha is null)
         {

--- a/src/dotnet-roslyn-tools/PRTagger/PRTagger.cs
+++ b/src/dotnet-roslyn-tools/PRTagger/PRTagger.cs
@@ -193,15 +193,13 @@ internal class PRTagger
                 labels = new string[] { "vs-insertion" }
             }));
 
-        if (response.IsSuccessStatusCode)
-        {
-            logger.LogInformation("Successfully created issue.");
-            return true;
-        }
-        else
+        if (!response.IsSuccessStatusCode)
         {
             logger.LogInformation($"Issue creation failed with status code: {response.StatusCode}");
             return false;
         }
+
+        logger.LogInformation("Successfully created issue.");
+        return true;
     }
 }


### PR DESCRIPTION
- Implements a PR tagger that creates an issue with the PRs that were inserted in a given VS build.
- Currently works with Roslyn and Razor but can likely be extended to other repos as well.
- After this is merged, we should be able to trigger runs automatically via AzDo pipelines.