### PR TITLE
Don't error out when failing to apply a tag

### DIFF
--- a/src/dotnet-roslyn-tools/CreateReleaseTags/CreateReleaseTags.cs
+++ b/src/dotnet-roslyn-tools/CreateReleaseTags/CreateReleaseTags.cs
@@ -75,7 +75,14 @@ internal static class CreateReleaseTags
 
                             string message = $"Build Branch: {build.SourceBranch}\r\nInternal ID: {build.BuildId}\r\nInternal VS ID: {visualStudioRelease.BuildId}";
 
-                            repository.ApplyTag(tagName, build.CommitSha, new Signature(product.GitUserName, product.GitEmail, when: visualStudioRelease.CreationTime), message);
+                            try
+                            {
+                                repository.ApplyTag(tagName, build.CommitSha, new Signature(product.GitUserName, product.GitEmail, when: visualStudioRelease.CreationTime), message);
+                            }
+                            catch (Exception ex)
+                            {
+                                logger.LogWarning(ex, $"Unable to tag the commit '{build.CommitSha}' with '{tagName}'.");
+                            }
                         }
                         else
                         {


### PR DESCRIPTION
I'm guessing due to all of the repo moves, there are a couple of commits that can't be found in the Razor repo, and they were stopping us progressing through to tagging more recent, relevant versions.