### PR TITLE
Skip non-github repo, not return -1

### DIFF
--- a/src/dotnet-roslyn-tools/PRTagger/PRTagger.cs
+++ b/src/dotnet-roslyn-tools/PRTagger/PRTagger.cs
@@ -63,7 +63,7 @@ internal static class PRTagger
             if (!product.IsGitHubRepo())
             {
                 logger.LogWarning($"Only GitHub repos are supported. Skipped repo: {product.Name}");
-                return -1;
+                continue;
             }
 
             var gitHubRepoName = product.RepoHttpBaseUrl.Split('/').Last();


### PR DESCRIPTION
https://dev.azure.com/dnceng/internal/_build/results?buildId=2388416&view=logs&j=9d82d844-45a0-5d2e-bd4b-992528a7bed5&t=5cca82b3-8182-5619-1c3b-68ef1449fa53

VS-Typescript is not a GitHub repo, and the tagger returns -1 causing the pipeline to fail. So Skip the repo.