### PR TITLE
Update all the TFMs to use arcade 9.0 sdk

### DIFF
--- a/.azure-ci.yaml
+++ b/.azure-ci.yaml
@@ -23,7 +23,7 @@ jobs:
       release:
         _configuration: Release
   steps:
-  - script: .\eng\common\CIBuild.cmd -configuration $(_configuration) -prepareMachine
+  - script: .\eng\common\CIBuild.cmd -configuration $(_configuration) -prepareMachine  /p:DotnetPublishUsingPipelines=true
 
   - task: PublishTestResults@2
     displayName: Publish xUnit Test Results
@@ -53,7 +53,7 @@ jobs:
       release:
         _configuration: Release
   steps:
-  - script: ./eng/common/cibuild.sh --configuration $(_configuration) --prepareMachine
+  - script: ./eng/common/cibuild.sh --configuration $(_configuration) --prepareMachine /p:DotnetPublishUsingPipelines=true
 
   - task: PublishTestResults@2
     displayName: Publish xUnit Test Results

--- a/docs/RepoToolset.md
+++ b/docs/RepoToolset.md
@@ -307,7 +307,7 @@ For example,
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
    <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <VisualStudioInsertionComponent>Microsoft.VisualStudio.ProjectSystem.Managed</VisualStudioInsertionComponent>
   </PropertyGroup>
   <ItemGroup>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -14,8 +14,7 @@
 
       instead of the following lines.
     -->
-    <ItemsToSign Include="$(ArtifactsBinDir)GithubMergeTool/**/net46/GithubMergeTool.dll" />
-    <ItemsToSign Include="$(ArtifactsBinDir)VstsMergeTool/**/net46/VstsMergeTool.dll" />
+    <ItemsToSign Include="$(ArtifactsBinDir)GithubMergeTool/**/$(NetCurrent)/GithubMergeTool.dll" />
 
     <!-- Sign 3rd party dlls with 3rd party cert -->
     <FileSignInfo Include="Newtonsoft.Json.dll" CertificateName="3PartySHA2" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,7 +8,7 @@
     <PreReleaseVersionLabel>beta3</PreReleaseVersionLabel>
     <!-- CoreFX -->
     <MicrosoftExtensionsFileSystemGlobbingVersion>2.0.0</MicrosoftExtensionsFileSystemGlobbingVersion>
-    <SystemCollectionsImmutableVersion>1.3.1</SystemCollectionsImmutableVersion>
+    <SystemCollectionsImmutableVersion>1.5.0</SystemCollectionsImmutableVersion>
     <SystemReflectionMetadataVersion>1.4.2</SystemReflectionMetadataVersion>
     <SystemValueTupleVersion>4.4.0</SystemValueTupleVersion>
     <SystemIOCompressionVersion>4.3.0</SystemIOCompressionVersion>

--- a/eng/common/internal/Tools.csproj
+++ b/eng/common/internal/Tools.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>$(NetFrameworkToolCurrent)</TargetFramework>
     <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
     <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
   </PropertyGroup>

--- a/src/BuildTasks.Tests/RoslynTools.BuildTasks.UnitTests.csproj
+++ b/src/BuildTasks.Tests/RoslynTools.BuildTasks.UnitTests.csproj
@@ -2,7 +2,8 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(NetFrameworkToolCurrent);$(NetMinimum)</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkToolCurrent);$(NetCurrent)</TargetFrameworks>
+    <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\BuildTasks\RoslynTools.BuildTasks.csproj" />

--- a/src/BuildTasks.Tests/RoslynTools.BuildTasks.UnitTests.csproj
+++ b/src/BuildTasks.Tests/RoslynTools.BuildTasks.UnitTests.csproj
@@ -2,7 +2,7 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkToolCurrent);$(NetMinimum)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\BuildTasks\RoslynTools.BuildTasks.csproj" />

--- a/src/BuildTasks.Tests/RoslynTools.BuildTasks.UnitTests.csproj
+++ b/src/BuildTasks.Tests/RoslynTools.BuildTasks.UnitTests.csproj
@@ -3,7 +3,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetFrameworkToolCurrent);$(NetCurrent)</TargetFrameworks>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\BuildTasks\RoslynTools.BuildTasks.csproj" />

--- a/src/BuildTasks/RoslynTools.BuildTasks.csproj
+++ b/src/BuildTasks/RoslynTools.BuildTasks.csproj
@@ -2,7 +2,7 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(NetFrameworkToolCurrent);$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkToolCurrent);$(NetMinimum)</TargetFrameworks>
 
     <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
 

--- a/src/BuildTasks/RoslynTools.BuildTasks.csproj
+++ b/src/BuildTasks/RoslynTools.BuildTasks.csproj
@@ -24,5 +24,6 @@
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
   </ItemGroup>
+
   <Target Name="_CorePublish" DependsOnTargets="Publish" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
 </Project>

--- a/src/BuildTasks/RoslynTools.BuildTasks.csproj
+++ b/src/BuildTasks/RoslynTools.BuildTasks.csproj
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkToolCurrent);$(NetCurrent)</TargetFrameworks>
 
     <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
 

--- a/src/BuildTasks/RoslynTools.BuildTasks.csproj
+++ b/src/BuildTasks/RoslynTools.BuildTasks.csproj
@@ -2,7 +2,7 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(NetFrameworkToolCurrent);$(NetMinimum)</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkToolCurrent);$(NetCurrent)</TargetFrameworks>
 
     <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
 

--- a/src/BuildTasks/RoslynTools.BuildTasks.nuspec
+++ b/src/BuildTasks/RoslynTools.BuildTasks.nuspec
@@ -5,11 +5,11 @@
   </metadata>
   <files>
     $CommonFileElements$
-    <file src="netcoreapp3.1\publish\RoslynTools.*" target="tools\netcoreapp3.1" />
-    <file src="netcoreapp3.1\publish\NuGet.Versioning.*" target="tools\netcoreapp3.1" />
-    <file src="netcoreapp3.1\publish\System.*" target="tools\netcoreapp3.1" />
-    <file src="net472\RoslynTools.*" target="tools\net472" />
-    <file src="net472\NuGet.Versioning.*" target="tools\net472" />
-    <file src="net472\System.*" target="tools\net472" />
+    <file src="$NetCurrent$\publish\RoslynTools.*" target="tools\$NetCurrent$" />
+    <file src="$NetCurrent$\publish\NuGet.Versioning.*" target="tools\$NetCurrent$" />
+    <file src="$NetCurrent$\publish\System.*" target="tools\$NetCurrent$" />
+    <file src="$NetFrameworkCurrent$\RoslynTools.*" target="tools\$NetFrameworkCurrent$" />
+    <file src="$NetFrameworkCurrent$\NuGet.Versioning.*" target="tools\$NetFrameworkCurrent$" />
+    <file src="$NetFrameworkCurrent$\System.*" target="tools\$NetFrameworkCurrent$" />
   </files>
 </package>

--- a/src/BuildTasks/RoslynTools.BuildTasks.nuspec
+++ b/src/BuildTasks/RoslynTools.BuildTasks.nuspec
@@ -5,11 +5,11 @@
   </metadata>
   <files>
     $CommonFileElements$
-    <file src="$NetCurrent$\publish\RoslynTools.*" target="tools\$NetCurrent$" />
-    <file src="$NetCurrent$\publish\NuGet.Versioning.*" target="tools\$NetCurrent$" />
-    <file src="$NetCurrent$\publish\System.*" target="tools\$NetCurrent$" />
-    <file src="$NetFrameworkToolCurrent$\RoslynTools.*" target="tools\$NetFrameworkToolCurrent$" />
-    <file src="$NetFrameworkToolCurrent$\NuGet.Versioning.*" target="tools\$NetFrameworkToolCurrent$" />
-    <file src="$NetFrameworkToolCurrent$\System.*" target="tools\$NetFrameworkToolCurrent$" />
+    <file src="net9.0\publish\RoslynTools.*" target="tools\net9.0" />
+    <file src="net9.0\publish\NuGet.Versioning.*" target="tools\net9.0" />
+    <file src="net9.0\publish\System.*" target="tools\net9.0" />
+    <file src="net472\RoslynTools.*" target="tools\net472" />
+    <file src="net472\NuGet.Versioning.*" target="tools\net472" />
+    <file src="net472\System.*" target="tools\net472" />
   </files>
 </package>

--- a/src/BuildTasks/RoslynTools.BuildTasks.nuspec
+++ b/src/BuildTasks/RoslynTools.BuildTasks.nuspec
@@ -8,8 +8,8 @@
     <file src="$NetCurrent$\publish\RoslynTools.*" target="tools\$NetCurrent$" />
     <file src="$NetCurrent$\publish\NuGet.Versioning.*" target="tools\$NetCurrent$" />
     <file src="$NetCurrent$\publish\System.*" target="tools\$NetCurrent$" />
-    <file src="$NetFrameworkCurrent$\RoslynTools.*" target="tools\$NetFrameworkCurrent$" />
-    <file src="$NetFrameworkCurrent$\NuGet.Versioning.*" target="tools\$NetFrameworkCurrent$" />
-    <file src="$NetFrameworkCurrent$\System.*" target="tools\$NetFrameworkCurrent$" />
+    <file src="$NetFrameworkToolCurrent$\RoslynTools.*" target="tools\$NetFrameworkToolCurrent$" />
+    <file src="$NetFrameworkToolCurrent$\NuGet.Versioning.*" target="tools\$NetFrameworkToolCurrent$" />
+    <file src="$NetFrameworkToolCurrent$\System.*" target="tools\$NetFrameworkToolCurrent$" />
   </files>
 </package>

--- a/src/CompilerPerfTests/CompilerPerfTests.csproj
+++ b/src/CompilerPerfTests/CompilerPerfTests.csproj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(NetCurrent)</TargetFramework>
+    <NoWarn>$(NoWarn);NETSDK1206</NoWarn>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 

--- a/src/CompilerPerfTests/CompilerPerfTests.csproj
+++ b/src/CompilerPerfTests/CompilerPerfTests.csproj
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 

--- a/src/GitHubCreateMergePRs/GitHubCreateMergePRs.csproj
+++ b/src/GitHubCreateMergePRs/GitHubCreateMergePRs.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(NetMinimum)</TargetFramework>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GitHubCreateMergePRs/GitHubCreateMergePRs.csproj
+++ b/src/GitHubCreateMergePRs/GitHubCreateMergePRs.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6</TargetFramework>
+    <TargetFramework>$(NetMinimum)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GithubMergeTool/GithubMergeTool.csproj
+++ b/src/GithubMergeTool/GithubMergeTool.csproj
@@ -1,9 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>$(NetMinimum)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GithubMergeTool/GithubMergeTool.csproj
+++ b/src/GithubMergeTool/GithubMergeTool.csproj
@@ -3,7 +3,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetMinimum)</TargetFramework>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GithubMergeTool/test.csx
+++ b/src/GithubMergeTool/test.csx
@@ -3,7 +3,7 @@
 // README: This is a simple test script for trying out local changes.
 // Nothing in this file runs in production.
 
-#r "../../artifacts/bin/GithubMergeTool/Debug/netcoreapp3.1/GithubMergeTool.dll"
+#r "../../artifacts/bin/GithubMergeTool/Debug/net9.0/GithubMergeTool.dll"
 
 using System;
 using System.Net;

--- a/src/ModifyVsixManifest/ModifyVsixManifest.csproj
+++ b/src/ModifyVsixManifest/ModifyVsixManifest.csproj
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>$(NetFrameworkToolCurrent)</TargetFramework>
     <OutputType>Exe</OutputType>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     

--- a/src/ModifyVsixManifest/ModifyVsixManifest.nuspec
+++ b/src/ModifyVsixManifest/ModifyVsixManifest.nuspec
@@ -5,6 +5,6 @@
   </metadata>
   <files>
     $CommonFileElements$
-    <file src="$NetFrameworkToolCurrent$\*.*" target="tools" />
+    <file src="net472\*.*" target="tools" />
   </files>
 </package>

--- a/src/ModifyVsixManifest/ModifyVsixManifest.nuspec
+++ b/src/ModifyVsixManifest/ModifyVsixManifest.nuspec
@@ -5,6 +5,6 @@
   </metadata>
   <files>
     $CommonFileElements$
-    <file src="net46\*.*" target="tools" />
+    <file src="$NetFrameworkToolCurrent$\*.*" target="tools" />
   </files>
 </package>

--- a/src/NuGetRepack/BuildTasks/RoslynTools.NuGetRepack.BuildTasks.csproj
+++ b/src/NuGetRepack/BuildTasks/RoslynTools.NuGetRepack.BuildTasks.csproj
@@ -2,7 +2,7 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(NetFrameworkToolCurrent);$(NetMinimum)</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkToolCurrent);$(NetCurrent)</TargetFrameworks>
 
     <!-- Using an explicit nuspec file since NuGet Pack target currently doesn't support including dependencies in tools packages -->
     <IsPackable>true</IsPackable>

--- a/src/NuGetRepack/BuildTasks/RoslynTools.NuGetRepack.BuildTasks.csproj
+++ b/src/NuGetRepack/BuildTasks/RoslynTools.NuGetRepack.BuildTasks.csproj
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkToolCurrent);$(NetMinimum)</TargetFrameworks>
 
     <!-- Using an explicit nuspec file since NuGet Pack target currently doesn't support including dependencies in tools packages -->
     <IsPackable>true</IsPackable>

--- a/src/NuGetRepack/BuildTasks/RoslynTools.NuGetRepack.BuildTasks.nuspec
+++ b/src/NuGetRepack/BuildTasks/RoslynTools.NuGetRepack.BuildTasks.nuspec
@@ -5,11 +5,11 @@
   </metadata>
   <files>
     $CommonFileElements$
-    <file src="$NetCurrent$\publish\RoslynTools.*" target="tools\$NetCurrent$" />
-    <file src="$NetCurrent$\publish\System.*" target="tools\$NetCurrent$" />
-    <file src="$NetCurrent$\publish\NuGet.Versioning.*" target="tools\$NetCurrent$" />
-    <file src="$NetFrameworkToolCurrent$\RoslynTools.*" target="tools\$NetFrameworkToolCurrent$" />
-    <file src="$NetFrameworkToolCurrent$\System.*" target="tools\$NetFrameworkToolCurrent$" />
-    <file src="$NetFrameworkToolCurrent$\NuGet.Versioning.*" target="tools\$NetFrameworkToolCurrent$" />
+    <file src="Net9.0\publish\RoslynTools.*" target="tools\Net9.0" />
+    <file src="Net9.0\publish\System.*" target="tools\Net9.0" />
+    <file src="Net9.0\publish\NuGet.Versioning.*" target="tools\Net9.0" />
+    <file src="net472\RoslynTools.*" target="tools\net472" />
+    <file src="net472\System.*" target="tools\net472" />
+    <file src="net472\NuGet.Versioning.*" target="tools\net472" />
   </files>
 </package>

--- a/src/NuGetRepack/BuildTasks/RoslynTools.NuGetRepack.BuildTasks.nuspec
+++ b/src/NuGetRepack/BuildTasks/RoslynTools.NuGetRepack.BuildTasks.nuspec
@@ -5,11 +5,11 @@
   </metadata>
   <files>
     $CommonFileElements$
-    <file src="netcoreapp3.1\publish\RoslynTools.*" target="tools\netcoreapp3.1" />
-    <file src="netcoreapp3.1\publish\System.*" target="tools\netcoreapp3.1" />
-    <file src="netcoreapp3.1\publish\NuGet.Versioning.*" target="tools\netcoreapp3.1" />
-    <file src="net472\RoslynTools.*" target="tools\net472" />
-    <file src="net472\System.*" target="tools\net472" />
-    <file src="net472\NuGet.Versioning.*" target="tools\net472" />
+    <file src="$NetCurrent%\publish\RoslynTools.*" target="tools\$NetCurrent%" />
+    <file src="$NetCurrent%\publish\System.*" target="tools\$NetCurrent%" />
+    <file src="$NetCurrent%\publish\NuGet.Versioning.*" target="tools\$NetCurrent%" />
+    <file src="$NetFrameworkToolCurrent$\RoslynTools.*" target="tools\$NetFrameworkToolCurrent$" />
+    <file src="$NetFrameworkToolCurrent$\System.*" target="tools\$NetFrameworkToolCurrent$" />
+    <file src="$NetFrameworkToolCurrent$\NuGet.Versioning.*" target="tools\$NetFrameworkToolCurrent$" />
   </files>
 </package>

--- a/src/NuGetRepack/BuildTasks/RoslynTools.NuGetRepack.BuildTasks.nuspec
+++ b/src/NuGetRepack/BuildTasks/RoslynTools.NuGetRepack.BuildTasks.nuspec
@@ -5,9 +5,9 @@
   </metadata>
   <files>
     $CommonFileElements$
-    <file src="Net9.0\publish\RoslynTools.*" target="tools\Net9.0" />
-    <file src="Net9.0\publish\System.*" target="tools\Net9.0" />
-    <file src="Net9.0\publish\NuGet.Versioning.*" target="tools\Net9.0" />
+    <file src="net9.0\publish\RoslynTools.*" target="tools\net9.0" />
+    <file src="net9.0\publish\System.*" target="tools\net9.0" />
+    <file src="net9.0\publish\NuGet.Versioning.*" target="tools\net9.0" />
     <file src="net472\RoslynTools.*" target="tools\net472" />
     <file src="net472\System.*" target="tools\net472" />
     <file src="net472\NuGet.Versioning.*" target="tools\net472" />

--- a/src/NuGetRepack/BuildTasks/RoslynTools.NuGetRepack.BuildTasks.nuspec
+++ b/src/NuGetRepack/BuildTasks/RoslynTools.NuGetRepack.BuildTasks.nuspec
@@ -5,9 +5,9 @@
   </metadata>
   <files>
     $CommonFileElements$
-    <file src="$NetCurrent%\publish\RoslynTools.*" target="tools\$NetCurrent%" />
-    <file src="$NetCurrent%\publish\System.*" target="tools\$NetCurrent%" />
-    <file src="$NetCurrent%\publish\NuGet.Versioning.*" target="tools\$NetCurrent%" />
+    <file src="$NetCurrent$\publish\RoslynTools.*" target="tools\$NetCurrent$" />
+    <file src="$NetCurrent$\publish\System.*" target="tools\$NetCurrent$" />
+    <file src="$NetCurrent$\publish\NuGet.Versioning.*" target="tools\$NetCurrent$" />
     <file src="$NetFrameworkToolCurrent$\RoslynTools.*" target="tools\$NetFrameworkToolCurrent$" />
     <file src="$NetFrameworkToolCurrent$\System.*" target="tools\$NetFrameworkToolCurrent$" />
     <file src="$NetFrameworkToolCurrent$\NuGet.Versioning.*" target="tools\$NetFrameworkToolCurrent$" />

--- a/src/NuGetRepack/CLI/NuGetRepack.csproj
+++ b/src/NuGetRepack/CLI/NuGetRepack.csproj
@@ -1,9 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>$(NetFrameworkToolCurrent)</TargetFramework>
 
     <!-- Using an explicit nuspec file since NuGet Pack target currently doesn't support including dependencies in tools packages -->
     <IsPackable>true</IsPackable>

--- a/src/NuGetRepack/CLI/NuGetRepack.nuspec
+++ b/src/NuGetRepack/CLI/NuGetRepack.nuspec
@@ -5,6 +5,6 @@
   </metadata>
   <files>
     $CommonFileElements$
-    <file src="net472\*.*" target="tools" />
+    <file src="$NetFrameworkToolCurrent$\*.*" target="tools" />
   </files>
 </package>

--- a/src/NuGetRepack/CLI/NuGetRepack.nuspec
+++ b/src/NuGetRepack/CLI/NuGetRepack.nuspec
@@ -5,6 +5,6 @@
   </metadata>
   <files>
     $CommonFileElements$
-    <file src="$NetFrameworkToolCurrent$\*.*" target="tools" />
+    <file src="net472\*.*" target="tools" />
   </files>
 </package>

--- a/src/NuGetRepack/Tests/RoslynTools.NuGetRepack.Tests.csproj
+++ b/src/NuGetRepack/Tests/RoslynTools.NuGetRepack.Tests.csproj
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>$(NetFrameworkToolCurrent)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Resources\*.cs" />

--- a/src/NuGetRepack/Tests/TestHelpers/AssertEx.cs
+++ b/src/NuGetRepack/Tests/TestHelpers/AssertEx.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the License.txt file in the project root for more information.
 
@@ -162,7 +162,7 @@ namespace Roslyn.Test.Utilities
 
             if (normalizedExpected != normalizedActual)
             {
-                Assert.True(false, GetAssertMessage(expected, actual, escapeQuotes, expectedValueSourcePath, expectedValueSourceLine));
+                Assert.Fail(GetAssertMessage(expected, actual, escapeQuotes, expectedValueSourcePath, expectedValueSourceLine));
             }
         }
 
@@ -220,7 +220,7 @@ namespace Roslyn.Test.Utilities
                     assertMessage = message + "\r\n" + assertMessage;
                 }
 
-                Assert.True(false, assertMessage);
+                Assert.Fail(assertMessage);
             }
         }
 
@@ -323,12 +323,12 @@ namespace Roslyn.Test.Utilities
 
         public static void Fail(string message)
         {
-            Assert.False(true, message);
+            Assert.Fail(message);
         }
 
         public static void Fail(string format, params object[] args)
         {
-            Assert.False(true, string.Format(format, args));
+            Assert.Fail(string.Format(format, args));
         }
 
         public static void Null<T>(T @object, string message = null)

--- a/src/OptProf/roslyn.optprof.lib/roslyn.optprof.lib.csproj
+++ b/src/OptProf/roslyn.optprof.lib/roslyn.optprof.lib.csproj
@@ -1,9 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>$(NetFrameworkToolCurrent)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OptProf/roslyn.optprof.runsettings.generator.unittests/roslyn.optprof.runsettings.generator.UnitTests.csproj
+++ b/src/OptProf/roslyn.optprof.runsettings.generator.unittests/roslyn.optprof.runsettings.generator.UnitTests.csproj
@@ -1,9 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>$(NetFrameworkToolCurrent)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OptProf/roslyn.optprof.runsettings.generator/roslyn.optprof.runsettings.generator.csproj
+++ b/src/OptProf/roslyn.optprof.runsettings.generator/roslyn.optprof.runsettings.generator.csproj
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>$(NetFrameworkToolCurrent)</TargetFramework>
     <OutputType>Exe</OutputType>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <CopyNuGetImplementations>true</CopyNuGetImplementations>

--- a/src/OptProf/roslyn.optprof.runsettings.generator/roslyn.optprof.runsettings.generator.nuspec
+++ b/src/OptProf/roslyn.optprof.runsettings.generator/roslyn.optprof.runsettings.generator.nuspec
@@ -5,6 +5,6 @@
   </metadata>
   <files>
     $CommonFileElements$
-    <file src="net472\*.*" target="tools" />
+    <file src="$NetFrameworkToolCurrent$\*.*" target="tools" />
   </files>
 </package>

--- a/src/OptProf/roslyn.optprof.runsettings.generator/roslyn.optprof.runsettings.generator.nuspec
+++ b/src/OptProf/roslyn.optprof.runsettings.generator/roslyn.optprof.runsettings.generator.nuspec
@@ -5,6 +5,6 @@
   </metadata>
   <files>
     $CommonFileElements$
-    <file src="$NetFrameworkToolCurrent$\*.*" target="tools" />
+    <file src="net472\*.*" target="tools" />
   </files>
 </package>

--- a/src/OptProf/roslyn.optprof/roslyn.optprof.csproj
+++ b/src/OptProf/roslyn.optprof/roslyn.optprof.csproj
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>$(NetFrameworkToolCurrent)</TargetFramework>
     <OutputType>Exe</OutputType>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <CopyNuGetImplementations>true</CopyNuGetImplementations>

--- a/src/OptProf/roslyn.optprof/roslyn.optprof.nuspec
+++ b/src/OptProf/roslyn.optprof/roslyn.optprof.nuspec
@@ -5,6 +5,6 @@
   </metadata>
   <files>
     $CommonFileElements$
-    <file src="net472\*.*" target="tools" />
+    <file src="$NetFrameworkToolCurrent$\*.*" target="tools" />
   </files>
 </package>

--- a/src/OptProf/roslyn.optprof/roslyn.optprof.nuspec
+++ b/src/OptProf/roslyn.optprof/roslyn.optprof.nuspec
@@ -5,6 +5,6 @@
   </metadata>
   <files>
     $CommonFileElements$
-    <file src="$NetFrameworkToolCurrent$\*.*" target="tools" />
+    <file src="net472\*.*" target="tools" />
   </files>
 </package>

--- a/src/ProjectDependencies/ProjectDependencies.csproj
+++ b/src/ProjectDependencies/ProjectDependencies.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>$(NetFrameworkToolCurrent)</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
   </PropertyGroup>

--- a/src/RepoToolset/RoslynTools.RepoToolset.csproj
+++ b/src/RepoToolset/RoslynTools.RepoToolset.csproj
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkToolCurrent);$(NetMinimum)</TargetFrameworks>
 
     <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
 

--- a/src/RepoToolset/RoslynTools.RepoToolset.csproj
+++ b/src/RepoToolset/RoslynTools.RepoToolset.csproj
@@ -2,7 +2,7 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(NetFrameworkToolCurrent);$(NetMinimum)</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkToolCurrent);$(NetCurrent)</TargetFrameworks>
 
     <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
 

--- a/src/RepoToolset/RoslynTools.RepoToolset.nuspec
+++ b/src/RepoToolset/RoslynTools.RepoToolset.nuspec
@@ -10,9 +10,9 @@
     $CommonFileElements$
     <file src="$ProjectDirectory$\sdk\*.*" target="sdk" />
     <file src="$ProjectDirectory$\tools\*.*" target="tools" />
-    <file src="$NetCurrent$\publish\RoslynTools.*" target="tools\tasks\$NetCurrent$" />
-    <file src="$NetCurrent$\publish\System.*" target="tools\tasks\$NetCurrent$" />
-    <file src="$NetFrameworkToolCurrent$\RoslynTools.*" target="tools\tasks\$NetFrameworkToolCurrent$" />
-    <file src="$NetFrameworkToolCurrent$\System.*" target="tools\tasks\$NetFrameworkToolCurrent$" />
+    <file src="Net9.0\publish\RoslynTools.*" target="tools\tasks\Net9.0" />
+    <file src="Net9.0\publish\System.*" target="tools\tasks\Net9.0" />
+    <file src="net472\RoslynTools.*" target="tools\tasks\net472" />
+    <file src="net472\System.*" target="tools\tasks\net472" />
   </files>
 </package>

--- a/src/RepoToolset/RoslynTools.RepoToolset.nuspec
+++ b/src/RepoToolset/RoslynTools.RepoToolset.nuspec
@@ -10,8 +10,8 @@
     $CommonFileElements$
     <file src="$ProjectDirectory$\sdk\*.*" target="sdk" />
     <file src="$ProjectDirectory$\tools\*.*" target="tools" />
-    <file src="Net9.0\publish\RoslynTools.*" target="tools\tasks\Net9.0" />
-    <file src="Net9.0\publish\System.*" target="tools\tasks\Net9.0" />
+    <file src="net9.0\publish\RoslynTools.*" target="tools\tasks\net9.0" />
+    <file src="net9.0\publish\System.*" target="tools\tasks\net9.0" />
     <file src="net472\RoslynTools.*" target="tools\tasks\net472" />
     <file src="net472\System.*" target="tools\tasks\net472" />
   </files>

--- a/src/RepoToolset/RoslynTools.RepoToolset.nuspec
+++ b/src/RepoToolset/RoslynTools.RepoToolset.nuspec
@@ -10,9 +10,9 @@
     $CommonFileElements$
     <file src="$ProjectDirectory$\sdk\*.*" target="sdk" />
     <file src="$ProjectDirectory$\tools\*.*" target="tools" />
-    <file src="netcoreapp3.1\publish\RoslynTools.*" target="tools\tasks\netcoreapp3.1" />
-    <file src="netcoreapp3.1\publish\System.*" target="tools\tasks\netcoreapp3.1" />
-    <file src="net472\RoslynTools.*" target="tools\tasks\net472" />
-    <file src="net472\System.*" target="tools\tasks\net472" />
+    <file src="$NetCurrent$\publish\RoslynTools.*" target="tools\tasks\$NetCurrent$" />
+    <file src="$NetCurrent$\publish\System.*" target="tools\tasks\$NetCurrent$" />
+    <file src="$NetFrameworkToolCurrent$\RoslynTools.*" target="tools\tasks\$NetFrameworkToolCurrent$" />
+    <file src="$NetFrameworkToolCurrent$\System.*" target="tools\tasks\$NetFrameworkToolCurrent$" />
   </files>
 </package>

--- a/src/RepoToolset/tools/BuildReleasePackages.targets
+++ b/src/RepoToolset/tools/BuildReleasePackages.targets
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <_NuGetRepackAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(NuGetPackageRoot)roslyntools.nugetrepack.buildtasks\$(RoslynToolsNuGetRepackVersion)\tools\net461\RoslynTools.NuGetRepack.BuildTasks.dll</_NuGetRepackAssembly>
-    <_NuGetRepackAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(NuGetPackageRoot)roslyntools.nugetrepack.buildtasks\$(RoslynToolsNuGetRepackVersion)\tools\netcoreapp2.0\RoslynTools.NuGetRepack.BuildTasks.dll</_NuGetRepackAssembly>
+    <_NuGetRepackAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(NuGetPackageRoot)roslyntools.nugetrepack.buildtasks\$(RoslynToolsNuGetRepackVersion)\tools\$(NetFramworkToolCurrent)\RoslynTools.NuGetRepack.BuildTasks.dll</_NuGetRepackAssembly>
+    <_NuGetRepackAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(NuGetPackageRoot)roslyntools.nugetrepack.buildtasks\$(RoslynToolsNuGetRepackVersion)\tools\$(NetCurrent)\RoslynTools.NuGetRepack.BuildTasks.dll</_NuGetRepackAssembly>
   </PropertyGroup>
 
   <UsingTask TaskName="Roslyn.Tools.UpdatePackageVersionTask" AssemblyFile="$(_NuGetRepackAssembly)" />

--- a/src/RepoToolset/tools/BuildTasks.props
+++ b/src/RepoToolset/tools/BuildTasks.props
@@ -5,7 +5,7 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
   <PropertyGroup>
-    <RoslynToolsBuildTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)tasks\net461\RoslynTools.RepoToolset.dll</RoslynToolsBuildTasksAssembly>
-    <RoslynToolsBuildTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)tasks\netcoreapp2.0\RoslynTools.RepoToolset.dll</RoslynToolsBuildTasksAssembly>
+    <RoslynToolsBuildTasksAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)tasks\$(NetFrameworkToolCurrent)\RoslynTools.RepoToolset.dll</RoslynToolsBuildTasksAssembly>
+    <RoslynToolsBuildTasksAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)tasks\$(NetCurrent)\RoslynTools.RepoToolset.dll</RoslynToolsBuildTasksAssembly>
   </PropertyGroup>
 </Project>

--- a/src/RepoToolset/tools/Tools.proj
+++ b/src/RepoToolset/tools/Tools.proj
@@ -15,7 +15,7 @@
   <Import Project="BuildStep.props" />
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>$(NetFrameworkToolCurrent)</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/RoslynInsertionTool/AsyncProcess/AsyncProcess.csproj
+++ b/src/RoslynInsertionTool/AsyncProcess/AsyncProcess.csproj
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>$(NetFrameworkToolCurrent)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/RoslynInsertionTool/README.md
+++ b/src/RoslynInsertionTool/README.md
@@ -81,4 +81,4 @@ Additionally you will have to provide authentication by following these steps:
  1. Go to https://devdiv.visualstudio.com/_usersSettings/tokens and generate a token with the following scopes: vso.build_execute,vso.code_full,vso.release_execute,vso.packaging
  2. Add the command line arguments `/username=myusername@microsoft.com /password=myauthtoken`
 
-```G:\roslyn-tools\artifacts\bin\RIT\Debug\net46\RIT.exe /username=dmon@microsoft.com /password=token /in="Project System" /bn=main /bq=DotNet-Project-System /vsbn=main /ic=true /id=false /ua=true /uc=false /dpr=true /qv=false```
+```G:\roslyn-tools\artifacts\bin\RIT\Debug\net472\RIT.exe /username=dmon@microsoft.com /password=token /in="Project System" /bn=main /bq=DotNet-Project-System /vsbn=main /ic=true /id=false /ua=true /uc=false /dpr=true /qv=false```

--- a/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/RIT.csproj
+++ b/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/RIT.csproj
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>RoslynInsertionTool</RootNamespace>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>$(NetFrameworkToolCurrent)</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Prefer32Bit>false</Prefer32Bit>
 

--- a/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/RIT.nuspec
+++ b/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/RIT.nuspec
@@ -5,6 +5,6 @@
   </metadata>
   <files>
     $CommonFileElements$
-    <file src="$NetFrameworkToolCurrent$/**/*.*" target="tools" />
+    <file src="net472/**/*.*" target="tools" />
   </files>
 </package>

--- a/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/RIT.nuspec
+++ b/src/RoslynInsertionTool/RoslynInsertionTool.Commandline/RIT.nuspec
@@ -5,6 +5,6 @@
   </metadata>
   <files>
     $CommonFileElements$
-    <file src="net46/**/*.*" target="tools" />
+    <file src="$NetFrameworkToolCurrent$/**/*.*" target="tools" />
   </files>
 </package>

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.csproj
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.csproj
@@ -1,9 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>$(NetFrameworkToolCurrent)</TargetFramework>
     <RootNamespace>Roslyn.Insertion</RootNamespace>
     <OutputType>Library</OutputType>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>

--- a/src/RoslynInsertionTool/SingleThreadSynchronizationContext/SingleThreadSynchronizationContext.csproj
+++ b/src/RoslynInsertionTool/SingleThreadSynchronizationContext/SingleThreadSynchronizationContext.csproj
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>$(NetFrameworkToolCurrent)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/SignTool/SignTool/SignTool.csproj
+++ b/src/SignTool/SignTool/SignTool.csproj
@@ -1,9 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(NetFrameworkToolCurrent)</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 

--- a/src/SignTool/SignTool/SignTool.nuspec
+++ b/src/SignTool/SignTool/SignTool.nuspec
@@ -5,6 +5,6 @@
   </metadata>
   <files>
     $CommonFileElements$
-    <file src="$NetFrameworkToolCurrent$\*.*" target="tools" />
+    <file src="net472\*.*" target="tools" />
   </files>
 </package>

--- a/src/SignTool/SignTool/SignTool.nuspec
+++ b/src/SignTool/SignTool/SignTool.nuspec
@@ -5,6 +5,6 @@
   </metadata>
   <files>
     $CommonFileElements$
-    <file src="net461\*.*" target="tools" />
+    <file src="$NetFrameworkToolCurrent$\*.*" target="tools" />
   </files>
 </package>

--- a/src/SignTool/SignToolTests/SignTool.UnitTests.csproj
+++ b/src/SignTool/SignToolTests/SignTool.UnitTests.csproj
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>$(NetFrameworkToolCurrent)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Moq" Version="$(MoqVersion)" />

--- a/src/VSIXExpInstaller/VSIXExpInstaller.csproj
+++ b/src/VSIXExpInstaller/VSIXExpInstaller.csproj
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>$(NetFrameworkToolCurrent)</TargetFramework>
     <OutputType>Exe</OutputType>
     <PlatformTarget>x64</PlatformTarget>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>

--- a/src/VSIXExpInstaller/VSIXExpInstaller.nuspec
+++ b/src/VSIXExpInstaller/VSIXExpInstaller.nuspec
@@ -5,6 +5,6 @@
   </metadata>
   <files>
     $CommonFileElements$
-    <file src="net472\VSIXExpInstaller.*" target="tools" />
+    <file src="$NetFrameworkToolCurrent$\VSIXExpInstaller.*" target="tools" />
   </files>
 </package>

--- a/src/VSIXExpInstaller/VSIXExpInstaller.nuspec
+++ b/src/VSIXExpInstaller/VSIXExpInstaller.nuspec
@@ -5,6 +5,6 @@
   </metadata>
   <files>
     $CommonFileElements$
-    <file src="$NetFrameworkToolCurrent$\VSIXExpInstaller.*" target="tools" />
+    <file src="net472\VSIXExpInstaller.*" target="tools" />
   </files>
 </package>

--- a/src/dotnet-roslyn-tools/Microsoft.RoslynTools.csproj
+++ b/src/dotnet-roslyn-tools/Microsoft.RoslynTools.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>$(NetMinimum)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/src/dotnet-roslyn-tools/Microsoft.RoslynTools.csproj
+++ b/src/dotnet-roslyn-tools/Microsoft.RoslynTools.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(NetMinimum)</TargetFramework>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 


### PR DESCRIPTION
Arcade sdks using in the repo hasn't been updated for years. Some TFMs are retired and, we need to update the sdk to move to 1ES.

`$(NetFrameworkToolCurrent)` means `net472`
`$(NetCurrent)` mean `net9.0`

This will fix the build see validation https://github.com/dotnet/roslyn-tools/pull/1396