### PR TITLE
Update config.xml

### DIFF
--- a/src/GitHubCreateMergePRs/config.xml
+++ b/src/GitHubCreateMergePRs/config.xml
@@ -42,11 +42,9 @@
 
   <!-- Project System repo -->
   <repo owner="dotnet" name="project-system">
-    <merge from="dev16.11.x" to="main" />
-    <merge from="dev17.2.x" to="main" />
-    <merge from="dev17.4.x" to="main" />
-    <merge from="dev17.7.x" to="main" />
-    <merge from="dev17.8.x" to="main" />
+    <!-- dotnet/project-system doesn't take enough servicing fixes to warrant
+         automatic PRs from a release branch back to main. This entry is left
+         as a placeholder for if/when we need this functionality again. -->
   </repo>
 
   <repo owner="dotnet" name="templates">


### PR DESCRIPTION
This change removes the configuration to automatically create PRs from release branches to `main` in the dotnet/project-system repo. The repo doesn't tend to take many changes to release branches, and most of them need to be validated in `main` first anyway. We also sometimes make changes specific to a particular release branch that _shouldn't_ merge back to `main`.