### PR TITLE
Fix RIT

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
@@ -361,7 +361,7 @@ namespace Roslyn.Insertion
                 {
                     // artifact.Resource.Data should be available and non-null due to BuildWithValidArtifactsAsync,
                     // which checks this precondition
-                    if (!StringComparer.OrdinalIgnoreCase.Equals(artifact.Resource.Type, "container"))
+                    if (!StringComparer.OrdinalIgnoreCase.Equals(artifact.Resource.Type, "pipelineArtifact"))
                     {
                         throw new InvalidOperationException($"Could not find artifact '{arcadeArtifactName}' associated with build '{build.Id}'");
                     }

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
@@ -8,7 +8,6 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
-using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
@@ -411,6 +411,9 @@ namespace Roslyn.Insertion
             }
             else
             {
+                // When the published by Publish artifacts pipeline task, buildClient.GetArtifactContentZipAsync() is unable to get the content of the artifacts.
+                // See https://developercommunity.visualstudio.com/t/exception-is-being-thrown-for-getartifactcontentzi/1270336
+                // It recommended to use http client to download the payload directly from the Url.
                 var downloadUrl = artifact.Resource.DownloadUrl;
                 var pat = !string.IsNullOrEmpty(Options.ComponentBuildAzdoUri)
                     ? Options.ComponentBuildAzdoPassword


### PR DESCRIPTION
So RIT has some problem, example run: https://dev.azure.com/dnceng/internal/_apps/hub/ms.vss-releaseManagement-web.cd-release-progress?_a=release-pipeline-progress&releaseId=42298

1. After we move to 1ES template, artifacts container would become pipeline artifacts.
2. There is a problem to get pipeline artifacts directly by calling `build.GetArtifactContentZipAsync()`

I locally verified it works. 
https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/546136