### PR TITLE
Merge feature branches on every run.

### DIFF
--- a/src/GitHubCreateMergePRs/config.xml
+++ b/src/GitHubCreateMergePRs/config.xml
@@ -26,8 +26,8 @@
     <merge from="main" to="features/vs2022-theme" owners="joerobich" frequency="weekly" />
     <merge from="main" to="features/editorconfig_lsp" owners="dibarbet,Danyboyyy" frequency="weekly" />
     <merge from="main" to="features/FixAllNamingViolation" owners="Cosifne" frequency="weekly" />
-    <merge from="main" to="features/CollectionLiterals" owners="CyrusNajmabadi" frequency="daily" />
-    <merge from="main" to="features/UsingAliasesTypes" owners="CyrusNajmabadi" frequency="daily" />
+    <merge from="main" to="features/CollectionLiterals" owners="CyrusNajmabadi" />
+    <merge from="main" to="features/UsingAliasesTypes" owners="CyrusNajmabadi" />
   </repo>
 
   <repo owner="dotnet" name="roslyn-sdk">


### PR DESCRIPTION
Daily merges check to see if they're running within +/- 5 minutes of 12am.  This fails when time changes and it runs at 1am instead.  TBD how to fix that, but for now configure these branches to merge on every run