### PR TITLE
Improve PR Descriptions

### DIFF
--- a/src/dotnet-roslyn-tools/Commands/PRFinderCommand.cs
+++ b/src/dotnet-roslyn-tools/Commands/PRFinderCommand.cs
@@ -13,11 +13,12 @@ internal static class PRFinderCommand
 {
     private static readonly PrFinderCommandDefaultHandler s_prFinderCommandHandler = new();
 
-    internal static readonly string[] SupportedFormats = { PRFinder.PRFinder.DefaultFormat, PRFinder.PRFinder.OmniSharpFormat };
+    internal static readonly string[] SupportedFormats = [PRFinder.PRFinder.DefaultFormat, PRFinder.PRFinder.OmniSharpFormat];
 
-    internal static readonly Option<string> PreviousCommitShaOption = new Option<string>(new[] { "--previous", "-p" }, "SHA of the commit you want to start looking for PRs from") { IsRequired = true };
-    internal static readonly Option<string> CurrentCommitSHAOption = new Option<string>(new[] { "--current", "-c" }, "SHA of commit you want to stop looking for PRs at") { IsRequired = true };
-    internal static readonly Option<string> FormatOption = new Option<string>(new[] { "--format" }, () => PRFinder.PRFinder.DefaultFormat, "The formatting to apply to the PR list.").FromAmong(SupportedFormats);
+    internal static readonly Option<string> PreviousCommitShaOption = new(["--previous", "-p"], "SHA of the commit you want to start looking for PRs from") { IsRequired = true };
+    internal static readonly Option<string> CurrentCommitSHAOption = new(["--current", "-c"], "SHA of commit you want to stop looking for PRs at") { IsRequired = true };
+    internal static readonly Option<string> FormatOption = new Option<string>(["--format"], () => PRFinder.PRFinder.DefaultFormat, "The formatting to apply to the PR list.").FromAmong(SupportedFormats);
+    internal static readonly Option<string?> RepoPathOption = new(["--repo"], () => null, "The directory of the repository to look for PRs. If none is provided, the current directory is used");
 
     public static Symbol GetCommand()
     {
@@ -26,7 +27,8 @@ internal static class PRFinderCommand
             PreviousCommitShaOption,
             CurrentCommitSHAOption,
             FormatOption,
-            VerbosityOption
+            VerbosityOption,
+            RepoPathOption
         };
         prFinderCommand.Handler = s_prFinderCommandHandler;
         return prFinderCommand;
@@ -41,8 +43,9 @@ internal static class PRFinderCommand
             var previousCommit = context.ParseResult.GetValueForOption(PreviousCommitShaOption)!;
             var currentCommit = context.ParseResult.GetValueForOption(CurrentCommitSHAOption)!;
             var format = context.ParseResult.GetValueForOption(FormatOption)!;
+            var repoPath = context.ParseResult.GetValueForOption(RepoPathOption);
 
-            return Task.FromResult(PRFinder.PRFinder.FindPRs(previousCommit, currentCommit, format, logger));
+            return PRFinder.PRFinder.FindPRsAsync(previousCommit, currentCommit, format, logger, repoPath: repoPath);
         }
     }
 }

--- a/src/dotnet-roslyn-tools/PRFinder/Hosts/Azure.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/Hosts/Azure.cs
@@ -54,23 +54,19 @@ public class Azure : IRepositoryHost
         return false;
     }
 
-    public bool TryParseMergeInfo(Commit commit, out string prNumber, out string comment)
+    public Task<MergeInfo?> TryParseMergeInfoAsync(Commit commit)
     {
         var match = IsAzDOMergePRCommit.Match(commit.Message);
         if (match.Success)
         {
             // Merge PR Messages are in the form "Merged PR 320820: Resolving encoding issue on test summary pane, using UTF8 now\n\nAdded a StreamWriterWrapper to resolve encoding issue"
-            comment = commit.MessageShort;
-            prNumber = match.Groups[1].Value;
-            return true;
+            return Task.FromResult<MergeInfo?>(new(match.Groups[1].Value, commit.Message));
         }
         else
         {
             // Todo: Determine if there is a format for AzDO squash merges that preserves the PR #
         }
 
-        comment = string.Empty;
-        prNumber = string.Empty;
-        return false;
+        return Task.FromResult<MergeInfo?>(null);
     }
 }

--- a/src/dotnet-roslyn-tools/PRFinder/Hosts/Azure.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/Hosts/Azure.cs
@@ -11,16 +11,22 @@ public class Azure : IRepositoryHost
 {
     private static readonly Regex IsAzDOReleaseFlowCommit = new Regex(@"^Merged PR \d+: Merging .* to ");
     private static readonly Regex IsAzDOMergePRCommit = new Regex(@"^Merged PR (\d+):");
+    private readonly string _repoUrl;
 
-    public string GetCommitUrl(string repoUrl, string commitSha)
-        => $"{repoUrl}/commit/{commitSha}";
+    public Azure(string repoUrl)
+    {
+        _repoUrl = repoUrl;
+    }
 
-    public string GetDiffUrl(string repoUrl, string previousSha, string currentSha)
+    public string GetCommitUrl(string commitSha)
+        => $"{_repoUrl}/commit/{commitSha}";
+
+    public string GetDiffUrl(string previousSha, string currentSha)
         // AzDO does not have a UI for comparing two commits. Instead generate the REST API call to retrieve commits between two SHAs.
-        => $"{repoUrl.Replace("_git", "_apis/git/repositories")}/commits?searchCriteria.itemVersion.version={previousSha}&searchCriteria.itemVersion.versionType=commit&searchCriteria.compareVersion.version={currentSha}&searchCriteria.compareVersion.versionType=commit";
+        => $"{_repoUrl.Replace("_git", "_apis/git/repositories")}/commits?searchCriteria.itemVersion.version={previousSha}&searchCriteria.itemVersion.versionType=commit&searchCriteria.compareVersion.version={currentSha}&searchCriteria.compareVersion.versionType=commit";
 
-    public string GetPullRequestUrl(string repoUrl, string prNumber)
-        => $"{repoUrl}/pullrequest/{prNumber}";
+    public string GetPullRequestUrl(string prNumber)
+        => $"{_repoUrl}/pullrequest/{prNumber}";
 
     public bool ShouldSkip(Commit commit, ref bool mergePRFound)
     {

--- a/src/dotnet-roslyn-tools/PRFinder/Hosts/GitHub.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/Hosts/GitHub.cs
@@ -2,8 +2,12 @@
 // The.NET Foundation licenses this file to you under the MIT license.
 // See the License.txt file in the project root for more information.
 
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using LibGit2Sharp;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.RoslynTools.PRFinder.Hosts;
 
@@ -14,9 +18,21 @@ public class GitHub : IRepositoryHost
     private static readonly Regex IsGitHubSquashedPRCommit = new(@"\(#(\d+)\)(?:\n|$)");
     private readonly string _repoUrl;
 
-    public GitHub(string repoUrl)
+    private readonly HttpClient _httpClient;
+    private readonly ILogger _logger;
+
+    public GitHub(string repoUrl, ILogger logger)
     {
         _repoUrl = repoUrl;
+        _logger = logger;
+        _httpClient = new HttpClient()
+        {
+            BaseAddress = new Uri(repoUrl)
+        };
+
+        _httpClient.DefaultRequestHeaders.Accept.Add(
+            new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+        _httpClient.DefaultRequestHeaders.Add("User-Agent", "roslyn-pr-finder");
     }
 
     public string GetCommitUrl(string commitSha)
@@ -63,9 +79,17 @@ public class GitHub : IRepositoryHost
             // Merge PR Messages are in the form "Merge pull request #39526 from mavasani/GetValueUsageInfoAssert\n\nFix an assert in IOperationExtension.GetValueUsageInfo"
             // Try and extract the 1st non-empty line since it is the useful part of the message, otherwise take the first line.
             var lines = commit.Message.Split('\n', StringSplitOptions.RemoveEmptyEntries);
-            var comment = lines.Length > 1
-                ? $"{lines[1]} (#{prNumber})"
-                : commit.MessageShort;
+
+            if (lines.Length > 1)
+            {
+                return new MergeInfo(prNumber, $"{lines[1]} (#{prNumber})");
+            }
+
+            var comment = await TryGetPrTitleAsync(prNumber);
+
+            // Fallback to the commit message if the PR Title can't be retrieved
+            comment ??= commit.MessageShort;
+
             return new(prNumber, comment);
         }
         else
@@ -83,5 +107,24 @@ public class GitHub : IRepositoryHost
         }
 
         return null;
+    }
+
+    private async Task<string?> TryGetPrTitleAsync(string prNumber)
+    {
+        _logger.LogTrace($"Attempting to fetch PR Title for {prNumber} at {_httpClient.BaseAddress}/pull/{prNumber}");
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"pulls/{prNumber}");
+        var response = await _httpClient.GetFromJsonAsync<PullRequestResponse>($"pulls/{prNumber}");
+
+        return response?.Title;
+    }
+
+    private class PullRequestResponse
+    {
+        [JsonPropertyName("title")]
+        public string Title { get; set; } = "";
+
+        [JsonPropertyName ("description")]
+        public string Body { get; set; } = "";
     }
 }

--- a/src/dotnet-roslyn-tools/PRFinder/Hosts/GitHub.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/Hosts/GitHub.cs
@@ -116,11 +116,19 @@ public class GitHub : IRepositoryHost
 
     private async Task<string?> TryGetPrTitleAsync(string prNumber)
     {
-        var relativeUrl = $"{prNumber}";
-        _logger.LogTrace($"Attempting to fetch PR Title for {prNumber} at {_httpClient.BaseAddress}{relativeUrl}");
-        var response = await _httpClient.GetFromJsonAsync<PullRequestResponse>(relativeUrl);
+        try
+        {
+            var relativeUrl = $"{prNumber}";
+            _logger.LogTrace($"Attempting to fetch PR Title for {prNumber} at {_httpClient.BaseAddress}{relativeUrl}");
+            var response = await _httpClient.GetFromJsonAsync<PullRequestResponse>(relativeUrl);
 
-        return response?.Title;
+            return response?.Title;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, e.Message);
+            return null;
+        }
     }
 
     private class PullRequestResponse

--- a/src/dotnet-roslyn-tools/PRFinder/Hosts/GitHub.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/Hosts/GitHub.cs
@@ -12,15 +12,21 @@ public class GitHub : IRepositoryHost
     private static readonly Regex IsGitHubReleaseFlowCommit = new(@"^Merge pull request #\d+ from dotnet/merges/");
     private static readonly Regex IsGitHubMergePRCommit = new(@"^Merge pull request #(\d+) from");
     private static readonly Regex IsGitHubSquashedPRCommit = new(@"\(#(\d+)\)(?:\n|$)");
+    private readonly string _repoUrl;
 
-    public string GetCommitUrl(string repoUrl, string commitSha)
-        => $"{repoUrl}/commit/{commitSha}";
+    public GitHub(string repoUrl)
+    {
+        _repoUrl = repoUrl;
+    }
 
-    public string GetDiffUrl(string repoUrl, string previousSha, string currentSha)
-        => $"{repoUrl}/compare/{previousSha}...{currentSha}?w=1";
+    public string GetCommitUrl(string commitSha)
+        => $"{_repoUrl}/commit/{commitSha}";
 
-    public string GetPullRequestUrl(string repoUrl, string prNumber)
-        => $"{repoUrl}/pull/{prNumber}";
+    public string GetDiffUrl(string previousSha, string currentSha)
+        => $"{_repoUrl}/compare/{previousSha}...{currentSha}?w=1";
+
+    public string GetPullRequestUrl(string prNumber)
+        => $"{_repoUrl}/pull/{prNumber}";
 
     public bool ShouldSkip(Commit commit, ref bool mergePRFound)
     {

--- a/src/dotnet-roslyn-tools/PRFinder/IRepositoryHost.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/IRepositoryHost.cs
@@ -10,7 +10,7 @@ public interface IRepositoryHost
 {
     bool ShouldSkip(Commit commit, ref bool mergePRFound);
     bool TryParseMergeInfo(Commit commit, out string prNumber, out string comment);
-    string GetPullRequestUrl(string repoUrl, string prNumber);
-    string GetCommitUrl(string repoUrl, string commitSha);
-    string GetDiffUrl(string repoUrl, string previousSha, string currentSha);
+    string GetPullRequestUrl(string prNumber);
+    string GetCommitUrl(string commitSha);
+    string GetDiffUrl(string previousSha, string currentSha);
 }

--- a/src/dotnet-roslyn-tools/PRFinder/IRepositoryHost.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/IRepositoryHost.cs
@@ -9,8 +9,10 @@ namespace Microsoft.RoslynTools.PRFinder;
 public interface IRepositoryHost
 {
     bool ShouldSkip(Commit commit, ref bool mergePRFound);
-    bool TryParseMergeInfo(Commit commit, out string prNumber, out string comment);
+    Task<MergeInfo?> TryParseMergeInfoAsync(Commit commit);
     string GetPullRequestUrl(string prNumber);
     string GetCommitUrl(string commitSha);
     string GetDiffUrl(string previousSha, string currentSha);
 }
+
+public record class MergeInfo(string PrNumber, string Comment);

--- a/src/dotnet-roslyn-tools/PRFinder/PRFinder.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/PRFinder.cs
@@ -90,7 +90,7 @@ internal class PRFinder
         }
 
         IRepositoryHost host = isGitHub
-            ? new Hosts.GitHub(repoUrl)
+            ? new Hosts.GitHub(repoUrl, logger)
             : new Hosts.Azure(repoUrl);
 
         IPRLogFormatter formatter = format == DefaultFormat

--- a/src/dotnet-roslyn-tools/PRFinder/PRFinder.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/PRFinder.cs
@@ -120,17 +120,17 @@ internal class PRFinder
                 continue;
             }
 
-            var wasMergeCommit = host.TryParseMergeInfo(commit, out var prNumber, out var comment);
+            var mergeInfo = await host.TryParseMergeInfoAsync(commit);
 
             // We will print commit comments until we find the first merge PR
-            if (!wasMergeCommit && mergePRFound)
+            if (mergeInfo is null && mergePRFound)
             {
                 continue;
             }
 
             string prLink;
 
-            if (wasMergeCommit)
+            if (mergeInfo is not null)
             {
                 if (commitHeaderAdded && !mergePRHeaderAdded)
                 {
@@ -140,7 +140,7 @@ internal class PRFinder
 
                 mergePRFound = true;
 
-                prLink = formatter.FormatPRListItem(comment, prNumber, host.GetPullRequestUrl(prNumber));
+                prLink = formatter.FormatPRListItem(mergeInfo.Comment, mergeInfo.PrNumber, host.GetPullRequestUrl(mergeInfo.PrNumber));
             }
             else
             {

--- a/src/dotnet-roslyn-tools/PRFinder/PRFinder.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/PRFinder.cs
@@ -23,7 +23,7 @@ internal class PRFinder
     /// <param name="repoPath">Optional path to product repo. Current directory will be used otherwise.</param>
     /// <param name="builder">Optional if the caller wants result as a string.</param>
     /// <returns></returns>
-    public static int FindPRs(
+    public static async Task<int> FindPRsAsync(
         string previousCommitSha,
         string currentCommitSha,
         string format,
@@ -90,8 +90,8 @@ internal class PRFinder
         }
 
         IRepositoryHost host = isGitHub
-            ? new Hosts.GitHub()
-            : new Hosts.Azure();
+            ? new Hosts.GitHub(repoUrl)
+            : new Hosts.Azure(repoUrl);
 
         IPRLogFormatter formatter = format == DefaultFormat
             ? new Formatters.DefaultFormatter()
@@ -105,9 +105,9 @@ internal class PRFinder
                 ExcludeReachableFrom = previousCommit
             });
 
-        logger.LogDebug(formatter.FormatChangesHeader(previousCommitSha, host.GetCommitUrl(repoUrl, previousCommitSha), currentCommitSha, host.GetCommitUrl(repoUrl, currentCommitSha)));
+        logger.LogDebug(formatter.FormatChangesHeader(previousCommitSha, host.GetCommitUrl(previousCommitSha), currentCommitSha, host.GetCommitUrl(currentCommitSha)));
 
-        RecordLine(formatter.FormatDiffHeader(host.GetDiffUrl(repoUrl, previousCommitSha, currentCommitSha)), logger, builder);
+        RecordLine(formatter.FormatDiffHeader(host.GetDiffUrl(previousCommitSha, currentCommitSha)), logger, builder);
 
         var commitHeaderAdded = false;
         var mergePRHeaderAdded = false;
@@ -140,7 +140,7 @@ internal class PRFinder
 
                 mergePRFound = true;
 
-                prLink = formatter.FormatPRListItem(comment, prNumber, host.GetPullRequestUrl(repoUrl, prNumber));
+                prLink = formatter.FormatPRListItem(comment, prNumber, host.GetPullRequestUrl(prNumber));
             }
             else
             {
@@ -153,7 +153,7 @@ internal class PRFinder
                 var fullSHA = commit.Sha;
                 var shortSHA = fullSHA.Substring(0, 7);
 
-                prLink = formatter.FormatCommitListItem(commit.MessageShort, shortSHA, host.GetCommitUrl(repoUrl, fullSHA));
+                prLink = formatter.FormatCommitListItem(commit.MessageShort, shortSHA, host.GetCommitUrl(fullSHA));
             }
 
             RecordLine(prLink, logger, builder);

--- a/src/dotnet-roslyn-tools/PRTagger/PRTagger.cs
+++ b/src/dotnet-roslyn-tools/PRTagger/PRTagger.cs
@@ -157,7 +157,7 @@ internal static class PRTagger
 
         // Find PRs between product commit SHAs
         var prDescription = new StringBuilder();
-        var isSuccess = PRFinder.PRFinder.FindPRs(previousProductCommitSha, currentProductCommitSha, PRFinder.PRFinder.DefaultFormat, logger, gitHubRepoPath, prDescription);
+        var isSuccess = await PRFinder.PRFinder.FindPRsAsync(previousProductCommitSha, currentProductCommitSha, PRFinder.PRFinder.DefaultFormat, logger, gitHubRepoPath, prDescription);
         if (isSuccess != 0)
         {
             // Error occurred; should be logged in FindPRs method


### PR DESCRIPTION
Use the [GH Api](https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests) to fetch PR titles if the commit message isn't indicative of a user provided message

TODO: This is limited by IP to 60 requests per hour. I managed to exceed that fairly easily.

```diff
diff --git a/description.md b/description.md
index 740b4d1..ae2cfc9 100644
--- a/description.md
+++ b/description.md
@@ -1,52 +1,52 @@
 [View Complete Diff of Changes](https://github.com/dotnet/roslyn/compare/dd3795a49875bef2728f01e0284406f33ea1e2e1...e5dc6c6e6afd5bd217309ee540a22e1d88489a52?w=1)
 - [Snap 17.11 Preview 2 (73753)](https://github.com/dotnet/roslyn/pull/73753)
-- [Merge pull request 73729 from CyrusNajmabadi/taggerAllocs](https://github.com/dotnet/roslyn/pull/73729)
+- [Lower allocations in tagging](https://github.com/dotnet/roslyn/pull/73729)
 - [Align sort implementation with reference from dotnet/runtime (73739)](https://github.com/dotnet/roslyn/pull/73739)
 - [Optimization of (de)serialization of ProjectId.DebugNames (73734)](https://github.com/dotnet/roslyn/pull/73734)
-- [Merge pull request 73727 from CyrusNajmabadi/arrayAlloc](https://github.com/dotnet/roslyn/pull/73727)
-- [Merge pull request 73724 from CyrusNajmabadi/vs4macApi](https://github.com/dotnet/roslyn/pull/73724)
-- [Merge pull request 73721 from CyrusNajmabadi/asyncAwaitPerf](https://github.com/dotnet/roslyn/pull/73721)
-- [Merge pull request 73723 from CyrusNajmabadi/codeDefWindow](https://github.com/dotnet/roslyn/pull/73723)
-- [Merge pull request 73722 from CyrusNajmabadi/braceMatcherPerf](https://github.com/dotnet/roslyn/pull/73722)
-- [Merge pull request 73719 from CyrusNajmabadi/stringIndentationRecurse](https://github.com/dotnet/roslyn/pull/73719)
+- [Avoid unnecessary array+linq allocs in common case](https://github.com/dotnet/roslyn/pull/73727)
+- [Remove legacy api used only by vs4mac.](https://github.com/dotnet/roslyn/pull/73724)
+- [Don't run code in the async/await highlighter unless on one of those keywords.](https://github.com/dotnet/roslyn/pull/73721)
+- [Switch to work queue for code definition window](https://github.com/dotnet/roslyn/pull/73723)
+- [Streamline brace matcher code](https://github.com/dotnet/roslyn/pull/73722)
+- [Small tweaks to the recursion walk we do when looking for strign indentation regions](https://github.com/dotnet/roslyn/pull/73719)
 - [Avoid unnecessary tree walk when hitting non-relevant directives (73720)](https://github.com/dotnet/roslyn/pull/73720)
-- [Merge pull request 73715 from CyrusNajmabadi/allIntervalTreeWork](https://github.com/dotnet/roslyn/pull/73715)
+- [Reduce lots of allocations in TagSpanIntervalTree](https://github.com/dotnet/roslyn/pull/73715)
 - [Cache the getnode/gettoken classifiers retrieived from the extension manager. (73712)](https://github.com/dotnet/roslyn/pull/73712)
-- [Merge pull request 73717 from CyrusNajmabadi/classificatoinStack](https://github.com/dotnet/roslyn/pull/73717)
-- [Merge pull request 73713 from CyrusNajmabadi/tagSpan](https://github.com/dotnet/roslyn/pull/73713)
-- [Merge pull request 73714 from CyrusNajmabadi/intervalTreeSpan](https://github.com/dotnet/roslyn/pull/73714)
-- [Merge pull request 73708 from CyrusNajmabadi/treeEfficiency](https://github.com/dotnet/roslyn/pull/73708)
+- [Don't push non-intersecting nodes/tokens to the classification stack](https://github.com/dotnet/roslyn/pull/73717)
+- [Move over to IDE using TagSpan uniformly](https://github.com/dotnet/roslyn/pull/73713)
+- [Move interval trees over to being TextSpan based](https://github.com/dotnet/roslyn/pull/73714)
+- [Pool collections during tagging.](https://github.com/dotnet/roslyn/pull/73708)
 - [Do not suppress the warning, which doesn't need to be suppressed (73711)](https://github.com/dotnet/roslyn/pull/73711)
 - [Reduce size of interval tree used for tagging (73703)](https://github.com/dotnet/roslyn/pull/73703)
-- [Merge pull request 73574 from RenderMichael/switch-or](https://github.com/dotnet/roslyn/pull/73574)
+- [Add support for or-pattern in `IDE0010`](https://github.com/dotnet/roslyn/pull/73574)
 - [Convert interval-tree type to a struct (73676)](https://github.com/dotnet/roslyn/pull/73676)
-- [Merge pull request 73699 from CyrusNajmabadi/lessMainThreadSwitch](https://github.com/dotnet/roslyn/pull/73699)
+- [Update tagging to avoid jumping back to the UI thread when finished.](https://github.com/dotnet/roslyn/pull/73699)
 - [Utilize ImmutableCollectionsMarshal to get ROS for XxHash128.Hash call (73692)](https://github.com/dotnet/roslyn/pull/73692)
 - [Return the SignatureHelp items nearest to the cursor (73606)](https://github.com/dotnet/roslyn/pull/73606)
 - [Final editor side changes for "allow ref struct" support (73700)](https://github.com/dotnet/roslyn/pull/73700)
-- [Merge pull request 73688 from CyrusNajmabadi/inProgress](https://github.com/dotnet/roslyn/pull/73688)
-- [Merge pull request 73673 from CyrusNajmabadi/lineCache](https://github.com/dotnet/roslyn/pull/73673)
+- [Ensure we sync source-generator versions over properly when doing a cone-sync](https://github.com/dotnet/roslyn/pull/73688)
+- [Reduce cost of syntactic classification by around 25% while paging down through a file (and around 50% while arrowing down).](https://github.com/dotnet/roslyn/pull/73673)
 - [Avoid having to go back to the UI thread in the navbar code (73681)](https://github.com/dotnet/roslyn/pull/73681)
 - [Include more data for debugging purposes (73684)](https://github.com/dotnet/roslyn/pull/73684)
-- [Merge pull request 73680 from CyrusNajmabadi/navBarCAdence](https://github.com/dotnet/roslyn/pull/73680)
+- [Slow down the work navbar does, and cancel updating it when receiving a high volume of user events](https://github.com/dotnet/roslyn/pull/73680)
 - [Expose XAML IDiagnosticSourceProvider names (73674)](https://github.com/dotnet/roslyn/pull/73674)
 - [Move EnC workspace tests down to Features layer (73660)](https://github.com/dotnet/roslyn/pull/73660)
 - [Strengthen language version tests for Ref Struct Interfaces (73607)](https://github.com/dotnet/roslyn/pull/73607)
 - [Implement ICollection<T> on ArrayBuilder (73659)](https://github.com/dotnet/roslyn/pull/73659)
 - [Add test for F1 on "allows ref struct" (73654)](https://github.com/dotnet/roslyn/pull/73654)
-- [Merge pull request 73648 from CyrusNajmabadi/classificationPerf](https://github.com/dotnet/roslyn/pull/73648)
+- [Drop roslyn impact on scrolling perf by 30%](https://github.com/dotnet/roslyn/pull/73648)
 - [Work around crash in Document Outline (73564)](https://github.com/dotnet/roslyn/pull/73564)
 - [Ignore drive casing when comparing on windows platforms (73380)](https://github.com/dotnet/roslyn/pull/73380)
-- [Merge pull request 73635 from CyrusNajmabadi/cacheServices](https://github.com/dotnet/roslyn/pull/73635)
-- [Merge pull request 73647 from CyrusNajmabadi/ignoreWhitespace](https://github.com/dotnet/roslyn/pull/73647)
-- [Merge pull request 73634 from CyrusNajmabadi/fileScopedNamespace](https://github.com/dotnet/roslyn/pull/73634)
-- [Merge pull request 73646 from CyrusNajmabadi/asNode2](https://github.com/dotnet/roslyn/pull/73646)
-- [Merge pull request 73645 from CyrusNajmabadi/asNode](https://github.com/dotnet/roslyn/pull/73645)
-- [Merge pull request 73629 from CyrusNajmabadi/classificationWalk](https://github.com/dotnet/roslyn/pull/73629)
+- [Cache classification services](https://github.com/dotnet/roslyn/pull/73635)
+- [Ignore the commits that update us to FileScopedNamespaces](https://github.com/dotnet/roslyn/pull/73647)
+- [Switch to file scoped namespace for tests](https://github.com/dotnet/roslyn/pull/73634)
+- [Simplify code in ForAttributeWithMetadataName](https://github.com/dotnet/roslyn/pull/73646)
+- [Switch to AsNode extension](https://github.com/dotnet/roslyn/pull/73645)
+- [Optimize syntactic classification walk](https://github.com/dotnet/roslyn/pull/73629)
 - [Add object browser support for ref struct interfaces (73621)](https://github.com/dotnet/roslyn/pull/73621)
 - [Remove unused usings (73633)](https://github.com/dotnet/roslyn/pull/73633)
 - [Update to simple using statements (73632)](https://github.com/dotnet/roslyn/pull/73632)
-- [Merge pull request 73625 from CyrusNajmabadi/constructorInit](https://github.com/dotnet/roslyn/pull/73625)
+- [Avoid searching entire trees when looking for implicit constructors in find-refs](https://github.com/dotnet/roslyn/pull/73625)
 - [Add signature help support for ref struct interfaces (73624)](https://github.com/dotnet/roslyn/pull/73624)
 - [Use semantics to check for readonly struct (72893)](https://github.com/dotnet/roslyn/pull/72893)
 - [Switch SG mode to 'balanced' by default (73618)](https://github.com/dotnet/roslyn/pull/73618)
 ```