### PR TITLE
Remove main sync for convert to record

### DIFF
--- a/src/GitHubCreateMergePRs/config.xml
+++ b/src/GitHubCreateMergePRs/config.xml
@@ -26,7 +26,6 @@
     <merge from="main" to="features/vs2022-theme" owners="joerobich" frequency="weekly" />
     <merge from="main" to="features/DocumentOutline" owners="jmarolf,emilyanas2323" frequency="weekly" />
     <merge from="main" to="features/editorconfig_lsp" owners="dibarbet,Danyboyyy" frequency="weekly" />
-    <merge from="main" to="features/ConvertToRecord" owners="Soreloser2,jasonmalinowski" frequency="weekly" />
     <merge from="main" to="features/FixAllNamingViolation" owners="Cosifne" frequency="weekly" />
   </repo>
 


### PR DESCRIPTION
Remove so that we can (potentially) merge the feature for Preview 2. If we don't make it, we can put it back or manually do merges.