### PR TITLE
Skip duplicate

### DIFF
--- a/src/dotnet-roslyn-tools/Commands/NuGetPublishCommand.cs
+++ b/src/dotnet-roslyn-tools/Commands/NuGetPublishCommand.cs
@@ -21,6 +21,7 @@ internal class NuGetPublishCommand
     internal static readonly Option<string> SourceOption = new Option<string>(new[] { "--source", "-s" }, () => "https://www.nuget.org", "Package source (URL, UNC/folder path or package source name) to use.");
     internal static readonly Option<string> ApiKeyOption = new Option<string>(new[] { "--api-key", "-k" }, "The API key for the server.") { IsRequired = true };
     internal static readonly Option<bool> UnlistedOption = new Option<bool>(new[] { "--unlisted", "-u" }, "Whether to publish the packages as unlisted.");
+    internal static readonly Option<bool> SkipDuplicateOption = new Option<bool>(new[] { "--skip-duplicate" }, "Whether to skip packages that have already been published.");
 
     public static Symbol GetCommand()
     {
@@ -30,7 +31,8 @@ internal class NuGetPublishCommand
             SourceOption,
             ApiKeyOption,
             UnlistedOption,
-            VerbosityOption
+            VerbosityOption,
+            SkipDuplicateOption
         };
         command.Handler = s_nuGetPublishCommandHandler;
         return command;
@@ -47,8 +49,9 @@ internal class NuGetPublishCommand
             var source = context.ParseResult.GetValueForOption(SourceOption)!;
             var apiKey = context.ParseResult.GetValueForOption(ApiKeyOption)!;
             var unlisted = context.ParseResult.GetValueForOption(UnlistedOption)!;
+            var skipDuplicate = context.ParseResult.GetValueForOption(SkipDuplicateOption);
 
-            return await NuGetPublish.PublishAsync(repoName, source, apiKey, unlisted, logger);
+            return await NuGetPublish.PublishAsync(repoName, source, apiKey, unlisted, skipDuplicate, logger);
         }
     }
 }

--- a/src/dotnet-roslyn-tools/NuGet/NuGetPrepare.cs
+++ b/src/dotnet-roslyn-tools/NuGet/NuGetPrepare.cs
@@ -32,6 +32,7 @@ namespace Microsoft.RoslynTools.NuGet
                 "Microsoft.CodeAnalysis.Workspaces.Common",
                 "Microsoft.CodeAnalysis.Workspaces.MSBuild",
                 "Microsoft.Net.Compilers.Toolset",
+                "Microsoft.Net.Compilers.Toolset.Framework",
                 "Microsoft.VisualStudio.LanguageServices"
             };
 

--- a/src/dotnet-roslyn-tools/NuGet/NuGetPublish.cs
+++ b/src/dotnet-roslyn-tools/NuGet/NuGetPublish.cs
@@ -81,7 +81,7 @@ namespace Microsoft.RoslynTools.NuGet
                 "Microsoft.CodeAnalysis.VisualBasic.SourceGenerators.Testing.XUnit"
             };
 
-        internal static async Task<int> PublishAsync(string repoName, string source, string apiKey, bool unlisted, ILogger logger)
+        internal static async Task<int> PublishAsync(string repoName, string source, string apiKey, bool unlisted, bool skipDuplicate, ILogger logger)
         {
             try
             {
@@ -103,9 +103,11 @@ namespace Microsoft.RoslynTools.NuGet
 
                 logger.LogInformation($"Publishing {version} packages...");
 
+                var skipDuplicateFlag = skipDuplicate ? "--skip-duplicate" : "";
+
                 foreach (var packageId in packageIds)
                 {
-                    var result = await PublishPackageAsync(packageId, version);
+                    var result = await PublishPackageAsync(packageId, version, skipDuplicateFlag);
                     if (result.ExitCode != 0)
                     {
                         logger.LogError($"Failed to publish '{packageId}'");
@@ -159,9 +161,9 @@ namespace Microsoft.RoslynTools.NuGet
                 return true;
             }
 
-            Task<ProcessResult> PublishPackageAsync(string packageId, string? version)
+            Task<ProcessResult> PublishPackageAsync(string packageId, string? version, string skipDuplicatesFlag)
             {
-                return ProcessRunner.RunProcessAsync("dotnet", $"nuget push --source \"{source}\" --api-key \"{apiKey}\" \"{packageId}.{version}.nupkg\"");
+                return ProcessRunner.RunProcessAsync("dotnet", $"nuget push {skipDuplicatesFlag} --source \"{source}\" --api-key \"{apiKey}\" \"{packageId}.{version}.nupkg\"");
             }
 
             Task<ProcessResult> UnlistPackageAsync(string packageId, string? version)


### PR DESCRIPTION
Adds a `--skip-duplicate` flag for publishing purposes, and fixes a location that `Toolset.Framework` was missed. If you're curious, yes these two things are related.