### PR TITLE
Use .NET 9.0 to run PR tagger

### DIFF
--- a/insertion-pr-tagger.yml
+++ b/insertion-pr-tagger.yml
@@ -34,6 +34,10 @@ extends:
       - job: runPRTagger
         steps:
           - task: UseDotNet@2
+            displayName: 'Install .NET'
+            inputs:
+              version: 9.x
+              includePreviewVersions: true
           - script: dotnet tool install Microsoft.RoslynTools --prerelease --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json -g
             displayName: Install Roslyn Insertion Tool
           - script: roslyn-tools pr-tagger --github-token  $(roslyn-dotnet-bot-issue-w-pat) --devdiv-azdo-token $(roslyn-dn-bot-devdiv-build-r-release-r-code-r)  --dnceng-azdo-token $(roslyn-dn-bot-dnceng-build-r)


### PR DESCRIPTION
PR tagger is broken https://dev.azure.com/dnceng/internal/_build/results?buildId=2422541&view=results
And update the runtime to 9.0 solving the issue.
Verified in https://dev.azure.com/dnceng/internal/_build/results?buildId=2422800&view=logs&j=9d82d844-45a0-5d2e-bd4b-992528a7bed5&t=5cca82b3-8182-5619-1c3b-68ef1449fa53