### PR TITLE
`F#`: Disable `main` -> `17.4` branches auto-merges

### DIFF
--- a/src/GitHubCreateMergePRs/config.xml
+++ b/src/GitHubCreateMergePRs/config.xml
@@ -66,7 +66,6 @@
     <merge from="release/dev17.3" to="release/dev17.4" />
 
     <!-- regular branch flow -->
-    <merge from="main" to="release/dev17.4" />
     <merge from="feature/auto-widen" to="feature/erased-unions" />
   </repo>
 


### PR DESCRIPTION
Disabling auto merges to release branch, all fixes will have to be a separate PR.