### PR TITLE
Exclude libTo2Git.so

### DIFF
--- a/eng/SymbolPublishingExclusionsFile.txt
+++ b/eng/SymbolPublishingExclusionsFile.txt
@@ -1,0 +1,1 @@
+tools/net9.0/any/runtimes/linux-musl-x64/native/libgit2-b7bad55.so


### PR DESCRIPTION
Exclude the symbol publish for libTo2Git.so, following the instructions [here](https://github.com/dotnet/arcade/blob/main/Documentation/CorePackages/Publishing.md#can-we-exclude-symbols-from-publishing-to-symbols-server)
Fix https://github.com/dotnet/dnceng/issues/2958#issuecomment-2137692339