### PR TITLE
Close down F# 17.11 branch

### DIFF
--- a/src/GitHubCreateMergePRs/config.xml
+++ b/src/GitHubCreateMergePRs/config.xml
@@ -69,8 +69,8 @@
     <merge from="release/dev17.10" to="release/dev17.11" />
 
     <!-- regular branch flow -->
-    <merge from="release/dev17.10" to="main" />
-    <merge from="main" to="release/dev17.11" />
+    <merge from="release/dev17.11" to="main" />
+    <!-- <merge from="main" to="release/dev17.11" /> -->
 
     <!-- feature branches -->
     <merge from="main" to="feature/nullness" owners="T-Gro" frequency="daily" />


### PR DESCRIPTION
This will merge 17.11 back to main, and will disable main -> 17.11, while we preparing 17.12/net9/F#9