### PR TITLE
Move the official build pipeline to dnceng and appy 1ES template

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -34,6 +34,9 @@ extends:
     stages:
     - stage: build
       displayName: Build and Test
+      pool:
+        name: netcore1espool-internal
+        os: 1es-windows-2022-pt
       jobs:
       - job: OfficialBuild
         displayName: Official Build
@@ -68,7 +71,7 @@ extends:
             condition: succeededOrFailed()
           - output: pipelineArtifact
             displayName: Publish Asset Manifests
-            targetPath: $(Build.SourcesDirectory)/artifacts/log/$(BuildConfiguration)/AssetManifest
+            targetPath: $(Build.SourcesDirectory)\artifacts\log\$(BuildConfiguration)\AssetManifest
             artifactName: 'AssetManifests'
             condition: succeeded()
           - output: pipelineArtifact

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -21,11 +21,11 @@ trigger:
 - main
 
 extends:
-  template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     pool:
-      name: NetCore1ESPool-Svc-Internal
-      os: windows
+      name: netcore1espool-internal
+      os: 1es-windows-2022-pt
     stages:
     - stage: build
       displayName: Build and Test

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -74,11 +74,11 @@ extends:
 
           # Publish our NuPkgs as an artifact. The name of this artifact must be PackageArtifacts as the
           # arcade templates depend on the name.
-          - output: pipelineArtifact
-            targetPath: $(Build.SourcesDirectory)\artifacts\packages\$(BuildConfiguration)
-            displayName: Publish packages
-            artifactName: 'BuildPackageArtifacts'
-            condition: succeededOrFailed()
+        #   - output: pipelineArtifact
+        #     targetPath: $(Build.SourcesDirectory)\artifacts\packages\$(BuildConfiguration)
+        #     displayName: Publish packages
+        #     artifactName: 'PackageArtifacts'
+        #     condition: succeededOrFailed()
 
           - output: pipelineArtifact
             displayName: Publish Asset Manifests

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -84,6 +84,7 @@ extends:
           inputs:
             zipSources: false
             signType: $(SignType)
+            feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
           condition: and(succeeded(), ne(variables['SignType'], ''))
         - script: eng\common\CIBuild.cmd
                     -configuration $(BuildConfiguration)

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -34,9 +34,6 @@ extends:
     stages:
     - stage: build
       displayName: Build and Test
-      pool:
-        name: netcore1espool-internal
-        os: 1es-windows-2022-pt
       jobs:
       - job: OfficialBuild
         displayName: Official Build
@@ -114,6 +111,9 @@ extends:
       - template: /eng/common/templates-official/job/publish-build-assets.yml@self
         parameters:
           publishUsingPipelines: true
+          pool:
+            name: netcore1espool-internal
+            os: 1es-windows-2022-pt
           dependsOn:
             - OfficialBuild
           queue:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -89,33 +89,33 @@ extends:
                     /p:DotnetPublishUsingPipelines=true
           displayName: Build
 
-        # - template: eng\common\templates\steps\generate-sbom.yml@self
+        - template: /eng/common/templates-official/steps/generate-sbom.yml@self
 
-    #     - task: PublishTestResults@2
-    #       displayName: Publish xUnit Test Results
-    #       inputs:
-    #         testRunner: XUnit
-    #         testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
-    #         mergeTestResults: true
-    #         testRunTitle: 'Unit Tests'
-    #       condition: succeededOrFailed()
-    #     - task: MicroBuildCleanup@1
-    #       displayName: Cleanup
-    #       condition: succeededOrFailed()
-    #   # Publish to Build Asset Registry
-    #   - template: /eng/common/templates-official/job/publish-build-assets.yml@self
-    #     parameters:
-    #       publishUsingPipelines: true
-    #       dependsOn:
-    #         - OfficialBuild
-    #       queue:
-    #         name: Hosted VS2017
+        - task: PublishTestResults@2
+          displayName: Publish xUnit Test Results
+          inputs:
+            testRunner: XUnit
+            testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
+            mergeTestResults: true
+            testRunTitle: 'Unit Tests'
+          condition: succeededOrFailed()
+        - task: MicroBuildCleanup@1
+          displayName: Cleanup
+          condition: succeededOrFailed()
+      # Publish to Build Asset Registry
+      - template: /eng/common/templates-official/job/publish-build-assets.yml@self
+        parameters:
+          publishUsingPipelines: true
+          dependsOn:
+            - OfficialBuild
+          queue:
+            name: Hosted VS2017
 
-    # - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    #   - template: eng\common\templates\post-build\post-build.yml@self
-    #     parameters:
-    #       # Symbol validation is not entirely reliable as of yet, so should be turned off until
-    #       # https://github.com/dotnet/arcade/issues/2871 is resolved.
-    #       enableSymbolValidation: false
-    #       enableSourceLinkValidation: false
-    #       publishingInfraVersion: 3
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - template: eng\common\templates\post-build\post-build.yml@self
+        parameters:
+          # Symbol validation is not entirely reliable as of yet, so should be turned off until
+          # https://github.com/dotnet/arcade/issues/2871 is resolved.
+          enableSymbolValidation: false
+          enableSourceLinkValidation: false
+          publishingInfraVersion: 3

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -40,6 +40,9 @@ extends:
       jobs:
       - job: OfficialBuild
         displayName: Official Build
+        pool:
+          name: netcore1espool-internal
+          os: 1es-windows-2022-pt
         templateContext:
           outputs:
           # Note that insertion scripts currently depend on bin directory being uploaded to drops.
@@ -98,36 +101,36 @@ extends:
                     /p:DotnetPublishUsingPipelines=true
           displayName: Build
 
-    #     - template: /eng/common/templates-official/steps/generate-sbom.yml@self
+        - template: /eng/common/templates-official/steps/generate-sbom.yml@self
 
-    #     - task: PublishTestResults@2
-    #       displayName: Publish xUnit Test Results
-    #       inputs:
-    #         testRunner: XUnit
-    #         testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
-    #         mergeTestResults: true
-    #         testRunTitle: 'Unit Tests'
-    #       condition: succeededOrFailed()
-    #     - task: MicroBuildCleanup@1
-    #       displayName: Cleanup
-    #       condition: succeededOrFailed()
-    #   # Publish to Build Asset Registry
-    #   - template: /eng/common/templates-official/job/publish-build-assets.yml@self
-    #     parameters:
-    #       publishUsingPipelines: true
-    #       pool:
-    #         name: netcore1espool-internal
-    #         os: 1es-windows-2022-pt
-    #       dependsOn:
-    #         - OfficialBuild
-    #       queue:
-    #         name: Hosted VS2017
+        - task: PublishTestResults@2
+          displayName: Publish xUnit Test Results
+          inputs:
+            testRunner: XUnit
+            testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
+            mergeTestResults: true
+            testRunTitle: 'Unit Tests'
+          condition: succeededOrFailed()
+        - task: MicroBuildCleanup@1
+          displayName: Cleanup
+          condition: succeededOrFailed()
+      # Publish to Build Asset Registry
+      - template: /eng/common/templates-official/job/publish-build-assets.yml@self
+        parameters:
+          publishUsingPipelines: true
+          pool:
+            name: netcore1espool-internal
+            os: 1es-windows-2022-pt
+          dependsOn:
+            - OfficialBuild
+          queue:
+            name: Hosted VS2017
 
-    # - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    #   - template: eng\common\templates-official\post-build\post-build.yml@self
-    #     parameters:
-    #       # Symbol validation is not entirely reliable as of yet, so should be turned off until
-    #       # https://github.com/dotnet/arcade/issues/2871 is resolved.
-    #       enableSymbolValidation: false
-    #       enableSourceLinkValidation: false
-    #       publishingInfraVersion: 3
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - template: eng\common\templates-official\post-build\post-build.yml@self
+        parameters:
+          # Symbol validation is not entirely reliable as of yet, so should be turned off until
+          # https://github.com/dotnet/arcade/issues/2871 is resolved.
+          enableSymbolValidation: false
+          enableSourceLinkValidation: false
+          publishingInfraVersion: 3

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -18,7 +18,7 @@ variables:
   - name: BuildConfiguration
     value: Release
   - name: SignType
-    value: Real
+    value: ''
   - name: system.debug
     value: false
   - name: TeamName
@@ -107,36 +107,36 @@ extends:
                     /p:DotnetPublishUsingPipelines=true
           displayName: Build
 
-    #     - template: /eng/common/templates-official/steps/generate-sbom.yml@self
+        - template: /eng/common/templates-official/steps/generate-sbom.yml@self
 
-    #     - task: PublishTestResults@2
-    #       displayName: Publish xUnit Test Results
-    #       inputs:
-    #         testRunner: XUnit
-    #         testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
-    #         mergeTestResults: true
-    #         testRunTitle: 'Unit Tests'
-    #       condition: succeededOrFailed()
-    #     - task: MicroBuildCleanup@1
-    #       displayName: Cleanup
-    #       condition: succeededOrFailed()
-    #   # Publish to Build Asset Registry
-    #   - template: /eng/common/templates-official/job/publish-build-assets.yml@self
-    #     parameters:
-    #       publishUsingPipelines: true
-    #       pool:
-    #         name: netcore1espool-internal
-    #         os: 1es-windows-2022-pt
-    #       dependsOn:
-    #         - OfficialBuild
-    #       queue:
-    #         name: Hosted VS2017
+        - task: PublishTestResults@2
+          displayName: Publish xUnit Test Results
+          inputs:
+            testRunner: XUnit
+            testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
+            mergeTestResults: true
+            testRunTitle: 'Unit Tests'
+          condition: succeededOrFailed()
+        - task: MicroBuildCleanup@1
+          displayName: Cleanup
+          condition: succeededOrFailed()
+      # Publish to Build Asset Registry
+      - template: /eng/common/templates-official/job/publish-build-assets.yml@self
+        parameters:
+          publishUsingPipelines: true
+          pool:
+            name: netcore1espool-internal
+            os: 1es-windows-2022-pt
+          dependsOn:
+            - OfficialBuild
+          queue:
+            name: Hosted VS2017
 
-    # - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    #   - template: eng\common\templates-official\post-build\post-build.yml@self
-    #     parameters:
-    #       # Symbol validation is not entirely reliable as of yet, so should be turned off until
-    #       # https://github.com/dotnet/arcade/issues/2871 is resolved.
-    #       enableSymbolValidation: false
-    #       enableSourceLinkValidation: false
-    #       publishingInfraVersion: 3
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - template: eng\common\templates-official\post-build\post-build.yml@self
+        parameters:
+          # Symbol validation is not entirely reliable as of yet, so should be turned off until
+          # https://github.com/dotnet/arcade/issues/2871 is resolved.
+          enableSymbolValidation: false
+          enableSourceLinkValidation: false
+          publishingInfraVersion: 3

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -107,36 +107,36 @@ extends:
                     /p:DotnetPublishUsingPipelines=true
           displayName: Build
 
-    #     - template: /eng/common/templates-official/steps/generate-sbom.yml@self
+        - template: /eng/common/templates-official/steps/generate-sbom.yml@self
 
-    #     - task: PublishTestResults@2
-    #       displayName: Publish xUnit Test Results
-    #       inputs:
-    #         testRunner: XUnit
-    #         testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
-    #         mergeTestResults: true
-    #         testRunTitle: 'Unit Tests'
-    #       condition: succeededOrFailed()
-    #     - task: MicroBuildCleanup@1
-    #       displayName: Cleanup
-    #       condition: succeededOrFailed()
-    #   # Publish to Build Asset Registry
-    #   - template: /eng/common/templates-official/job/publish-build-assets.yml@self
-    #     parameters:
-    #       publishUsingPipelines: true
-    #       pool:
-    #         name: netcore1espool-internal
-    #         os: 1es-windows-2022-pt
-    #       dependsOn:
-    #         - OfficialBuild
-    #       queue:
-    #         name: Hosted VS2017
+        - task: PublishTestResults@2
+          displayName: Publish xUnit Test Results
+          inputs:
+            testRunner: XUnit
+            testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
+            mergeTestResults: true
+            testRunTitle: 'Unit Tests'
+          condition: succeededOrFailed()
+        - task: MicroBuildCleanup@1
+          displayName: Cleanup
+          condition: succeededOrFailed()
+      # Publish to Build Asset Registry
+      - template: /eng/common/templates-official/job/publish-build-assets.yml@self
+        parameters:
+          publishUsingPipelines: true
+          pool:
+            name: netcore1espool-internal
+            os: 1es-windows-2022-pt
+          dependsOn:
+            - OfficialBuild
+          queue:
+            name: Hosted VS2017
 
-    # - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    #   - template: eng\common\templates-official\post-build\post-build.yml@self
-    #     parameters:
-    #       # Symbol validation is not entirely reliable as of yet, so should be turned off until
-    #       # https://github.com/dotnet/arcade/issues/2871 is resolved.
-    #       enableSymbolValidation: false
-    #       enableSourceLinkValidation: false
-    #       publishingInfraVersion: 3
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - template: eng\common\templates-official\post-build\post-build.yml@self
+        parameters:
+          # Symbol validation is not entirely reliable as of yet, so should be turned off until
+          # https://github.com/dotnet/arcade/issues/2871 is resolved.
+          enableSymbolValidation: false
+          enableSourceLinkValidation: false
+          publishingInfraVersion: 3

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -50,45 +50,45 @@ extends:
         templateContext:
           outputs:
           # Note that insertion scripts currently depend on bin directory being uploaded to drops.
-          - output: pipelineArtifact
-            targetPath: $(Build.SourcesDirectory)\artifacts\bin
+          - output: buildArtifacts
+            PathtoPublish: $(Build.SourcesDirectory)\artifacts\bin
             displayName: Publish binaries
             publishLocation: Container
             artifactName: bin
             condition: succeededOrFailed()
 
-          - output: pipelineArtifact
-            targetPath: $(Build.SourcesDirectory)\artifacts\log\$(BuildConfiguration)
+          - output: buildArtifacts
+            PathtoPublish: $(Build.SourcesDirectory)\artifacts\log\$(BuildConfiguration)
             displayName: Publish logs
             artifactName: 'Build Diagnostic Files'
             publishLocation: Container
             continueOnError: true
             condition: succeededOrFailed()
 
-          - output: pipelineArtifact
+          - output: buildArtifacts
             displayName: Publish test results
-            targetPath: $(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)
+            PathtoPublish: $(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)
             artifactName: 'TestResults'
             publishLocation: Container
             condition: succeededOrFailed()
 
           # Publish our NuPkgs as an artifact. The name of this artifact must be PackageArtifacts as the
           # arcade templates depend on the name.
-        #   - output: pipelineArtifact
-        #     targetPath: $(Build.SourcesDirectory)\artifacts\packages\$(BuildConfiguration)
-        #     displayName: Publish packages
-        #     artifactName: 'PackageArtifacts'
-        #     condition: succeededOrFailed()
+          - output: buildArtifacts
+            PathtoPublish: $(Build.SourcesDirectory)\artifacts\packages\$(BuildConfiguration)
+            displayName: Publish packages
+            artifactName: 'PackageArtifacts'
+            condition: succeededOrFailed()
 
-          - output: pipelineArtifact
+          - output: buildArtifacts
             displayName: Publish Asset Manifests
-            targetPath: $(Build.SourcesDirectory)\artifacts\log\$(BuildConfiguration)\AssetManifest
+            PathtoPublish: $(Build.SourcesDirectory)\artifacts\log\$(BuildConfiguration)\AssetManifest
             artifactName: 'AssetManifests'
             condition: succeeded()
 
-          - output: pipelineArtifact
+          - output: buildArtifacts
             displayName: Publish MicroBuild Artifacts
-            targetPath: $(Build.ArtifactStagingDirectory)\MicroBuild\Output
+            PathtoPublish: $(Build.ArtifactStagingDirectory)\MicroBuild\Output
             artifactName: MicroBuildOutputs
             artifactType: Container
             condition: succeededOrFailed()

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -100,6 +100,9 @@ extends:
                     -configuration $(BuildConfiguration)
                     /p:PB_PublishBlobFeedKey=$(PB_PublishBlobFeedKey)
                     /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+                    /p:DotNetSignType=$(SignType)
+                    /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
+                    /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
                     /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
                     /p:DotnetPublishUsingPipelines=true
           displayName: Build
@@ -122,9 +125,8 @@ extends:
         parameters:
           publishUsingPipelines: true
           pool:
-            name: NetCore1ESPool-Svc-Internal
-            image: 1es-windows-2022-pt
-            os: windows
+            name: netcore1espool-internal
+            os: 1es-windows-2022-pt
           dependsOn:
             - OfficialBuild
           queue:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -81,9 +81,10 @@ extends:
             artifactType: Container
             condition: succeededOrFailed()
         steps:
-        - task: MicroBuildSigningPlugin@1
+        - task: MicroBuildSigningPlugin@4
           displayName: Install Signing Plugin
           inputs:
+            zipSources: false
             signType: $(SignType)
           condition: and(succeeded(), ne(variables['SignType'], ''))
         - script: eng\common\CIBuild.cmd
@@ -97,7 +98,7 @@ extends:
                     /p:DotnetPublishUsingPipelines=true
           displayName: Build
 
-        #- template: /eng/common/templates-official/steps/generate-sbom.yml@self
+        - template: /eng/common/templates-official/steps/generate-sbom.yml@self
 
         - task: PublishTestResults@2
           displayName: Publish xUnit Test Results

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -20,112 +20,102 @@ variables:
 trigger:
 - main
 
-stages:
-- stage: Build
-  jobs:
-  - job: Build
+extends:
+  template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
     pool:
-      vmImage: 'Ubuntu-16.04'
-    continueOnError: true
-    steps:
-    - script: echo "Hello world"
+      name: VSEngSS-MicroBuild2022-1ES
+      os: windows
+    stages:
+    - stage: build
+      displayName: Build and Test
+      jobs:
+      - job: OfficialBuild
+        displayName: Official Build
+        templateContext:
+          outputs:
+          # Note that insertion scripts currently depend on bin directory being uploaded to drops.
+          - output: pipelineArtifact
+            targetPath: $(Build.SourcesDirectory)\artifacts\bin
+            displayName: Publish binaries
+            publishLocation: Container
+            artifactName: bin
+            condition: succeededOrFailed()
+          - output: pipelineArtifact
+            targetPath: $(Build.SourcesDirectory)\artifacts\log\$(BuildConfiguration)
+            displayName: Publish logs
+            artifactName: 'Build Diagnostic Files'
+            publishLocation: Container
+            continueOnError: true
+            condition: succeededOrFailed()
+          - output: pipelineArtifact
+            displayName: Publish test results
+            targetPath: $(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)
+            artifactName: 'TestResults'
+            publishLocation: Container
+            condition: succeededOrFailed()
+          # Publish our NuPkgs as an artifact. The name of this artifact must be PackageArtifacts as the
+          # arcade templates depend on the name.
+          - output: pipelineArtifact
+            targetPath: $(Build.SourcesDirectory)\artifacts\packages\$(BuildConfiguration)
+            displayName: Publish packages
+            artifactName: 'PackageArtifacts'
+            condition: succeededOrFailed()
+          - output: pipelineArtifact
+            displayName: Publish Asset Manifests
+            targetPath: $(Build.SourcesDirectory)/artifacts/log/$(BuildConfiguration)/AssetManifest
+            artifactName: 'AssetManifests'
+            condition: succeeded()
+          - output: pipelineArtifact
+            displayName: Publish MicroBuild Artifacts
+            targetPath: $(Build.ArtifactStagingDirectory)\MicroBuild\Output
+            artifactName: MicroBuildOutputs
+            artifactType: Container
+            condition: succeededOrFailed()
+        steps:
+        - task: MicroBuildSigningPlugin@1
+          displayName: Install Signing Plugin
+          inputs:
+            signType: $(SignType)
+          condition: succeeded()
+        - script: eng\common\CIBuild.cmd
+                    -configuration $(BuildConfiguration)
+                    /p:PB_PublishBlobFeedKey=$(PB_PublishBlobFeedKey)
+                    /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+                    /p:DotNetSignType=$(SignType)
+                    /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
+                    /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
+                    /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
+                    /p:DotnetPublishUsingPipelines=true
+          displayName: Build
 
-# extends:
-#   template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
-#   parameters:
-#     pool:
-#       name: VSEngSS-MicroBuild2022-1ES
-#       os: windows
-#     stages:
-#     - stage: build
-#       displayName: Build and Test
-#       jobs:
-#       - job: OfficialBuild
-#         displayName: Official Build
-#         templateContext:
-#           outputs:
-#           # Note that insertion scripts currently depend on bin directory being uploaded to drops.
-#           - output: pipelineArtifact
-#             targetPath: $(Build.SourcesDirectory)\artifacts\bin
-#             displayName: Publish binaries
-#             publishLocation: Container
-#             artifactName: bin
-#             condition: succeededOrFailed()
-#           - output: pipelineArtifact
-#             targetPath: $(Build.SourcesDirectory)\artifacts\log\$(BuildConfiguration)
-#             displayName: Publish logs
-#             artifactName: 'Build Diagnostic Files'
-#             publishLocation: Container
-#             continueOnError: true
-#             condition: succeededOrFailed()
-#           - output: pipelineArtifact
-#             displayName: Publish test results
-#             targetPath: $(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)
-#             artifactName: 'TestResults'
-#             publishLocation: Container
-#             condition: succeededOrFailed()
-#           # Publish our NuPkgs as an artifact. The name of this artifact must be PackageArtifacts as the
-#           # arcade templates depend on the name.
-#           - output: pipelineArtifact
-#             targetPath: $(Build.SourcesDirectory)\artifacts\packages\$(BuildConfiguration)
-#             displayName: Publish packages
-#             artifactName: 'PackageArtifacts'
-#             condition: succeededOrFailed()
-#           - output: pipelineArtifact
-#             displayName: Publish Asset Manifests
-#             targetPath: $(Build.SourcesDirectory)/artifacts/log/$(BuildConfiguration)/AssetManifest
-#             artifactName: 'AssetManifests'
-#             condition: succeeded()
-#           - output: pipelineArtifact
-#             displayName: Publish MicroBuild Artifacts
-#             targetPath: $(Build.ArtifactStagingDirectory)\MicroBuild\Output
-#             artifactName: MicroBuildOutputs
-#             artifactType: Container
-#             condition: succeededOrFailed()
-#         steps:
-#         - task: MicroBuildSigningPlugin@1
-#           displayName: Install Signing Plugin
-#           inputs:
-#             signType: $(SignType)
-#           condition: succeeded()
-#         - script: eng\common\CIBuild.cmd
-#                     -configuration $(BuildConfiguration)
-#                     /p:PB_PublishBlobFeedKey=$(PB_PublishBlobFeedKey)
-#                     /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-#                     /p:DotNetSignType=$(SignType)
-#                     /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
-#                     /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
-#                     /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
-#                     /p:DotnetPublishUsingPipelines=true
-#           displayName: Build
+        - template: eng\common\templates\steps\generate-sbom.yml@self
 
-#         - template: eng\common\templates\steps\generate-sbom.yml@self
+        - task: PublishTestResults@2
+          displayName: Publish xUnit Test Results
+          inputs:
+            testRunner: XUnit
+            testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
+            mergeTestResults: true
+            testRunTitle: 'Unit Tests'
+          condition: succeededOrFailed()
+        - task: MicroBuildCleanup@1
+          displayName: Cleanup
+          condition: succeededOrFailed()
+      # Publish to Build Asset Registry
+      - template: /eng/common/templates-official/job/publish-build-assets.yml@self
+        parameters:
+          publishUsingPipelines: true
+          dependsOn:
+            - OfficialBuild
+          queue:
+            name: Hosted VS2017
 
-    #     - task: PublishTestResults@2
-    #       displayName: Publish xUnit Test Results
-    #       inputs:
-    #         testRunner: XUnit
-    #         testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
-    #         mergeTestResults: true
-    #         testRunTitle: 'Unit Tests'
-    #       condition: succeededOrFailed()
-    #     - task: MicroBuildCleanup@1
-    #       displayName: Cleanup
-    #       condition: succeededOrFailed()
-    #   # Publish to Build Asset Registry
-    #   - template: /eng/common/templates-official/job/publish-build-assets.yml@self
-    #     parameters:
-    #       publishUsingPipelines: true
-    #       dependsOn:
-    #         - OfficialBuild
-    #       queue:
-    #         name: Hosted VS2017
-
-    # - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    #   - template: eng\common\templates\post-build\post-build.yml@self
-    #     parameters:
-    #       # Symbol validation is not entirely reliable as of yet, so should be turned off until
-    #       # https://github.com/dotnet/arcade/issues/2871 is resolved.
-    #       enableSymbolValidation: false
-    #       enableSourceLinkValidation: false
-    #       publishingInfraVersion: 3
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - template: eng\common\templates\post-build\post-build.yml@self
+        parameters:
+          # Symbol validation is not entirely reliable as of yet, so should be turned off until
+          # https://github.com/dotnet/arcade/issues/2871 is resolved.
+          enableSymbolValidation: false
+          enableSourceLinkValidation: false
+          publishingInfraVersion: 3

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -89,7 +89,7 @@ extends:
                     /p:DotnetPublishUsingPipelines=true
           displayName: Build
 
-        - template: eng\common\templates\steps\generate-sbom.yml@self
+        # - template: eng\common\templates\steps\generate-sbom.yml@self
 
     #     - task: PublishTestResults@2
     #       displayName: Publish xUnit Test Results

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -18,7 +18,7 @@ variables:
   - name: BuildConfiguration
     value: Release
   - name: SignType
-    value: ''
+    value: Real
   - name: system.debug
     value: false
   - name: TeamName

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -19,7 +19,7 @@ variables:
   - name: BuildConfiguration
     value: Release
   - name: SignType
-    value: ''
+    value: Real
   - name: system.debug
     value: false
   - name: TeamName
@@ -45,9 +45,6 @@ extends:
     - stage: build
       displayName: Build and Test
       jobs:
-      - template: /eng/common/templates-official/job/job.yml@self
-        parameters:
-          enablePublishUsingPipelines: true
       - job: OfficialBuild
         displayName: Official Build
         templateContext:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -34,6 +34,9 @@ extends:
     stages:
     - stage: build
       displayName: Build and Test
+      pool:
+        name: netcore1espool-internal
+        os: 1es-windows-2022-pt
       jobs:
       - job: OfficialBuild
         displayName: Official Build

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -29,20 +29,14 @@ extends:
         image: 1es-windows-2022-pt
         os: windows
     pool:
-      name: netcore1espool-internal
+      name: NetCore1ESPool-Svc-Internal
       os: 1es-windows-2022-pt
     stages:
     - stage: build
       displayName: Build and Test
-      pool:
-        name: netcore1espool-internal
-        os: 1es-windows-2022-pt
       jobs:
       - job: OfficialBuild
         displayName: Official Build
-        pool:
-          name: netcore1espool-internal
-          os: 1es-windows-2022-pt
         templateContext:
           outputs:
           # Note that insertion scripts currently depend on bin directory being uploaded to drops.
@@ -101,36 +95,36 @@ extends:
                     /p:DotnetPublishUsingPipelines=true
           displayName: Build
 
-        - template: /eng/common/templates-official/steps/generate-sbom.yml@self
+    #     - template: /eng/common/templates-official/steps/generate-sbom.yml@self
 
-        - task: PublishTestResults@2
-          displayName: Publish xUnit Test Results
-          inputs:
-            testRunner: XUnit
-            testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
-            mergeTestResults: true
-            testRunTitle: 'Unit Tests'
-          condition: succeededOrFailed()
-        - task: MicroBuildCleanup@1
-          displayName: Cleanup
-          condition: succeededOrFailed()
-      # Publish to Build Asset Registry
-      - template: /eng/common/templates-official/job/publish-build-assets.yml@self
-        parameters:
-          publishUsingPipelines: true
-          pool:
-            name: netcore1espool-internal
-            os: 1es-windows-2022-pt
-          dependsOn:
-            - OfficialBuild
-          queue:
-            name: Hosted VS2017
+    #     - task: PublishTestResults@2
+    #       displayName: Publish xUnit Test Results
+    #       inputs:
+    #         testRunner: XUnit
+    #         testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
+    #         mergeTestResults: true
+    #         testRunTitle: 'Unit Tests'
+    #       condition: succeededOrFailed()
+    #     - task: MicroBuildCleanup@1
+    #       displayName: Cleanup
+    #       condition: succeededOrFailed()
+    #   # Publish to Build Asset Registry
+    #   - template: /eng/common/templates-official/job/publish-build-assets.yml@self
+    #     parameters:
+    #       publishUsingPipelines: true
+    #       pool:
+    #         name: netcore1espool-internal
+    #         os: 1es-windows-2022-pt
+    #       dependsOn:
+    #         - OfficialBuild
+    #       queue:
+    #         name: Hosted VS2017
 
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - template: eng\common\templates-official\post-build\post-build.yml@self
-        parameters:
-          # Symbol validation is not entirely reliable as of yet, so should be turned off until
-          # https://github.com/dotnet/arcade/issues/2871 is resolved.
-          enableSymbolValidation: false
-          enableSourceLinkValidation: false
-          publishingInfraVersion: 3
+    # - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    #   - template: eng\common\templates-official\post-build\post-build.yml@self
+    #     parameters:
+    #       # Symbol validation is not entirely reliable as of yet, so should be turned off until
+    #       # https://github.com/dotnet/arcade/issues/2871 is resolved.
+    #       enableSymbolValidation: false
+    #       enableSourceLinkValidation: false
+    #       publishingInfraVersion: 3

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -97,6 +97,9 @@ extends:
           env:
             TeamName: '$(TeamName)'
           condition: and(succeeded(), ne(variables['SignType'], ''))
+        - template: /eng/common/templates/job/job.yml@self
+          parameters:
+            enablePublishUsingPipelines: true
         - script: eng\common\CIBuild.cmd
                     -configuration $(BuildConfiguration)
                     /p:OfficialBuildId=$(BUILD.BUILDNUMBER)

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -30,7 +30,8 @@ extends:
         os: windows
     pool:
       name: NetCore1ESPool-Svc-Internal
-      os: 1es-windows-2022-pt
+      image: 1es-windows-2022-pt
+      os: windows
     stages:
     - stage: build
       displayName: Build and Test

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -91,19 +91,19 @@ extends:
 
         - template: eng\common\templates\steps\generate-sbom.yml@self
 
-        # - task: PublishTestResults@2
-        #   displayName: Publish xUnit Test Results
-        #   inputs:
-        #     testRunner: XUnit
-        #     testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
-        #     mergeTestResults: true
-        #     testRunTitle: 'Unit Tests'
-        #   condition: succeededOrFailed()
-        # - task: MicroBuildCleanup@1
-        #   displayName: Cleanup
-        #   condition: succeededOrFailed()
+        - task: PublishTestResults@2
+          displayName: Publish xUnit Test Results
+          inputs:
+            testRunner: XUnit
+            testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
+            mergeTestResults: true
+            testRunTitle: 'Unit Tests'
+          condition: succeededOrFailed()
+        - task: MicroBuildCleanup@1
+          displayName: Cleanup
+          condition: succeededOrFailed()
       # Publish to Build Asset Registry
-      - template: /eng/common/templates-Official/job/publish-build-assets.yml@self
+      - template: /eng/common/templates-official/job/publish-build-assets.yml@self
         parameters:
           publishUsingPipelines: true
           dependsOn:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -26,12 +26,6 @@ extends:
     pool:
       name: VSEngSS-MicroBuild2022-1ES
       os: windows
-    sdl:
-      sourceAnalysisPool:
-        name:  VSEngSS-MicroBuild2022-1ES
-        os: windows
-      sbom:
-        enabled: false
     stages:
     - stage: build
       displayName: Build and Test
@@ -95,7 +89,7 @@ extends:
                     /p:DotnetPublishUsingPipelines=true
           displayName: Build
 
-        - template: eng\common\templates\steps\generate-sbom.yml
+        - template: eng\common\templates\steps\generate-sbom.yml@self
 
         - task: PublishTestResults@2
           displayName: Publish xUnit Test Results

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -91,31 +91,31 @@ extends:
 
         - template: eng\common\templates\steps\generate-sbom.yml@self
 
-        - task: PublishTestResults@2
-          displayName: Publish xUnit Test Results
-          inputs:
-            testRunner: XUnit
-            testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
-            mergeTestResults: true
-            testRunTitle: 'Unit Tests'
-          condition: succeededOrFailed()
-        - task: MicroBuildCleanup@1
-          displayName: Cleanup
-          condition: succeededOrFailed()
-      # Publish to Build Asset Registry
-      # - template: /eng/common/templates-official/job/publish-build-assets.yml@self
-      #   parameters:
-      #     publishUsingPipelines: true
-      #     dependsOn:
-      #       - OfficialBuild
-      #     queue:
-      #       name: Hosted VS2017
+    #     - task: PublishTestResults@2
+    #       displayName: Publish xUnit Test Results
+    #       inputs:
+    #         testRunner: XUnit
+    #         testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
+    #         mergeTestResults: true
+    #         testRunTitle: 'Unit Tests'
+    #       condition: succeededOrFailed()
+    #     - task: MicroBuildCleanup@1
+    #       displayName: Cleanup
+    #       condition: succeededOrFailed()
+    #   # Publish to Build Asset Registry
+    #   - template: /eng/common/templates-official/job/publish-build-assets.yml@self
+    #     parameters:
+    #       publishUsingPipelines: true
+    #       dependsOn:
+    #         - OfficialBuild
+    #       queue:
+    #         name: Hosted VS2017
 
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - template: eng\common\templates\post-build\post-build.yml@self
-        parameters:
-          # Symbol validation is not entirely reliable as of yet, so should be turned off until
-          # https://github.com/dotnet/arcade/issues/2871 is resolved.
-          enableSymbolValidation: false
-          enableSourceLinkValidation: false
-          publishingInfraVersion: 3
+    # - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    #   - template: eng\common\templates\post-build\post-build.yml@self
+    #     parameters:
+    #       # Symbol validation is not entirely reliable as of yet, so should be turned off until
+    #       # https://github.com/dotnet/arcade/issues/2871 is resolved.
+    #       enableSymbolValidation: false
+    #       enableSourceLinkValidation: false
+    #       publishingInfraVersion: 3

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -20,6 +20,16 @@ variables:
 trigger:
 - main
 
+stages:
+- stage: Build
+  jobs:
+  - job: Build
+    pool:
+      vmImage: 'Ubuntu-16.04'
+    continueOnError: true
+    steps:
+    - script: echo "Hello world"
+
 # extends:
 #   template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
 #   parameters:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -18,7 +18,7 @@ variables:
   - name: BuildConfiguration
     value: Release
   - name: SignType
-    value: real
+    value: Real
   - name: system.debug
     value: false
   - name: TeamName
@@ -93,6 +93,8 @@ extends:
             zipSources: false
             signType: $(SignType)
             feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+          env:
+            TeamName: '$(TeamName)'
           condition: and(succeeded(), ne(variables['SignType'], ''))
         - script: eng\common\CIBuild.cmd
                     -configuration $(BuildConfiguration)

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -15,6 +15,7 @@ variables:
     value: .NETCoreValidation
   - name: Codeql.Enabled
     value: true​
+  - group: DotNet-Symbol-Server-Pats
   - name: BuildConfiguration
     value: Release
   - name: SignType

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -151,7 +151,7 @@ extends:
         #     ArtifactType: Container
         #   condition: succeededOrFailed()
       # Publish to Build Asset Registry
-      - template: /eng/common/templates/job/publish-build-assets.yml
+      - template: /eng/common/templates/job/publish-build-assets.yml@self
         parameters:
           publishUsingPipelines: true
           dependsOn:
@@ -160,7 +160,7 @@ extends:
             name: Hosted VS2017
 
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - template: eng\common\templates\post-build\post-build.yml
+      - template: eng\common\templates\post-build\post-build.yml@self
         parameters:
           # Symbol validation is not entirely reliable as of yet, so should be turned off until
           # https://github.com/dotnet/arcade/issues/2871 is resolved.

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -91,17 +91,17 @@ extends:
 
         - template: /eng/common/templates-official/steps/generate-sbom.yml@self
 
-    #     - task: PublishTestResults@2
-    #       displayName: Publish xUnit Test Results
-    #       inputs:
-    #         testRunner: XUnit
-    #         testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
-    #         mergeTestResults: true
-    #         testRunTitle: 'Unit Tests'
-    #       condition: succeededOrFailed()
-    #     - task: MicroBuildCleanup@1
-    #       displayName: Cleanup
-    #       condition: succeededOrFailed()
+        - task: PublishTestResults@2
+          displayName: Publish xUnit Test Results
+          inputs:
+            testRunner: XUnit
+            testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
+            mergeTestResults: true
+            testRunTitle: 'Unit Tests'
+          condition: succeededOrFailed()
+        - task: MicroBuildCleanup@1
+          displayName: Cleanup
+          condition: succeededOrFailed()
       # Publish to Build Asset Registry
       - template: /eng/common/templates-official/job/publish-build-assets.yml@self
         parameters:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -99,7 +99,6 @@ extends:
           condition: and(succeeded(), ne(variables['SignType'], ''))
         - script: eng\common\CIBuild.cmd
                     -configuration $(BuildConfiguration)
-                    /p:PB_PublishBlobFeedKey=$(PB_PublishBlobFeedKey)
                     /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
                     /p:DotNetSignType=$(SignType)
                     /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -56,6 +56,7 @@ extends:
             publishLocation: Container
             artifactName: bin
             condition: succeededOrFailed()
+
           - output: pipelineArtifact
             targetPath: $(Build.SourcesDirectory)\artifacts\log\$(BuildConfiguration)
             displayName: Publish logs
@@ -63,12 +64,14 @@ extends:
             publishLocation: Container
             continueOnError: true
             condition: succeededOrFailed()
+
           - output: pipelineArtifact
             displayName: Publish test results
             targetPath: $(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)
             artifactName: 'TestResults'
             publishLocation: Container
             condition: succeededOrFailed()
+
           # Publish our NuPkgs as an artifact. The name of this artifact must be PackageArtifacts as the
           # arcade templates depend on the name.
           - output: pipelineArtifact
@@ -76,11 +79,13 @@ extends:
             displayName: Publish packages
             artifactName: 'PackageArtifacts'
             condition: succeededOrFailed()
+
           - output: pipelineArtifact
             displayName: Publish Asset Manifests
             targetPath: $(Build.SourcesDirectory)\artifacts\log\$(BuildConfiguration)\AssetManifest
             artifactName: 'AssetManifests'
             condition: succeeded()
+
           - output: pipelineArtifact
             displayName: Publish MicroBuild Artifacts
             targetPath: $(Build.ArtifactStagingDirectory)\MicroBuild\Output

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -20,21 +20,15 @@ variables:
 trigger:
 - main
 
-
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     pool:
-      name: NetCore1ESPool-Svc-Internal
-      image: 1es-windows-2022-pt
+      name: VSEngSS-MicroBuild2022-1ES
       os: windows
     stages:
     - stage: build
       displayName: Build and Test
-      pool:
-        name: VSEngSS-MicroBuild2019-1ES
-        demands:
-        - cmd
       jobs:
       - job: OfficialBuild
         displayName: Official Build

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -103,7 +103,7 @@ extends:
         #   displayName: Cleanup
         #   condition: succeededOrFailed()
       # Publish to Build Asset Registry
-      - template: /eng/common/templates/job/publish-build-assets.yml@self
+      - template: /eng/common/templates-Official/job/publish-build-assets.yml@self
         parameters:
           publishUsingPipelines: true
           dependsOn:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -45,6 +45,9 @@ extends:
     - stage: build
       displayName: Build and Test
       jobs:
+      - template: /eng/common/templates-official/job/job.yml@self
+        parameters:
+        enablePublishUsingPipelines: true
       - job: OfficialBuild
         displayName: Official Build
         templateContext:
@@ -97,9 +100,7 @@ extends:
           env:
             TeamName: '$(TeamName)'
           condition: and(succeeded(), ne(variables['SignType'], ''))
-        - template: /eng/common/templates/job/job.yml@self
-          parameters:
-            enablePublishUsingPipelines: true
+
         - script: eng\common\CIBuild.cmd
                     -configuration $(BuildConfiguration)
                     /p:OfficialBuildId=$(BUILD.BUILDNUMBER)

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -91,25 +91,25 @@ extends:
 
         - template: eng\common\templates\steps\generate-sbom.yml@self
 
-        # - task: PublishTestResults@2
-        #   displayName: Publish xUnit Test Results
-        #   inputs:
-        #     testRunner: XUnit
-        #     testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
-        #     mergeTestResults: true
-        #     testRunTitle: 'Unit Tests'
-        #   condition: succeededOrFailed()
+        - task: PublishTestResults@2
+          displayName: Publish xUnit Test Results
+          inputs:
+            testRunner: XUnit
+            testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
+            mergeTestResults: true
+            testRunTitle: 'Unit Tests'
+          condition: succeededOrFailed()
         - task: MicroBuildCleanup@1
           displayName: Cleanup
           condition: succeededOrFailed()
       # Publish to Build Asset Registry
-      - template: /eng/common/templates-official/job/publish-build-assets.yml@self
-        parameters:
-          publishUsingPipelines: true
-          dependsOn:
-            - OfficialBuild
-          queue:
-            name: Hosted VS2017
+      # - template: /eng/common/templates-official/job/publish-build-assets.yml@self
+      #   parameters:
+      #     publishUsingPipelines: true
+      #     dependsOn:
+      #       - OfficialBuild
+      #     queue:
+      #       name: Hosted VS2017
 
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - template: eng\common\templates\post-build\post-build.yml@self

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -76,7 +76,7 @@ extends:
         - task: MicroBuildSigningPlugin@1
           displayName: Install Signing Plugin
           inputs:
-            signType: real
+            signType: $(SignType)
           condition: succeeded()
         - script: eng\common\CIBuild.cmd
                     -configuration $(BuildConfiguration)

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -91,14 +91,14 @@ extends:
 
         - template: eng\common\templates\steps\generate-sbom.yml@self
 
-        - task: PublishTestResults@2
-          displayName: Publish xUnit Test Results
-          inputs:
-            testRunner: XUnit
-            testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
-            mergeTestResults: true
-            testRunTitle: 'Unit Tests'
-          condition: succeededOrFailed()
+        # - task: PublishTestResults@2
+        #   displayName: Publish xUnit Test Results
+        #   inputs:
+        #     testRunner: XUnit
+        #     testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
+        #     mergeTestResults: true
+        #     testRunTitle: 'Unit Tests'
+        #   condition: succeededOrFailed()
         - task: MicroBuildCleanup@1
           displayName: Cleanup
           condition: succeededOrFailed()

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -24,7 +24,7 @@ extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: NetCore1ESPool-Svc-Internal
       os: windows
     stages:
     - stage: build

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -91,31 +91,31 @@ extends:
 
         - template: /eng/common/templates-official/steps/generate-sbom.yml@self
 
-        - task: PublishTestResults@2
-          displayName: Publish xUnit Test Results
-          inputs:
-            testRunner: XUnit
-            testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
-            mergeTestResults: true
-            testRunTitle: 'Unit Tests'
-          condition: succeededOrFailed()
-        - task: MicroBuildCleanup@1
-          displayName: Cleanup
-          condition: succeededOrFailed()
-      # Publish to Build Asset Registry
-      - template: /eng/common/templates-official/job/publish-build-assets.yml@self
-        parameters:
-          publishUsingPipelines: true
-          dependsOn:
-            - OfficialBuild
-          queue:
-            name: Hosted VS2017
+    #     - task: PublishTestResults@2
+    #       displayName: Publish xUnit Test Results
+    #       inputs:
+    #         testRunner: XUnit
+    #         testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
+    #         mergeTestResults: true
+    #         testRunTitle: 'Unit Tests'
+    #       condition: succeededOrFailed()
+    #     - task: MicroBuildCleanup@1
+    #       displayName: Cleanup
+    #       condition: succeededOrFailed()
+    #   # Publish to Build Asset Registry
+    #   - template: /eng/common/templates-official/job/publish-build-assets.yml@self
+    #     parameters:
+    #       publishUsingPipelines: true
+    #       dependsOn:
+    #         - OfficialBuild
+    #       queue:
+    #         name: Hosted VS2017
 
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - template: eng\common\templates\post-build\post-build.yml@self
-        parameters:
-          # Symbol validation is not entirely reliable as of yet, so should be turned off until
-          # https://github.com/dotnet/arcade/issues/2871 is resolved.
-          enableSymbolValidation: false
-          enableSourceLinkValidation: false
-          publishingInfraVersion: 3
+    # - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    #   - template: eng\common\templates\post-build\post-build.yml@self
+    #     parameters:
+    #       # Symbol validation is not entirely reliable as of yet, so should be turned off until
+    #       # https://github.com/dotnet/arcade/issues/2871 is resolved.
+    #       enableSymbolValidation: false
+    #       enableSourceLinkValidation: false
+    #       publishingInfraVersion: 3

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -20,76 +20,76 @@ variables:
 trigger:
 - main
 
-extends:
-  template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
-  parameters:
-    pool:
-      name: VSEngSS-MicroBuild2022-1ES
-      os: windows
-    stages:
-    - stage: build
-      displayName: Build and Test
-      jobs:
-      - job: OfficialBuild
-        displayName: Official Build
-        templateContext:
-          outputs:
-          # Note that insertion scripts currently depend on bin directory being uploaded to drops.
-          - output: pipelineArtifact
-            targetPath: $(Build.SourcesDirectory)\artifacts\bin
-            displayName: Publish binaries
-            publishLocation: Container
-            artifactName: bin
-            condition: succeededOrFailed()
-          - output: pipelineArtifact
-            targetPath: $(Build.SourcesDirectory)\artifacts\log\$(BuildConfiguration)
-            displayName: Publish logs
-            artifactName: 'Build Diagnostic Files'
-            publishLocation: Container
-            continueOnError: true
-            condition: succeededOrFailed()
-          - output: pipelineArtifact
-            displayName: Publish test results
-            targetPath: $(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)
-            artifactName: 'TestResults'
-            publishLocation: Container
-            condition: succeededOrFailed()
-          # Publish our NuPkgs as an artifact. The name of this artifact must be PackageArtifacts as the
-          # arcade templates depend on the name.
-          - output: pipelineArtifact
-            targetPath: $(Build.SourcesDirectory)\artifacts\packages\$(BuildConfiguration)
-            displayName: Publish packages
-            artifactName: 'PackageArtifacts'
-            condition: succeededOrFailed()
-          - output: pipelineArtifact
-            displayName: Publish Asset Manifests
-            targetPath: $(Build.SourcesDirectory)/artifacts/log/$(BuildConfiguration)/AssetManifest
-            artifactName: 'AssetManifests'
-            condition: succeeded()
-          - output: pipelineArtifact
-            displayName: Publish MicroBuild Artifacts
-            targetPath: $(Build.ArtifactStagingDirectory)\MicroBuild\Output
-            artifactName: MicroBuildOutputs
-            artifactType: Container
-            condition: succeededOrFailed()
-        steps:
-        - task: MicroBuildSigningPlugin@1
-          displayName: Install Signing Plugin
-          inputs:
-            signType: $(SignType)
-          condition: succeeded()
-        - script: eng\common\CIBuild.cmd
-                    -configuration $(BuildConfiguration)
-                    /p:PB_PublishBlobFeedKey=$(PB_PublishBlobFeedKey)
-                    /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-                    /p:DotNetSignType=$(SignType)
-                    /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
-                    /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
-                    /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
-                    /p:DotnetPublishUsingPipelines=true
-          displayName: Build
+# extends:
+#   template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
+#   parameters:
+#     pool:
+#       name: VSEngSS-MicroBuild2022-1ES
+#       os: windows
+#     stages:
+#     - stage: build
+#       displayName: Build and Test
+#       jobs:
+#       - job: OfficialBuild
+#         displayName: Official Build
+#         templateContext:
+#           outputs:
+#           # Note that insertion scripts currently depend on bin directory being uploaded to drops.
+#           - output: pipelineArtifact
+#             targetPath: $(Build.SourcesDirectory)\artifacts\bin
+#             displayName: Publish binaries
+#             publishLocation: Container
+#             artifactName: bin
+#             condition: succeededOrFailed()
+#           - output: pipelineArtifact
+#             targetPath: $(Build.SourcesDirectory)\artifacts\log\$(BuildConfiguration)
+#             displayName: Publish logs
+#             artifactName: 'Build Diagnostic Files'
+#             publishLocation: Container
+#             continueOnError: true
+#             condition: succeededOrFailed()
+#           - output: pipelineArtifact
+#             displayName: Publish test results
+#             targetPath: $(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)
+#             artifactName: 'TestResults'
+#             publishLocation: Container
+#             condition: succeededOrFailed()
+#           # Publish our NuPkgs as an artifact. The name of this artifact must be PackageArtifacts as the
+#           # arcade templates depend on the name.
+#           - output: pipelineArtifact
+#             targetPath: $(Build.SourcesDirectory)\artifacts\packages\$(BuildConfiguration)
+#             displayName: Publish packages
+#             artifactName: 'PackageArtifacts'
+#             condition: succeededOrFailed()
+#           - output: pipelineArtifact
+#             displayName: Publish Asset Manifests
+#             targetPath: $(Build.SourcesDirectory)/artifacts/log/$(BuildConfiguration)/AssetManifest
+#             artifactName: 'AssetManifests'
+#             condition: succeeded()
+#           - output: pipelineArtifact
+#             displayName: Publish MicroBuild Artifacts
+#             targetPath: $(Build.ArtifactStagingDirectory)\MicroBuild\Output
+#             artifactName: MicroBuildOutputs
+#             artifactType: Container
+#             condition: succeededOrFailed()
+#         steps:
+#         - task: MicroBuildSigningPlugin@1
+#           displayName: Install Signing Plugin
+#           inputs:
+#             signType: $(SignType)
+#           condition: succeeded()
+#         - script: eng\common\CIBuild.cmd
+#                     -configuration $(BuildConfiguration)
+#                     /p:PB_PublishBlobFeedKey=$(PB_PublishBlobFeedKey)
+#                     /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+#                     /p:DotNetSignType=$(SignType)
+#                     /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
+#                     /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
+#                     /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
+#                     /p:DotnetPublishUsingPipelines=true
+#           displayName: Build
 
-        - template: eng\common\templates\steps\generate-sbom.yml@self
+#         - template: eng\common\templates\steps\generate-sbom.yml@self
 
     #     - task: PublishTestResults@2
     #       displayName: Publish xUnit Test Results

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -98,36 +98,36 @@ extends:
                     /p:DotnetPublishUsingPipelines=true
           displayName: Build
 
-        - template: /eng/common/templates-official/steps/generate-sbom.yml@self
+    #     - template: /eng/common/templates-official/steps/generate-sbom.yml@self
 
-        - task: PublishTestResults@2
-          displayName: Publish xUnit Test Results
-          inputs:
-            testRunner: XUnit
-            testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
-            mergeTestResults: true
-            testRunTitle: 'Unit Tests'
-          condition: succeededOrFailed()
-        - task: MicroBuildCleanup@1
-          displayName: Cleanup
-          condition: succeededOrFailed()
-      # Publish to Build Asset Registry
-      - template: /eng/common/templates-official/job/publish-build-assets.yml@self
-        parameters:
-          publishUsingPipelines: true
-          pool:
-            name: netcore1espool-internal
-            os: 1es-windows-2022-pt
-          dependsOn:
-            - OfficialBuild
-          queue:
-            name: Hosted VS2017
+    #     - task: PublishTestResults@2
+    #       displayName: Publish xUnit Test Results
+    #       inputs:
+    #         testRunner: XUnit
+    #         testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
+    #         mergeTestResults: true
+    #         testRunTitle: 'Unit Tests'
+    #       condition: succeededOrFailed()
+    #     - task: MicroBuildCleanup@1
+    #       displayName: Cleanup
+    #       condition: succeededOrFailed()
+    #   # Publish to Build Asset Registry
+    #   - template: /eng/common/templates-official/job/publish-build-assets.yml@self
+    #     parameters:
+    #       publishUsingPipelines: true
+    #       pool:
+    #         name: netcore1espool-internal
+    #         os: 1es-windows-2022-pt
+    #       dependsOn:
+    #         - OfficialBuild
+    #       queue:
+    #         name: Hosted VS2017
 
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - template: eng\common\templates-official\post-build\post-build.yml@self
-        parameters:
-          # Symbol validation is not entirely reliable as of yet, so should be turned off until
-          # https://github.com/dotnet/arcade/issues/2871 is resolved.
-          enableSymbolValidation: false
-          enableSourceLinkValidation: false
-          publishingInfraVersion: 3
+    # - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    #   - template: eng\common\templates-official\post-build\post-build.yml@self
+    #     parameters:
+    #       # Symbol validation is not entirely reliable as of yet, so should be turned off until
+    #       # https://github.com/dotnet/arcade/issues/2871 is resolved.
+    #       enableSymbolValidation: false
+    #       enableSourceLinkValidation: false
+    #       publishingInfraVersion: 3

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -19,7 +19,7 @@ variables:
   - name: BuildConfiguration
     value: Release
   - name: SignType
-    value: Real
+    value: ''
   - name: system.debug
     value: false
   - name: TeamName

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -18,7 +18,7 @@ variables:
   - name: BuildConfiguration
     value: Release
   - name: SignType
-    value: Real
+    value: ''
   - name: system.debug
     value: false
   - name: TeamName

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -97,7 +97,7 @@ extends:
                     /p:DotnetPublishUsingPipelines=true
           displayName: Build
 
-        - template: /eng/common/templates-official/steps/generate-sbom.yml@self
+        #- template: /eng/common/templates-official/steps/generate-sbom.yml@self
 
         - task: PublishTestResults@2
           displayName: Publish xUnit Test Results

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,6 +1,11 @@
 resources:
-- repo: self
-  clean: true
+  repositories:
+  - repository: self
+    clean: true
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
 
 # The variables `_DotNetArtifactsCategory` and `_DotNetValidationArtifactsCategory` are required for proper publishing of build artifacts. See https://github.com/dotnet/roslyn/pull/38259
 variables:
@@ -15,115 +20,156 @@ variables:
 trigger:
 - main
 
-stages:
-- stage: build
-  displayName: Build and Test
-  pool:
-    name: VSEngSS-MicroBuild2019-1ES
-    demands:
-    - cmd
 
-  jobs:
-  - job: OfficialBuild
-    displayName: Official Build
+extends:
+  template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: NetCore1ESPool-Svc-Internal
+      image: 1es-windows-2022-pt
+      os: windows
+    stages:
+    - stage: build
+      displayName: Build and Test
+      pool:
+        name: VSEngSS-MicroBuild2019-1ES
+        demands:
+        - cmd
+      jobs:
+      - job: OfficialBuild
+        displayName: Official Build
+        templateContext:
+          outputs:
+          # Note that insertion scripts currently depend on bin directory being uploaded to drops.
+          - output: pipelineArtifact
+            targetPath: $(Build.SourcesDirectory)\artifacts\bin
+            displayName: Publish binaries
+            publishLocation: Container
+            artifactName: bin
+            condition: succeededOrFailed()
+          - output: pipelineArtifact
+            targetPath: $(Build.SourcesDirectory)\artifacts\log\$(BuildConfiguration)
+            displayName: Publish logs
+            artifactName: 'Build Diagnostic Files'
+            publishLocation: Container
+            continueOnError: true
+            condition: succeededOrFailed()
+          - output: pipelineArtifact
+            displayName: Publish test results
+            targetPath: $(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)
+            artifactName: 'TestResults'
+            publishLocation: Container
+            condition: succeededOrFailed()
+          # Publish our NuPkgs as an artifact. The name of this artifact must be PackageArtifacts as the
+          # arcade templates depend on the name.
+          - output: pipelineArtifact
+            targetPath: $(Build.SourcesDirectory)\artifacts\packages\$(BuildConfiguration)
+            displayName: Publish packages
+            artifactName: 'PackageArtifacts'
+            condition: succeededOrFailed()
+          - output: pipelineArtifact
+            displayName: Publish Asset Manifests
+            targetPath: $(Build.SourcesDirectory)/artifacts/log/$(BuildConfiguration)/AssetManifest
+            artifactName: 'AssetManifests'
+            condition: succeeded()
+          - output: pipelineArtifact
+            displayName: Publish MicroBuild Artifacts
+            targetPath: $(Build.ArtifactStagingDirectory)\MicroBuild\Output
+            artifactName: MicroBuildOutputs
+            artifactType: Container
+            condition: succeededOrFailed()
+        steps:
+        - task: MicroBuildSigningPlugin@1
+          displayName: Install Signing Plugin
+          inputs:
+            signType: real
+          condition: succeeded()
+        - script: eng\common\CIBuild.cmd
+                    -configuration $(BuildConfiguration)
+                    /p:PB_PublishBlobFeedKey=$(PB_PublishBlobFeedKey)
+                    /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+                    /p:DotNetSignType=$(SignType)
+                    /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
+                    /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
+                    /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
+                    /p:DotnetPublishUsingPipelines=true
+          displayName: Build
 
-    steps:
-    - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
-      displayName: Install Signing Plugin
-      inputs:
-        signType: $(SignType)
-        esrpSigning: true
-      condition: and(succeeded(), ne(variables['SignType'], ''))
+        - template: eng\common\templates\steps\generate-sbom.yml
 
-    - script: eng\common\CIBuild.cmd
-                -configuration $(BuildConfiguration)
-                /p:PB_PublishBlobFeedKey=$(PB_PublishBlobFeedKey)
-                /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-                /p:DotNetSignType=$(SignType)
-                /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
-                /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
-                /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
-                /p:DotnetPublishUsingPipelines=true
-      displayName: Build
+        - task: PublishTestResults@2
+          displayName: Publish xUnit Test Results
+          inputs:
+            testRunner: XUnit
+            testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
+            mergeTestResults: true
+            testRunTitle: 'Unit Tests'
+          condition: succeededOrFailed()
 
-    - template: eng\common\templates\steps\generate-sbom.yml
+        # - task: PublishBuildArtifacts@1
+        #   displayName: Publish binaries
+        #   inputs:
+        #     PathtoPublish: '$(Build.SourcesDirectory)\artifacts\bin'
+        #     ArtifactName: 'bin'
+        #     publishLocation: Container
+        #   condition: succeededOrFailed()
 
-    - task: PublishTestResults@2
-      displayName: Publish xUnit Test Results
-      inputs:
-        testRunner: XUnit
-        testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
-        mergeTestResults: true
-        testRunTitle: 'Unit Tests'
-      condition: succeededOrFailed()
+        # - task: PublishBuildArtifacts@1
+        #   displayName: Publish logs
+        #   inputs:
+        #     PathtoPublish: '$(Build.SourcesDirectory)\artifacts\log\$(BuildConfiguration)'
+        #     ArtifactName: 'Build Diagnostic Files'
+        #     publishLocation: Container
+        #   continueOnError: true
+        #   condition: succeededOrFailed()
 
-    # Note that insertion scripts currently depend on bin directory being uploaded to drops.
-    - task: PublishBuildArtifacts@1
-      displayName: Publish binaries
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\bin'
-        ArtifactName: 'bin'
-        publishLocation: Container
-      condition: succeededOrFailed()
+        # - task: PublishBuildArtifacts@1
+        #   displayName: Publish test results
+        #   inputs:
+        #     PathtoPublish: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)'
+        #     ArtifactName: 'TestResults'
+        #     publishLocation: Container
+        #   condition: succeededOrFailed()
+        # - task: PublishBuildArtifacts@1
+        #   displayName: Publish packages
+        #   inputs:
+        #     PathtoPublish: '$(Build.SourcesDirectory)\artifacts\packages\$(BuildConfiguration)'
+        #     ArtifactName: 'PackageArtifacts'
+        #   condition: succeededOrFailed()
 
-    - task: PublishBuildArtifacts@1
-      displayName: Publish logs
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\log\$(BuildConfiguration)'
-        ArtifactName: 'Build Diagnostic Files'
-        publishLocation: Container
-      continueOnError: true
-      condition: succeededOrFailed()
+        # Publish Asset Manifests for Build Asset Registry job
+        # - task: PublishBuildArtifacts@1
+        #   displayName: Publish Asset Manifests
+        #   inputs:
+        #     PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(BuildConfiguration)/AssetManifest'
+        #     ArtifactName: AssetManifests
+        #   condition: succeeded()
+        # - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
+        - task: MicroBuildCleanup@1
+          displayName: Cleanup
+          condition: succeededOrFailed()
 
-    - task: PublishBuildArtifacts@1
-      displayName: Publish test results
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)'
-        ArtifactName: 'TestResults'
-        publishLocation: Container
-      condition: succeededOrFailed()
-    # Publish our NuPkgs as an artifact. The name of this artifact must be PackageArtifacts as the
-    # arcade templates depend on the name.
-    - task: PublishBuildArtifacts@1
-      displayName: Publish packages
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\packages\$(BuildConfiguration)'
-        ArtifactName: 'PackageArtifacts'
-      condition: succeededOrFailed()
+        # - task: PublishBuildArtifacts@1
+        #   displayName: Publish MicroBuild Artifacts
+        #   inputs:
+        #     PathtoPublish: '$(Build.ArtifactStagingDirectory)\MicroBuild\Output'
+        #     ArtifactName: MicroBuildOutputs
+        #     ArtifactType: Container
+        #   condition: succeededOrFailed()
+      # Publish to Build Asset Registry
+      - template: /eng/common/templates/job/publish-build-assets.yml
+        parameters:
+          publishUsingPipelines: true
+          dependsOn:
+            - OfficialBuild
+          queue:
+            name: Hosted VS2017
 
-    # Publish Asset Manifests for Build Asset Registry job
-    - task: PublishBuildArtifacts@1
-      displayName: Publish Asset Manifests
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(BuildConfiguration)/AssetManifest'
-        ArtifactName: AssetManifests
-      condition: succeeded()
-
-    - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
-      displayName: Cleanup
-      condition: succeededOrFailed()
-
-    - task: PublishBuildArtifacts@1
-      displayName: Publish MicroBuild Artifacts
-      inputs:
-        PathtoPublish: '$(Build.ArtifactStagingDirectory)\MicroBuild\Output'
-        ArtifactName: MicroBuildOutputs
-        ArtifactType: Container
-      condition: succeededOrFailed()
-  # Publish to Build Asset Registry
-  - template: /eng/common/templates/job/publish-build-assets.yml
-    parameters:
-      publishUsingPipelines: true
-      dependsOn:
-        - OfficialBuild
-      queue:
-        name: Hosted VS2017
-
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: eng\common\templates\post-build\post-build.yml
-    parameters:
-      # Symbol validation is not entirely reliable as of yet, so should be turned off until
-      # https://github.com/dotnet/arcade/issues/2871 is resolved.
-      enableSymbolValidation: false
-      enableSourceLinkValidation: false
-      publishingInfraVersion: 3
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - template: eng\common\templates\post-build\post-build.yml
+        parameters:
+          # Symbol validation is not entirely reliable as of yet, so should be turned off until
+          # https://github.com/dotnet/arcade/issues/2871 is resolved.
+          enableSymbolValidation: false
+          enableSourceLinkValidation: false
+          publishingInfraVersion: 3

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -23,6 +23,11 @@ trigger:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    sdl:
+      sourceAnalysisPool:
+        name: NetCore1ESPool-Svc-Internal
+        image: 1es-windows-2022-pt
+        os: windows
     pool:
       name: netcore1espool-internal
       os: 1es-windows-2022-pt

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -15,6 +15,14 @@ variables:
     value: .NETCoreValidation
   - name: Codeql.Enabled
     value: true​
+  - name: BuildConfiguration
+    value: Release
+  - name: SignType
+    value: real
+  - name: system.debug
+    value: false
+  - name: TeamName
+    value: Roslyn
 
 # Branches that trigger a build on commit
 trigger:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -18,7 +18,7 @@ variables:
   - name: BuildConfiguration
     value: Release
   - name: SignType
-    value: ''
+    value: Real
   - name: system.debug
     value: false
   - name: TeamName
@@ -107,36 +107,36 @@ extends:
                     /p:DotnetPublishUsingPipelines=true
           displayName: Build
 
-        - template: /eng/common/templates-official/steps/generate-sbom.yml@self
+    #     - template: /eng/common/templates-official/steps/generate-sbom.yml@self
 
-        - task: PublishTestResults@2
-          displayName: Publish xUnit Test Results
-          inputs:
-            testRunner: XUnit
-            testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
-            mergeTestResults: true
-            testRunTitle: 'Unit Tests'
-          condition: succeededOrFailed()
-        - task: MicroBuildCleanup@1
-          displayName: Cleanup
-          condition: succeededOrFailed()
-      # Publish to Build Asset Registry
-      - template: /eng/common/templates-official/job/publish-build-assets.yml@self
-        parameters:
-          publishUsingPipelines: true
-          pool:
-            name: netcore1espool-internal
-            os: 1es-windows-2022-pt
-          dependsOn:
-            - OfficialBuild
-          queue:
-            name: Hosted VS2017
+    #     - task: PublishTestResults@2
+    #       displayName: Publish xUnit Test Results
+    #       inputs:
+    #         testRunner: XUnit
+    #         testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
+    #         mergeTestResults: true
+    #         testRunTitle: 'Unit Tests'
+    #       condition: succeededOrFailed()
+    #     - task: MicroBuildCleanup@1
+    #       displayName: Cleanup
+    #       condition: succeededOrFailed()
+    #   # Publish to Build Asset Registry
+    #   - template: /eng/common/templates-official/job/publish-build-assets.yml@self
+    #     parameters:
+    #       publishUsingPipelines: true
+    #       pool:
+    #         name: netcore1espool-internal
+    #         os: 1es-windows-2022-pt
+    #       dependsOn:
+    #         - OfficialBuild
+    #       queue:
+    #         name: Hosted VS2017
 
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - template: eng\common\templates-official\post-build\post-build.yml@self
-        parameters:
-          # Symbol validation is not entirely reliable as of yet, so should be turned off until
-          # https://github.com/dotnet/arcade/issues/2871 is resolved.
-          enableSymbolValidation: false
-          enableSourceLinkValidation: false
-          publishingInfraVersion: 3
+    # - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    #   - template: eng\common\templates-official\post-build\post-build.yml@self
+    #     parameters:
+    #       # Symbol validation is not entirely reliable as of yet, so should be turned off until
+    #       # https://github.com/dotnet/arcade/issues/2871 is resolved.
+    #       enableSymbolValidation: false
+    #       enableSourceLinkValidation: false
+    #       publishingInfraVersion: 3

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -26,6 +26,12 @@ extends:
     pool:
       name: VSEngSS-MicroBuild2022-1ES
       os: windows
+    sdl:
+      sourceAnalysisPool:
+        name:  VSEngSS-MicroBuild2022-1ES
+        os: windows
+      sbom:
+        enabled: false
     stages:
     - stage: build
       displayName: Build and Test

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -91,31 +91,31 @@ extends:
 
         - template: eng\common\templates\steps\generate-sbom.yml@self
 
-        - task: PublishTestResults@2
-          displayName: Publish xUnit Test Results
-          inputs:
-            testRunner: XUnit
-            testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
-            mergeTestResults: true
-            testRunTitle: 'Unit Tests'
-          condition: succeededOrFailed()
-        - task: MicroBuildCleanup@1
-          displayName: Cleanup
-          condition: succeededOrFailed()
-      # Publish to Build Asset Registry
-      - template: /eng/common/templates-official/job/publish-build-assets.yml@self
-        parameters:
-          publishUsingPipelines: true
-          dependsOn:
-            - OfficialBuild
-          queue:
-            name: Hosted VS2017
+    #     - task: PublishTestResults@2
+    #       displayName: Publish xUnit Test Results
+    #       inputs:
+    #         testRunner: XUnit
+    #         testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
+    #         mergeTestResults: true
+    #         testRunTitle: 'Unit Tests'
+    #       condition: succeededOrFailed()
+    #     - task: MicroBuildCleanup@1
+    #       displayName: Cleanup
+    #       condition: succeededOrFailed()
+    #   # Publish to Build Asset Registry
+    #   - template: /eng/common/templates-official/job/publish-build-assets.yml@self
+    #     parameters:
+    #       publishUsingPipelines: true
+    #       dependsOn:
+    #         - OfficialBuild
+    #       queue:
+    #         name: Hosted VS2017
 
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - template: eng\common\templates\post-build\post-build.yml@self
-        parameters:
-          # Symbol validation is not entirely reliable as of yet, so should be turned off until
-          # https://github.com/dotnet/arcade/issues/2871 is resolved.
-          enableSymbolValidation: false
-          enableSourceLinkValidation: false
-          publishingInfraVersion: 3
+    # - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    #   - template: eng\common\templates\post-build\post-build.yml@self
+    #     parameters:
+    #       # Symbol validation is not entirely reliable as of yet, so should be turned off until
+    #       # https://github.com/dotnet/arcade/issues/2871 is resolved.
+    #       enableSymbolValidation: false
+    #       enableSourceLinkValidation: false
+    #       publishingInfraVersion: 3

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -99,57 +99,9 @@ extends:
             mergeTestResults: true
             testRunTitle: 'Unit Tests'
           condition: succeededOrFailed()
-
-        # - task: PublishBuildArtifacts@1
-        #   displayName: Publish binaries
-        #   inputs:
-        #     PathtoPublish: '$(Build.SourcesDirectory)\artifacts\bin'
-        #     ArtifactName: 'bin'
-        #     publishLocation: Container
-        #   condition: succeededOrFailed()
-
-        # - task: PublishBuildArtifacts@1
-        #   displayName: Publish logs
-        #   inputs:
-        #     PathtoPublish: '$(Build.SourcesDirectory)\artifacts\log\$(BuildConfiguration)'
-        #     ArtifactName: 'Build Diagnostic Files'
-        #     publishLocation: Container
-        #   continueOnError: true
-        #   condition: succeededOrFailed()
-
-        # - task: PublishBuildArtifacts@1
-        #   displayName: Publish test results
-        #   inputs:
-        #     PathtoPublish: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)'
-        #     ArtifactName: 'TestResults'
-        #     publishLocation: Container
-        #   condition: succeededOrFailed()
-        # - task: PublishBuildArtifacts@1
-        #   displayName: Publish packages
-        #   inputs:
-        #     PathtoPublish: '$(Build.SourcesDirectory)\artifacts\packages\$(BuildConfiguration)'
-        #     ArtifactName: 'PackageArtifacts'
-        #   condition: succeededOrFailed()
-
-        # Publish Asset Manifests for Build Asset Registry job
-        # - task: PublishBuildArtifacts@1
-        #   displayName: Publish Asset Manifests
-        #   inputs:
-        #     PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(BuildConfiguration)/AssetManifest'
-        #     ArtifactName: AssetManifests
-        #   condition: succeeded()
-        # - task: ms-vseng.MicroBuildTasks.521a94ea-9e68-468a-8167-6dcf361ea776.MicroBuildCleanup@1
         - task: MicroBuildCleanup@1
           displayName: Cleanup
           condition: succeededOrFailed()
-
-        # - task: PublishBuildArtifacts@1
-        #   displayName: Publish MicroBuild Artifacts
-        #   inputs:
-        #     PathtoPublish: '$(Build.ArtifactStagingDirectory)\MicroBuild\Output'
-        #     ArtifactName: MicroBuildOutputs
-        #     ArtifactType: Container
-        #   condition: succeededOrFailed()
       # Publish to Build Asset Registry
       - template: /eng/common/templates/job/publish-build-assets.yml@self
         parameters:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -47,7 +47,7 @@ extends:
       jobs:
       - template: /eng/common/templates-official/job/job.yml@self
         parameters:
-        enablePublishUsingPipelines: true
+          enablePublishUsingPipelines: true
       - job: OfficialBuild
         displayName: Official Build
         templateContext:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -91,17 +91,17 @@ extends:
 
         - template: eng\common\templates\steps\generate-sbom.yml@self
 
-        - task: PublishTestResults@2
-          displayName: Publish xUnit Test Results
-          inputs:
-            testRunner: XUnit
-            testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
-            mergeTestResults: true
-            testRunTitle: 'Unit Tests'
-          condition: succeededOrFailed()
-        - task: MicroBuildCleanup@1
-          displayName: Cleanup
-          condition: succeededOrFailed()
+        # - task: PublishTestResults@2
+        #   displayName: Publish xUnit Test Results
+        #   inputs:
+        #     testRunner: XUnit
+        #     testResultsFiles: '$(Build.SourcesDirectory)\artifacts\TestResults\$(BuildConfiguration)\*.xml'
+        #     mergeTestResults: true
+        #     testRunTitle: 'Unit Tests'
+        #   condition: succeededOrFailed()
+        # - task: MicroBuildCleanup@1
+        #   displayName: Cleanup
+        #   condition: succeededOrFailed()
       # Publish to Build Asset Registry
       - template: /eng/common/templates/job/publish-build-assets.yml@self
         parameters:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -77,7 +77,7 @@ extends:
           - output: pipelineArtifact
             targetPath: $(Build.SourcesDirectory)\artifacts\packages\$(BuildConfiguration)
             displayName: Publish packages
-            artifactName: 'PackageArtifacts'
+            artifactName: 'BuildPackageArtifacts'
             condition: succeededOrFailed()
 
           - output: pipelineArtifact

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -100,9 +100,6 @@ extends:
                     -configuration $(BuildConfiguration)
                     /p:PB_PublishBlobFeedKey=$(PB_PublishBlobFeedKey)
                     /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-                    /p:DotNetSignType=$(SignType)
-                    /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
-                    /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
                     /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
                     /p:DotnetPublishUsingPipelines=true
           displayName: Build
@@ -125,8 +122,9 @@ extends:
         parameters:
           publishUsingPipelines: true
           pool:
-            name: netcore1espool-internal
-            os: 1es-windows-2022-pt
+            name: NetCore1ESPool-Svc-Internal
+            image: 1es-windows-2022-pt
+            os: windows
           dependsOn:
             - OfficialBuild
           queue:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -102,20 +102,20 @@ extends:
     #     - task: MicroBuildCleanup@1
     #       displayName: Cleanup
     #       condition: succeededOrFailed()
-    #   # Publish to Build Asset Registry
-    #   - template: /eng/common/templates-official/job/publish-build-assets.yml@self
-    #     parameters:
-    #       publishUsingPipelines: true
-    #       dependsOn:
-    #         - OfficialBuild
-    #       queue:
-    #         name: Hosted VS2017
+      # Publish to Build Asset Registry
+      - template: /eng/common/templates-official/job/publish-build-assets.yml@self
+        parameters:
+          publishUsingPipelines: true
+          dependsOn:
+            - OfficialBuild
+          queue:
+            name: Hosted VS2017
 
-    # - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    #   - template: eng\common\templates\post-build\post-build.yml@self
-    #     parameters:
-    #       # Symbol validation is not entirely reliable as of yet, so should be turned off until
-    #       # https://github.com/dotnet/arcade/issues/2871 is resolved.
-    #       enableSymbolValidation: false
-    #       enableSourceLinkValidation: false
-    #       publishingInfraVersion: 3
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - template: eng\common\templates-official\post-build\post-build.yml@self
+        parameters:
+          # Symbol validation is not entirely reliable as of yet, so should be turned off until
+          # https://github.com/dotnet/arcade/issues/2871 is resolved.
+          enableSymbolValidation: false
+          enableSourceLinkValidation: false
+          publishingInfraVersion: 3

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -77,7 +77,7 @@ extends:
           displayName: Install Signing Plugin
           inputs:
             signType: $(SignType)
-          condition: succeeded()
+          condition: and(succeeded(), ne(variables['SignType'], ''))
         - script: eng\common\CIBuild.cmd
                     -configuration $(BuildConfiguration)
                     /p:PB_PublishBlobFeedKey=$(PB_PublishBlobFeedKey)

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -15,6 +15,7 @@ variables:
     value: .NETCoreValidation
   - name: Codeql.Enabled
     value: true​
+    # $(microsoft-symbol-server-pat) and $(symweb-symbol-server-pat) come from this group
   - group: DotNet-Symbol-Server-Pats
   - name: BuildConfiguration
     value: Release

--- a/insertion-pr-tagger.yml
+++ b/insertion-pr-tagger.yml
@@ -9,6 +9,9 @@ schedules:
 variables:
 - group: roslyn-perf-bot
 
+# Make sure the pipeline doesn't build on commits.
+trigger: none
+
 resources:
   repositories:
   - repository: 1ESPipelineTemplates


### PR DESCRIPTION
Test run https://dev.azure.com/dnceng/internal/_build/results?buildId=2436117&view=results
Our old pipeline lives under DevDiv and is disabled.
To make 1ES work and other future work easier, I move it to dnceng.

PR contains a lot of meaningless test commits, I will squash them into one commit.