### PR TITLE
Remove the results filter when fetch builds

### DIFF
--- a/src/dotnet-roslyn-tools/PRTagger/PRTagger.cs
+++ b/src/dotnet-roslyn-tools/PRTagger/PRTagger.cs
@@ -39,7 +39,6 @@ internal static class PRTagger
             logger: logger,
             buildNumber: vsBuild,
             maxFetchingVsBuildNumber: maxFetchingVSBuildNumber,
-            resultsFilter: BuildResult.Succeeded,
             buildQueryOrder: BuildQueryOrder.FinishTimeDescending).ConfigureAwait(false);
 
         if (builds is null)


### PR DESCRIPTION
Tagger should also check the failed build/partial passed build in reality