### PR TITLE
Fix missing dependency version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -24,6 +24,7 @@
     <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
     <MoqVersion>4.5.21</MoqVersion>
     <NuGetVersioningVersion>5.11.0</NuGetVersioningVersion>
+    <NuGetProjectModelVersion>6.4.2-rc.1</NuGetProjectModelVersion>
     <MicrosoftAzureKeyVaultVersion>3.0.0</MicrosoftAzureKeyVaultVersion>
     <MicrosoftBuildVersion>15.6.82</MicrosoftBuildVersion>
     <MicrosoftBuildTasksCoreVersion>15.6.82</MicrosoftBuildTasksCoreVersion>

--- a/src/ProjectDependencies/ProjectDependencies.csproj
+++ b/src/ProjectDependencies/ProjectDependencies.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.ProjectModel" Version="6.4.0" />
+    <PackageReference Include="NuGet.ProjectModel" Version="$(NuGetProjectModelVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
See this error when building locally

> C:\Users\gel\roslyn-tools\src\ProjectDependencies\ProjectDependencies.csproj : error NU1103: Unable to find a stable package NuGet.ProjectModel with version (>= 6.4
.1) [C:\Users\gel\roslyn-tools\RoslynTools.sln]
C:\Users\gel\roslyn-tools\src\ProjectDependencies\ProjectDependencies.csproj : error NU1103:   - Found 302 version(s) in dotnet-tools [ Nearest version: 6.4.2-rc.1
] [C:\Users\gel\roslyn-tools\RoslynTools.sln]