### PR TITLE
Compact logs

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
@@ -241,13 +241,13 @@ namespace Roslyn.Insertion
                 if (evaluation != null)
                 {
                     await policyClient.RequeuePolicyEvaluationAsync(repository.ProjectReference.Id, evaluation.EvaluationId);
-                    Console.WriteLine($"Started '{buildPolicy}' build policy on {pullRequest.Description}");
+                    Console.WriteLine($"Started '{buildPolicy}' build policy on {pullRequest.Title}");
                     break;
                 }
 
                 if (stopwatch.Elapsed > timeout)
                 {
-                    throw new ArgumentException($"Cannot find a '{buildPolicy}' build policy in {pullRequest.Description}.");
+                    throw new ArgumentException($"Cannot find a '{buildPolicy}' build policy in {pullRequest.Title}.");
                 }
             }
         }


### PR DESCRIPTION
Writing out pullRequest.Description multiple times is noisy, let's try using the Title instead.

https://dev.azure.com/dnceng/internal/_build/results?buildId=2028927&view=logs&j=7ae71e7c-d4fe-51ea-64cd-240849b77ab1&t=e2756d63-0606-58d5-0f0d-91c79a5ba922

<details>
    <summary>Long log</summary>

```md
- [Implement equality semantics for async tagger tags. (take2) (64895)](//github.com/dotnet/roslyn/pull/64895)
- [Only write out inVs properties when appropriate (64853)](//github.com/dotnet/roslyn/pull/64853)
- [Get binlog on constructor failure (64899)](//github.com/dotnet/roslyn/pull/64899)
- [Save the resx file after a button is added into the WinForm (64910)](//github.com/dotnet/roslyn/pull/64910)
- [Update NuGet version to run MSBuildWorkspace tests against .NET SDK (64840)](//github.com/dotnet/roslyn/pull/64840)
- [[release/dev16.11-vs-deps] Update dependencies from dotnet/arcade (64711)](//github.com/dotnet/roslyn/pull/64711)
- [[release/dev17.0-vs-deps] Update dependencies from dotnet/arcade (64663)](//github.com/dotnet/roslyn/pull/64663)

Started 'Insertion Symbol Check' build policy on Updating Roslyn from [20221023.1](https://dev.azure.com/dnceng/7ea9116e-9fac-403d-b258-b31fcf1bb293/_build/results?buildId=2028124) ([4d06eb3](https://dev.azure.com/dnceng/7ea9116e-9fac-403d-b258-b31fcf1bb293/_apis/build/builds/2028124/sources)) to [20221024.15](https://dev.azure.com/dnceng/7ea9116e-9fac-403d-b258-b31fcf1bb293/_build/results?buildId=2028927) ([34530da](https://dev.azure.com/dnceng/7ea9116e-9fac-403d-b258-b31fcf1bb293/_apis/build/builds/2028927/sources))

[Troubleshooting OneNote](https://aka.ms/roslyn-insertion-troubleshooting) (don't use the [web view](https://aka.ms/roslyn-insertion-troubleshooting-web))

---
[View Complete Diff of Changes](//github.com/dotnet/roslyn/compare/4d06eb3522eaaa75d6a05b68ec1ca5b6c123af9a...34530dacae1efc796937b41a0e1cf55fd93c7a10?w=1)

- [Add back async streaming of results for NavTo (part2) (64896)](//github.com/dotnet/roslyn/pull/64896)
- [Throw in unsupported Tag api (64937)](//github.com/dotnet/roslyn/pull/64937)
- [Clear build-only diagnostics in the document after document edit (64885)](//github.com/dotnet/roslyn/pull/64885)
- [Expose a way to change the document service provider to Razor (64884)](//github.com/dotnet/roslyn/pull/64884)
- [Add missing error to CSharpUpgradeProjectCodeFixProvider (64940)](//github.com/dotnet/roslyn/pull/64940)
- [Remove unused WeaklyCachedValueSource type (64941)](//github.com/dotnet/roslyn/pull/64941)
- [Remove 'ConstantValueSource' (64939)](//github.com/dotnet/roslyn/pull/64939)
- [Unify Peek behavior with GoToDef (64936)](//github.com/dotnet/roslyn/pull/64936)
- [Implement equality semantics for async tagger tags. (take2) (64895)](//github.com/dotnet/roslyn/pull/64895)
- [Only write out inVs properties when appropriate (64853)](//github.com/dotnet/roslyn/pull/64853)
- [Get binlog on constructor failure (64899)](//github.com/dotnet/roslyn/pull/64899)
- [Save the resx file after a button is added into the WinForm (64910)](//github.com/dotnet/roslyn/pull/64910)
- [Update NuGet version to run MSBuildWorkspace tests against .NET SDK (64840)](//github.com/dotnet/roslyn/pull/64840)
- [[release/dev16.11-vs-deps] Update dependencies from dotnet/arcade (64711)](//github.com/dotnet/roslyn/pull/64711)
- [[release/dev17.0-vs-deps] Update dependencies from dotnet/arcade (64663)](//github.com/dotnet/roslyn/pull/64663)

Started 'Required Tests' build policy on Updating Roslyn from [20221023.1](https://dev.azure.com/dnceng/7ea9116e-9fac-403d-b258-b31fcf1bb293/_build/results?buildId=2028124) ([4d06eb3](https://dev.azure.com/dnceng/7ea9116e-9fac-403d-b258-b31fcf1bb293/_apis/build/builds/2028124/sources)) to [20221024.15](https://dev.azure.com/dnceng/7ea9116e-9fac-403d-b258-b31fcf1bb293/_build/results?buildId=2028927) ([34530da](https://dev.azure.com/dnceng/7ea9116e-9fac-403d-b258-b31fcf1bb293/_apis/build/builds/2028927/sources))

[Troubleshooting OneNote](https://aka.ms/roslyn-insertion-troubleshooting) (don't use the [web view](https://aka.ms/roslyn-insertion-troubleshooting-web))

---
[View Complete Diff of Changes](//github.com/dotnet/roslyn/compare/4d06eb3522eaaa75d6a05b68ec1ca5b6c123af9a...34530dacae1efc796937b41a0e1cf55fd93c7a10?w=1)

- [Add back async streaming of results for NavTo (part2) (64896)](//github.com/dotnet/roslyn/pull/64896)
- [Throw in unsupported Tag api (64937)](//github.com/dotnet/roslyn/pull/64937)
- [Clear build-only diagnostics in the document after document edit (64885)](//github.com/dotnet/roslyn/pull/64885)
- [Expose a way to change the document service provider to Razor (64884)](//github.com/dotnet/roslyn/pull/64884)
- [Add missing error to CSharpUpgradeProjectCodeFixProvider (64940)](//github.com/dotnet/roslyn/pull/64940)
- [Remove unused WeaklyCachedValueSource type (64941)](//github.com/dotnet/roslyn/pull/64941)
- [Remove 'ConstantValueSource' (64939)](//github.com/dotnet/roslyn/pull/64939)
- [Unify Peek behavior with GoToDef (64936)](//github.com/dotnet/roslyn/pull/64936)
- [Implement equality semantics for async tagger tags. (take2) (64895)](//github.com/dotnet/roslyn/pull/64895)
- [Only write out inVs properties when appropriate (64853)](//github.com/dotnet/roslyn/pull/64853)
- [Get binlog on constructor failure (64899)](//github.com/dotnet/roslyn/pull/64899)
- [Save the resx file after a button is added into the WinForm (64910)](//github.com/dotnet/roslyn/pull/64910)
- [Update NuGet version to run MSBuildWorkspace tests against .NET SDK (64840)](//github.com/dotnet/roslyn/pull/64840)
- [[release/dev16.11-vs-deps] Update dependencies from dotnet/arcade (64711)](//github.com/dotnet/roslyn/pull/64711)
- [[release/dev17.0-vs-deps] Update dependencies from dotnet/arcade (64663)](//github.com/dotnet/roslyn/pull/64663)
```
</summary>