### PR TITLE
Use 9.x sdk to run merge PR pipeline

### DIFF
--- a/merge-pr-pipeline.yml
+++ b/merge-pr-pipeline.yml
@@ -28,17 +28,10 @@ pool:
 
 steps:
 - task: UseDotNet@2
-  displayName: 'Install .NET Core SDKs'
+  displayName: 'Install .NET'
   inputs:
     useGlobalJson: true
     installationPath: $(Agent.ToolsDirectory)/dotnet
-    
-- task: UseDotNet@2
-  displayName: 'Install .NET Core Runtime'
-  inputs:
-    packageType: runtime
-    version: 3.1.20
-    installationPath: $(Agent.ToolsDirectory)/dotnet
 
-- script: dotnet run -p $(Build.SourcesDirectory)/src/GitHubCreateMergePRs/GitHubCreateMergePRs.csproj --isDryRun=$(isDryRun) --isAutomated=$(isAutomated) --githubToken=$(BotAccount-dotnet-bot-repo-PAT)
+- script: dotnet --info; dotnet run -p $(Build.SourcesDirectory)/src/GitHubCreateMergePRs/GitHubCreateMergePRs.csproj --isDryRun=$(isDryRun) --isAutomated=$(isAutomated) --githubToken=$(BotAccount-dotnet-bot-repo-PAT)
   displayName: 'Run GitHub Create Merge PRs'

--- a/merge-pr-pipeline.yml
+++ b/merge-pr-pipeline.yml
@@ -32,6 +32,7 @@ steps:
   inputs:
     version: 9.x
     installationPath: $(Agent.ToolsDirectory)/dotnet
+    includePreviewVersions: true
 
 - script: dotnet --info; dotnet run -p $(Build.SourcesDirectory)/src/GitHubCreateMergePRs/GitHubCreateMergePRs.csproj --isDryRun=$(isDryRun) --isAutomated=$(isAutomated) --githubToken=$(BotAccount-dotnet-bot-repo-PAT)
   displayName: 'Run GitHub Create Merge PRs'

--- a/merge-pr-pipeline.yml
+++ b/merge-pr-pipeline.yml
@@ -30,7 +30,7 @@ steps:
 - task: UseDotNet@2
   displayName: 'Install .NET'
   inputs:
-    useGlobalJson: true
+    version: 9.x.x
     installationPath: $(Agent.ToolsDirectory)/dotnet
 
 - script: dotnet --info; dotnet run -p $(Build.SourcesDirectory)/src/GitHubCreateMergePRs/GitHubCreateMergePRs.csproj --isDryRun=$(isDryRun) --isAutomated=$(isAutomated) --githubToken=$(BotAccount-dotnet-bot-repo-PAT)

--- a/merge-pr-pipeline.yml
+++ b/merge-pr-pipeline.yml
@@ -30,7 +30,7 @@ steps:
 - task: UseDotNet@2
   displayName: 'Install .NET'
   inputs:
-    version: 9.x.x
+    version: 9.x
     installationPath: $(Agent.ToolsDirectory)/dotnet
 
 - script: dotnet --info; dotnet run -p $(Build.SourcesDirectory)/src/GitHubCreateMergePRs/GitHubCreateMergePRs.csproj --isDryRun=$(isDryRun) --isAutomated=$(isAutomated) --githubToken=$(BotAccount-dotnet-bot-repo-PAT)


### PR DESCRIPTION
netcore 3.1.20 is too old, should retire.
Test run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9321682&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9