### PR TITLE
Remove branch configurations that are no longer in servicing

### DIFF
--- a/src/GitHubCreateMergePRs/config.xml
+++ b/src/GitHubCreateMergePRs/config.xml
@@ -7,15 +7,13 @@
     -->
     <!-- Roslyn servicing branches (flowing between releases) -->
     <merge from="dev15.9.x" to="release/dev16.11-vs-deps" />
-    <merge from="release/dev16.11-vs-deps" to="release/dev17.0-vs-deps" />
-    <merge from="release/dev17.0-vs-deps" to="release/dev17.2" />
+    <merge from="release/dev16.11-vs-deps" to="release/dev17.2" />
     <merge from="release/dev17.2" to="release/dev17.4" />
-
-    <!-- Roslyn release branches (flowing between releases) -->
-    <merge from="release/dev17.4" to="release/dev17.5-vs-deps" />
-    <merge from="release/dev17.5-vs-deps" to="release/dev17.6" />
+    <merge from="release/dev17.4" to="release/dev17.6" />
     <merge from="release/dev17.6" to="release/dev17.7" />
     <merge from="release/dev17.7" to="release/dev17.8" />
+
+    <!-- Roslyn release branches (flowing between releases) -->
     <merge from="release/dev17.8" to="main" />
 
     <!-- Roslyn feature branches -->


### PR DESCRIPTION
Remove 17.0 and 17.5 as they have passed their servicing end dates.
https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/27212/Dev15-16-17-Servicing-Schedule?anchor=end-of-support-dates