### PR TITLE
[PR tagger] Add repo path parameter

### DIFF
--- a/src/dotnet-roslyn-tools/Commands/PRTaggerCommand.cs
+++ b/src/dotnet-roslyn-tools/Commands/PRTaggerCommand.cs
@@ -14,6 +14,7 @@ internal static class PRTaggerCommand
 
     private static readonly Option<string> ProductName = new Option<string>(new[] { "--product-name", "-p" }, "Name of product (e.g. 'roslyn' or 'razor')") { IsRequired = true }
         .FromAmong("roslyn", "razor");
+    private static readonly Option<string> ProductRepoPath = new(new[] { "--repo-path" }, "Path to product repo") { IsRequired = true };
     private static readonly Option<string> VSBuild = new(new[] { "--build", "-b" }, "VS build number") { IsRequired = true };
     private static readonly Option<string> CommitId = new(new[] { "--commit", "-c" }, "VS build commit") { IsRequired = true };
 
@@ -22,6 +23,7 @@ internal static class PRTaggerCommand
         var command = new Command("pr-tagger", "Tags PRs inserted in a given VS build.")
         {
             ProductName,
+            ProductRepoPath,
             VSBuild,
             CommitId,
             CommonOptions.GitHubTokenOption,
@@ -39,6 +41,7 @@ internal static class PRTaggerCommand
         {
             var logger = context.SetupLogging();
             var productName = context.ParseResult.GetValueForOption(ProductName)!;
+            var productRepoPath = context.ParseResult.GetValueForOption(ProductRepoPath)!;
             var vsBuild = context.ParseResult.GetValueForOption(VSBuild)!;
             var vsCommitSha = context.ParseResult.GetValueForOption(CommitId)!;
             var settings = context.ParseResult.LoadSettings(logger);
@@ -52,7 +55,7 @@ internal static class PRTaggerCommand
             }
 
             return await PRTagger.PRTagger.TagPRs(
-                productName, vsBuild, vsCommitSha, settings, logger, CancellationToken.None).ConfigureAwait(false);
+                productName, productRepoPath, vsBuild, vsCommitSha, settings, logger, CancellationToken.None).ConfigureAwait(false);
         }
     }
 }

--- a/src/dotnet-roslyn-tools/Commands/PRTaggerCommand.cs
+++ b/src/dotnet-roslyn-tools/Commands/PRTaggerCommand.cs
@@ -12,9 +12,9 @@ internal static class PRTaggerCommand
 {
     private static readonly PRTaggerCommandDefaultHandler s_prTaggerCommandHandler = new();
 
-    private static readonly Option<string> ProductName = new Option<string>(new[] { "--product-name", "-p" }, "Name of product (e.g. 'roslyn' or 'razor')") { IsRequired = true }
+    private static readonly Option<string> ProductName = new Option<string>(new[] { "--product-name", "-n" }, "Name of product (e.g. 'roslyn' or 'razor')") { IsRequired = true }
         .FromAmong("roslyn", "razor");
-    private static readonly Option<string> ProductRepoPath = new(new[] { "--repo-path" }, "Path to product repo") { IsRequired = true };
+    private static readonly Option<string> ProductRepoPath = new(new[] { "--repo-path", "-p" }, "Path to product repo") { IsRequired = true };
     private static readonly Option<string> VSBuild = new(new[] { "--build", "-b" }, "VS build number") { IsRequired = true };
     private static readonly Option<string> CommitId = new(new[] { "--commit", "-c" }, "VS build commit") { IsRequired = true };
 

--- a/src/dotnet-roslyn-tools/PRFinder/PRFinder.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/PRFinder.cs
@@ -16,11 +16,17 @@ internal class PRFinder
     /// <param name="previousCommitSha">Previous commit SHA.</param>
     /// <param name="currentCommitSha">Current commit SHA.</param>
     /// <param name="logger">Logger where result will be output.</param>
+    /// <param name="repoPath">Optional path to product repo. Current directory will be used otherwise.</param>
     /// <param name="builder">Optional if the caller wants result as a string.</param>
     /// <returns></returns>
-    public static int FindPRs(string previousCommitSha, string currentCommitSha, ILogger logger, StringBuilder? builder = null)
+    public static int FindPRs(
+        string previousCommitSha,
+        string currentCommitSha,
+        ILogger logger,
+        string? repoPath = null,
+        StringBuilder? builder = null)
     {
-        using var repo = new Repository(Environment.CurrentDirectory);
+        using var repo = new Repository(repoPath ?? Environment.CurrentDirectory);
 
         var currentCommit = repo.Lookup<Commit>(currentCommitSha);
         var previousCommit = repo.Lookup<Commit>(previousCommitSha);

--- a/src/dotnet-roslyn-tools/PRTagger/PRTagger.cs
+++ b/src/dotnet-roslyn-tools/PRTagger/PRTagger.cs
@@ -32,6 +32,7 @@ internal class PRTagger
     /// <returns>Exit code indicating whether issue was successfully created.</returns>
     public static async Task<int> TagPRs(
         string productName,
+        string productRepoPath,
         string vsBuild,
         string vsCommitSha,
         RoslynToolsSettings settings,
@@ -93,7 +94,7 @@ internal class PRTagger
 
         // Find PRs between product commit SHAs
         var prDescription = new StringBuilder();
-        var isSuccess = PRFinder.PRFinder.FindPRs(previousProductCommitSha, currentProductCommitSha, logger, prDescription);
+        var isSuccess = PRFinder.PRFinder.FindPRs(previousProductCommitSha, currentProductCommitSha, logger, productRepoPath, prDescription);
         if (isSuccess != 0)
         {
             return isSuccess;


### PR DESCRIPTION
Forgot this in the original PR - we need to pass in the product repo path as an argument since we won't necessarily be in the correct directory when running the release pipeline.