### PR TITLE
Add branch merge configuration for vscode-csharp

### DIFF
--- a/src/GitHubCreateMergePRs/config.xml
+++ b/src/GitHubCreateMergePRs/config.xml
@@ -1,5 +1,5 @@
 <config>
-  <repo owner="dotnet" name="roslyn" mergeOwners="allisonchou">
+  <repo owner="dotnet" name="roslyn" mergeOwners="dibarbet">
     <!--
       VS versions under servicing:
         VS 2019: https://docs.microsoft.com/en-us/lifecycle/products/visual-studio-2019
@@ -111,5 +111,11 @@
 
   <repo owner="dotnet" name="linker" mergeOwners="agocke,sbomer">
     <merge from="main" to="feature/damAnalyzer" />
+  </repo>
+
+  <repo owner="dotnet" name="vscode-csharp" mergeOwners="dibarbet">
+    <!-- Flow changes made only to release / prerelease branches back up to main. -->
+    <merge from="release" to="main" />
+    <merge from="prerelease" to="main" />
   </repo>
 </config>


### PR DESCRIPTION
Add merge configurations to vscode-csharp so that changes made to the release / prerelease branches automatically flow back into main.

We don't need to flow release -> prerelease because main will have the changes from release.  When we snap main again we'll merge main into prerelease (which will contain the release changes as well).