### PR TITLE
Update assembly resolution paths used by VSIXExpInstaller

### DIFF
--- a/src/VSIXExpInstaller/Program.cs
+++ b/src/VSIXExpInstaller/Program.cs
@@ -158,10 +158,12 @@ namespace VsixExpInstaller
                 var assemblyResolutionPaths = new string[] {
                     // Microsoft.VisualStudio.Threading, Version=17.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
                     Path.Combine(vsInstallDir, @"Common7\IDE\PublicAssemblies\Microsoft.VisualStudio.Threading.17.x"),
-                    // Newtonsoft.Json, Version=12.0.0.2, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed
-                    Path.Combine(vsInstallDir, @"Common7\IDE\PrivateAssemblies\Newtonsoft.Json.12.0.0.2"),
-                    Path.Combine(vsInstallDir, @"Common7\IDE"),
+                    Path.Combine(vsInstallDir, @"Common7\IDE\PublicAssemblies\Nerdbank.Streams.2.x"),
+                    Path.Combine(vsInstallDir, @"Common7\IDE\PublicAssemblies\MessagePack.2.x"),
+                    // Newtonsoft.Json, Version=13.0.1.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed
+                    Path.Combine(vsInstallDir, @"Common7\IDE\PrivateAssemblies\Newtonsoft.Json.13.0.1.0"),
                     Path.Combine(vsInstallDir, @"Common7\IDE\PrivateAssemblies"),
+                    Path.Combine(vsInstallDir, @"Common7\IDE"),
                     Path.Combine(vsInstallDir, @"Common7\IDE\PublicAssemblies")
                 };
 


### PR DESCRIPTION
This brings them in line with https://github.com/microsoft/vs-extension-testing/blob/7e123a38b0b5f52a233f449390e0346c4c598655/src/Microsoft.VisualStudio.VsixInstaller.Shared/Installer.cs#L41-L86

verified this work locally to fix the hang when launching integration tests.