### PR TITLE
Fix package verisons

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.csproj
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" Version="3.2.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NuGet.Versioning" Version="4.9.4" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.7.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.10.0" />
     <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="5.2.0" />

--- a/src/dotnet-roslyn-tools/Microsoft.RoslynTools.csproj
+++ b/src/dotnet-roslyn-tools/Microsoft.RoslynTools.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.201.0-preview" />
     <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="16.201.0-preview" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="NuGet.Protocol" Version="6.2.4" />
+    <PackageReference Include="NuGet.Protocol" Version="6.3.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta2.21615.1" />
     <PackageReference Include="System.CommandLine.Rendering" Version="0.4.0-alpha.21615.1" />
   </ItemGroup>


### PR DESCRIPTION
Fix restore error in local build

> C:\Users\gel\roslyn-tools\src\RoslynInsertionTool\RoslynInsertionTool\RoslynInsertionTool.csproj : error NU1603: Roslyn
InsertionTool depends on System.IdentityModel.Tokens.Jwt (>= 5.7.0) but System.IdentityModel.Tokens.Jwt 5.7.0 was not f
ound. An approximate best match of System.IdentityModel.Tokens.Jwt 6.10.0 was resolved. [C:\Users\gel\roslyn-tools\Rosl
ynTools.sln]
C:\Users\gel\roslyn-tools\src\RoslynInsertionTool\RoslynInsertionTool.Commandline\RIT.csproj : error NU1603: RoslynInse
rtionTool depends on System.IdentityModel.Tokens.Jwt (>= 5.7.0) but System.IdentityModel.Tokens.Jwt 5.7.0 was not found
. An approximate best match of System.IdentityModel.Tokens.Jwt 6.10.0 was resolved. [C:\Users\gel\roslyn-tools\RoslynTo
ols.sln]
C:\Users\gel\roslyn-tools\src\dotnet-roslyn-tools\Microsoft.RoslynTools.csproj : error NU1603: Microsoft.RoslynTools de
pends on NuGet.Protocol (>= 6.2.4) but NuGet.Protocol 6.2.4 was not found. An approximate best match of NuGet.Protocol
6.3.0 was resolved. [C:\Users\gel\roslyn-tools\RoslynTools.sln]