### PR TITLE
Try to queue MSBuildRetail on draft insertions

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
@@ -481,7 +481,7 @@ namespace Roslyn.Insertion
                             await QueueVSBuildPolicy(pullRequest, "CloudBuild - PR");
 
                             // MSBuildRetail policy doesn't exist in servicing branches.
-                            await TryQueueVSBuildPolicy(pullRequest, "Cloudbuild - MSBuildRetail");
+                            await TryQueueVSBuildPolicy(pullRequest, "Cloudbuild - MSBuildRetail", insertionBranchName);
                         }
 
                         await QueueVSBuildPolicy(pullRequest, "Request Perf DDRITs");

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.cs
@@ -479,7 +479,9 @@ namespace Roslyn.Insertion
                             // If we do not queue a CloudBuild the Perf DDRITs request will
                             // spin waiting for a build to test against until it timesout.
                             await QueueVSBuildPolicy(pullRequest, "CloudBuild - PR");
-                            await QueueVSBuildPolicy(pullRequest, "Cloudbuild - MSBuildRetail");
+
+                            // MSBuildRetail policy doesn't exist in servicing branches.
+                            await TryQueueVSBuildPolicy(pullRequest, "Cloudbuild - MSBuildRetail");
                         }
 
                         await QueueVSBuildPolicy(pullRequest, "Request Perf DDRITs");


### PR DESCRIPTION
Queuing a policy that doesn't exist throws and exception and keeps us from starting other necessary policies.