### PR TITLE
remove main-vs-deps from code flow

### DIFF
--- a/src/GitHubCreateMergePRs/config.xml
+++ b/src/GitHubCreateMergePRs/config.xml
@@ -16,15 +16,11 @@
 
     <!-- Roslyn release branches (flowing between releases) -->
     <merge from="release/dev17.4" to="release/dev17.5" />
-    <merge from="release/dev17.5" to="main" />
-    <merge from="release/dev17.5-vs-deps" to="main-vs-deps" />
+    <merge from="release/dev17.5-vs-deps" to="main" />
     <merge from="main" to="release/dev17.6" />
-    <merge from="main-vs-deps" to="release/dev17.6-vs-deps" />
       
     <!-- Roslyn release branches (flowing to -vs-deps) -->
     <merge from="release/dev17.5" to="release/dev17.5-vs-deps" />
-    <merge from="main" to="main-vs-deps" />
-    <merge from="release/dev17.6" to="release/dev17.6-vs-deps" />
 
     <!-- Roslyn feature branches -->
     <merge from="main" to="features/semi-auto-props" owners="333fred" frequency="weekly" />


### PR DESCRIPTION
pre-requisite: https://github.com/dotnet/roslyn/pull/65990