### PR TITLE
Add output formatters to the PR Finder command.

### DIFF
--- a/src/dotnet-roslyn-tools/Commands/PRFinderCommand.cs
+++ b/src/dotnet-roslyn-tools/Commands/PRFinderCommand.cs
@@ -13,8 +13,11 @@ internal static class PRFinderCommand
 {
     private static readonly PrFinderCommandDefaultHandler s_prFinderCommandHandler = new();
 
+    internal static readonly string[] SupportedFormats = { PRFinder.PRFinder.DefaultFormat, PRFinder.PRFinder.OmniSharpFormat };
+
     internal static readonly Option<string> PreviousCommitShaOption = new Option<string>(new[] { "--previous", "-p" }, "SHA of the commit you want to start looking for PRs from") { IsRequired = true };
     internal static readonly Option<string> CurrentCommitSHAOption = new Option<string>(new[] { "--current", "-c" }, "SHA of commit you want to stop looking for PRs at") { IsRequired = true };
+    internal static readonly Option<string> FormatOption = new Option<string>(new[] { "--format" }, () => PRFinder.PRFinder.DefaultFormat, "The formatting to apply to the PR list.").FromAmong(SupportedFormats);
 
     public static Symbol GetCommand()
     {
@@ -22,6 +25,7 @@ internal static class PRFinderCommand
         {
             PreviousCommitShaOption,
             CurrentCommitSHAOption,
+            FormatOption,
             VerbosityOption
         };
         prFinderCommand.Handler = s_prFinderCommandHandler;
@@ -36,8 +40,9 @@ internal static class PRFinderCommand
 
             var previousCommit = context.ParseResult.GetValueForOption(PreviousCommitShaOption)!;
             var currentCommit = context.ParseResult.GetValueForOption(CurrentCommitSHAOption)!;
+            var format = context.ParseResult.GetValueForOption(FormatOption)!;
 
-            return Task.FromResult(PRFinder.PRFinder.FindPRs(previousCommit, currentCommit, logger));
+            return Task.FromResult(PRFinder.PRFinder.FindPRs(previousCommit, currentCommit, format, logger));
         }
     }
 }

--- a/src/dotnet-roslyn-tools/PRFinder/Formatters/DefaultFormatter.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/Formatters/DefaultFormatter.cs
@@ -1,0 +1,31 @@
+// Licensed to the.NET Foundation under one or more agreements.
+// The.NET Foundation licenses this file to you under the MIT license.
+// See the License.txt file in the project root for more information.
+
+namespace Microsoft.RoslynTools.PRFinder.Formatters;
+
+public class DefaultFormatter : IPRLogFormatter
+{
+    public virtual string FormatChangesHeader(string previous, string previousUrl, string current, string currentUrl)
+        => $"### Changes from [{previous}]({previousUrl}) to [{current}]({currentUrl}):";
+
+    public virtual string FormatCommitListItem(string comment, string shortSHA, string commitUrl)
+        => $"- [{comment} ({shortSHA})]({commitUrl})";
+
+    public virtual string FormatDiffHeader(string diffUrl)
+        => $"[View Complete Diff of Changes]({diffUrl})";
+
+    public virtual string FormatPRListItem(string comment, string prNumber, string prUrl)
+    {
+        // Replace "#{prNumber}" with "{prNumber}" so that AzDO won't linkify it
+        comment = comment.Replace($"#{prNumber}", prNumber);
+
+        return $"- [{comment}]({prUrl})";
+    }
+
+    public virtual string GetCommitSectionHeader()
+        => "### Commits since last PR:";
+
+    public virtual string GetPRSectionHeader()
+        => "### Merged PRs:";
+}

--- a/src/dotnet-roslyn-tools/PRFinder/Formatters/OmniSharpFormatter.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/Formatters/OmniSharpFormatter.cs
@@ -1,0 +1,16 @@
+// Licensed to the.NET Foundation under one or more agreements.
+// The.NET Foundation licenses this file to you under the MIT license.
+// See the License.txt file in the project root for more information.
+
+namespace Microsoft.RoslynTools.PRFinder.Formatters;
+
+public class OmniSharpFormatter : DefaultFormatter
+{
+    public override string FormatPRListItem(string comment, string prNumber, string prUrl)
+    {
+        // Remove the PR Number from the comment
+        comment = comment.Replace($"(#{prNumber})", "");
+
+        return $@"* {comment}(PR: [#{prNumber}]({prUrl}))";
+    }
+}

--- a/src/dotnet-roslyn-tools/PRFinder/Hosts/GitHub.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/Hosts/GitHub.cs
@@ -58,7 +58,7 @@ public class GitHub : IRepositoryHost
             // Try and extract the 1st non-empty line since it is the useful part of the message, otherwise take the first line.
             var lines = commit.Message.Split('\n', StringSplitOptions.RemoveEmptyEntries);
             comment = lines.Length > 1
-                ? $"{lines[1]} ({prNumber})"
+                ? $"{lines[1]} (#{prNumber})"
                 : commit.MessageShort;
             return true;
         }

--- a/src/dotnet-roslyn-tools/PRFinder/IPRLogFormatter.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/IPRLogFormatter.cs
@@ -1,0 +1,15 @@
+// Licensed to the.NET Foundation under one or more agreements.
+// The.NET Foundation licenses this file to you under the MIT license.
+// See the License.txt file in the project root for more information.
+
+namespace Microsoft.RoslynTools.PRFinder;
+
+public interface IPRLogFormatter
+{
+    string FormatChangesHeader(string previous, string previousUrl, string current, string currentUrl);
+    string FormatDiffHeader(string diffUrl);
+    string GetCommitSectionHeader();
+    string GetPRSectionHeader();
+    string FormatCommitListItem(string comment, string shortSHA, string commitUrl);
+    string FormatPRListItem(string comment, string prNumber, string prUrl);
+}

--- a/src/dotnet-roslyn-tools/PRTagger/PRTagger.cs
+++ b/src/dotnet-roslyn-tools/PRTagger/PRTagger.cs
@@ -114,7 +114,7 @@ internal class PRTagger
 
             // Find PRs between product commit SHAs
             var prDescription = new StringBuilder();
-            var isSuccess = PRFinder.PRFinder.FindPRs(previousProductCommitSha, currentProductCommitSha, logger, gitHubRepoPath, prDescription);
+            var isSuccess = PRFinder.PRFinder.FindPRs(previousProductCommitSha, currentProductCommitSha, PRFinder.PRFinder.DefaultFormat, logger, gitHubRepoPath, prDescription);
             if (isSuccess != 0)
             {
                 // Error occurred; should be logged in FindPRs method


### PR DESCRIPTION
Using the default formatter (`roslyn-tools pr-finder -p {prev} -c {curr}`):
```markdown
- [Create 1.25.1 release with omnisharp-roslyn updated to 1.39.2 (5430)](https://github.com/OmniSharp/omnisharp-vscode/pull/5430)
- [Clear all strict mode violations in src & enforce strict mode (5407)](https://github.com/OmniSharp/omnisharp-vscode/pull/5407)
- [Update debugger to 1.25.1  (5415)](https://github.com/OmniSharp/omnisharp-vscode/pull/5415)
- [Add github action to merge master to feature branches (5414)](https://github.com/OmniSharp/omnisharp-vscode/pull/5414)
- [coreclr-debug nullability (5405)](https://github.com/OmniSharp/omnisharp-vscode/pull/5405)
```

Using the OmniSharp formatter (`roslyn-tools pr-finder -p {prev} -c {curr} --format o#`):
```markdown
* Create 1.25.1 release with omnisharp-roslyn updated to 1.39.2 (PR: [#5430](https://github.com/OmniSharp/omnisharp-vscode/pull/5430))
* Clear all strict mode violations in src & enforce strict mode (PR: [#5407](https://github.com/OmniSharp/omnisharp-vscode/pull/5407))
* Update debugger to 1.25.1  (PR: [#5415](https://github.com/OmniSharp/omnisharp-vscode/pull/5415))
* Add github action to merge master to feature branches (PR: [#5414](https://github.com/OmniSharp/omnisharp-vscode/pull/5414))
* coreclr-debug nullability (PR: [#5405](https://github.com/OmniSharp/omnisharp-vscode/pull/5405))
```