### PR TITLE
Use `--project` flag as the `-p` alias is deprecated.

### DIFF
--- a/merge-pr-pipeline.yml
+++ b/merge-pr-pipeline.yml
@@ -34,5 +34,5 @@ steps:
     installationPath: $(Agent.ToolsDirectory)/dotnet
     includePreviewVersions: true
 
-- script: dotnet --info; dotnet run -p $(Build.SourcesDirectory)/src/GitHubCreateMergePRs/GitHubCreateMergePRs.csproj --isDryRun=$(isDryRun) --isAutomated=$(isAutomated) --githubToken=$(BotAccount-dotnet-bot-repo-PAT)
+- script: dotnet --info; dotnet run --project $(Build.SourcesDirectory)/src/GitHubCreateMergePRs/GitHubCreateMergePRs.csproj --isDryRun=$(isDryRun) --isAutomated=$(isAutomated) --githubToken=$(BotAccount-dotnet-bot-repo-PAT)
   displayName: 'Run GitHub Create Merge PRs'


### PR DESCRIPTION
- Warning NETSDK1174: The abbreviation of -p for --project is deprecated. Please use --project.