### PR TITLE
Exclude other libgit symbols

### DIFF
--- a/eng/SymbolPublishingExclusionsFile.txt
+++ b/eng/SymbolPublishingExclusionsFile.txt
@@ -1,1 +1,3 @@
 tools/net9.0/any/runtimes/linux-musl-x64/native/libgit2-b7bad55.so
+tools/net9.0/any/runtimes/linux-musl-arm/native/libgit2-b7bad55.so
+tools/net9.0/any/runtimes/linux-musl-arm64/native/libgit2-b7bad55.so


### PR DESCRIPTION
Should fix this https://dev.azure.com/dnceng/internal/_build/results?buildId=2462920&view=logs&j=ba23343f-f710-5af9-782d-5bd26b102304&t=c7a8693b-2f9c-5ea8-c909-cde9405ac2e1