### PR TITLE
Remove Roslyn branches that are no longer under support.

### DIFF
--- a/src/GitHubCreateMergePRs/config.xml
+++ b/src/GitHubCreateMergePRs/config.xml
@@ -7,11 +7,9 @@
     -->
     <!-- Roslyn servicing branches (flowing between releases) -->
     <merge from="dev15.9.x" to="release/dev16.11-vs-deps" />
-    <merge from="release/dev16.11-vs-deps" to="release/dev17.2" />
-    <merge from="release/dev17.2" to="release/dev17.4" />
+    <merge from="release/dev16.11-vs-deps" to="release/dev17.4" />
     <merge from="release/dev17.4" to="release/dev17.6" />
-    <merge from="release/dev17.6" to="release/dev17.7" />
-    <merge from="release/dev17.7" to="release/dev17.8" />
+    <merge from="release/dev17.6" to="release/dev17.8" />
     <merge from="release/dev17.8" to="release/dev17.9" />
     <merge from="release/dev17.9" to="release/dev17.10" />
 


### PR DESCRIPTION
Saw we were being [questioned about older servicing branches](https://github.com/dotnet/roslyn/pull/68650), so took a look at what was currently under support. Checked code flow and saw it could use updating.