### PR TITLE
RIT: Queue symbol check for draft insertion PRs

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
@@ -482,6 +482,7 @@ namespace Roslyn.Insertion
                         }
 
                         await QueueVSBuildPolicy(pullRequest, "Request Perf DDRITs");
+                        await QueueVSBuildPolicy(pullRequest, "Insertion Symbol Check");
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
Roslyn had not configured a default channel for a newly snapped release branch and this would have caught the issue earlier.