### PR TITLE
Add a changelog format that makes it easier to add a changelog for VS Code

### DIFF
--- a/src/dotnet-roslyn-tools/Commands/PRFinderCommand.cs
+++ b/src/dotnet-roslyn-tools/Commands/PRFinderCommand.cs
@@ -13,7 +13,7 @@ internal static class PRFinderCommand
 {
     private static readonly PrFinderCommandDefaultHandler s_prFinderCommandHandler = new();
 
-    internal static readonly string[] SupportedFormats = [PRFinder.PRFinder.DefaultFormat, PRFinder.PRFinder.OmniSharpFormat];
+    internal static readonly string[] SupportedFormats = [PRFinder.PRFinder.DefaultFormat, PRFinder.PRFinder.OmniSharpFormat, PRFinder.PRFinder.ChangelogFormat];
 
     internal static readonly Option<string> PreviousCommitShaOption = new(["--previous", "-p"], "SHA of the commit you want to start looking for PRs from") { IsRequired = true };
     internal static readonly Option<string> CurrentCommitSHAOption = new(["--current", "-c"], "SHA of commit you want to stop looking for PRs at") { IsRequired = true };

--- a/src/dotnet-roslyn-tools/PRFinder/Formatters/ChangelogFormatter.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/Formatters/ChangelogFormatter.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the License.txt file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.RoslynTools.PRFinder.Formatters
+{
+    internal class ChangelogFormatter : IPRLogFormatter
+    {
+        public string FormatChangesHeader(string previous, string previousUrl, string current, string currentUrl)
+            => $"### Changes from [{previous}]({previousUrl}) to [{current}]({currentUrl}):";
+
+        public virtual string FormatCommitListItem(string comment, string shortSHA, string commitUrl)
+            => $"- [{comment} ({shortSHA})]({commitUrl})";
+
+        public virtual string FormatDiffHeader(string diffUrl)
+            => $"[View Complete Diff of Changes]({diffUrl})";
+
+        public virtual string FormatPRListItem(string comment, string prNumber, string prUrl)
+        {
+            prNumber = prNumber.StartsWith("#")
+                ? prNumber
+                : $"#{prNumber}";
+
+            return $"  * {comment} (PR: [{prNumber}]({prUrl}))";
+        }
+
+        public virtual string GetCommitSectionHeader()
+            => "### Commits since last PR:";
+
+        public virtual string GetPRSectionHeader()
+            => "### Merged PRs:";
+    }
+}

--- a/src/dotnet-roslyn-tools/PRFinder/Formatters/ChangelogFormatter.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/Formatters/ChangelogFormatter.cs
@@ -10,18 +10,9 @@ using System.Threading.Tasks;
 
 namespace Microsoft.RoslynTools.PRFinder.Formatters
 {
-    internal class ChangelogFormatter : IPRLogFormatter
+    internal class ChangelogFormatter : DefaultFormatter
     {
-        public string FormatChangesHeader(string previous, string previousUrl, string current, string currentUrl)
-            => $"### Changes from [{previous}]({previousUrl}) to [{current}]({currentUrl}):";
-
-        public virtual string FormatCommitListItem(string comment, string shortSHA, string commitUrl)
-            => $"- [{comment} ({shortSHA})]({commitUrl})";
-
-        public virtual string FormatDiffHeader(string diffUrl)
-            => $"[View Complete Diff of Changes]({diffUrl})";
-
-        public virtual string FormatPRListItem(string comment, string prNumber, string prUrl)
+        public override string FormatPRListItem(string comment, string prNumber, string prUrl)
         {
             prNumber = prNumber.StartsWith("#")
                 ? prNumber
@@ -29,11 +20,5 @@ namespace Microsoft.RoslynTools.PRFinder.Formatters
 
             return $"  * {comment} (PR: [{prNumber}]({prUrl}))";
         }
-
-        public virtual string GetCommitSectionHeader()
-            => "### Commits since last PR:";
-
-        public virtual string GetPRSectionHeader()
-            => "### Merged PRs:";
     }
 }

--- a/src/dotnet-roslyn-tools/PRFinder/PRFinder.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/PRFinder.cs
@@ -13,6 +13,7 @@ internal class PRFinder
 {
     public const string DefaultFormat = "default";
     public const string OmniSharpFormat = "o#";
+    public const string ChangelogFormat = "changelog";
 
     /// <summary>
     /// Finds the PRs merged between two given commits.
@@ -93,9 +94,13 @@ internal class PRFinder
             ? new Hosts.GitHub(repoUrl, logger)
             : new Hosts.Azure(repoUrl);
 
-        IPRLogFormatter formatter = format == DefaultFormat
-            ? new Formatters.DefaultFormatter()
-            : new Formatters.OmniSharpFormatter();
+        IPRLogFormatter formatter = format switch
+        {
+            DefaultFormat => new Formatters.DefaultFormatter(),
+            OmniSharpFormat => new Formatters.OmniSharpFormatter(),
+            ChangelogFormat => new Formatters.ChangelogFormatter(),
+            _ => throw new InvalidOperationException($"Uknown format '{format}'")
+        };
 
         // Get commit history starting at the current commit and ending at the previous commit
         var commitLog = repo.Commits.QueryBy(


### PR DESCRIPTION
Example output 

```
[View Complete Diff of Changes](https://github.com/dotnet/roslyn/compare/4fc2462522d2d63b94625f94bc0eaa2b28595d3d...2077862a15f4b955a4c5d139b82cb47087919e55?w=1)
  * Revert "Remove semantic model keep-alive code in completion (#73844)" (#74302) (PR: [#74302](https://github.com/dotnet/roslyn/pull/74302))
  * Remove fallbacks (#74041) (PR: [#74041](https://github.com/dotnet/roslyn/pull/74041))
  * Fix UseNullPropagationCodeFixProvider for parenthesized property access (PR: [#74316](https://github.com/dotnet/roslyn/pull/74316))
  * Disable BuildWithNetFrameworkHostedCompiler (#74299) (PR: [#74299](https://github.com/dotnet/roslyn/pull/74299))
  * Avoid using constants for large string literals (#74305) (PR: [#74305](https://github.com/dotnet/roslyn/pull/74305))
  * Adjust lowering of a string interpolation in an expression lambda to not use expanded non-array `params` collection in Format/Create calls. (#74274) (PR: [#74274](https://github.com/dotnet/roslyn/pull/74274))
  * Consolidate test Span sources (#74281) (PR: [#74281](https://github.com/dotnet/roslyn/pull/74281))
  * Fix style binding failure in Document Outline (#74263) (PR: [#74263](https://github.com/dotnet/roslyn/pull/74263))
  * Allow Document.FilePath to be set to null (#74290) (PR: [#74290](https://github.com/dotnet/roslyn/pull/74290))
  * Fix msbuild issue (#74293) (PR: [#74293](https://github.com/dotnet/roslyn/pull/74293))
  * Remove fallback options from IdeAnalyzerOptions (#74235) (PR: [#74235](https://github.com/dotnet/roslyn/pull/74235))
  * Improve parser recovery around nullable types in patterns (#72805) (PR: [#72805](https://github.com/dotnet/roslyn/pull/72805))
  * Syntax formatting options (#74223) (PR: [#74223](https://github.com/dotnet/roslyn/pull/74223))
  * Fix scenario where lightbulbs weren't being displayed (#74277) (PR: [#74277](https://github.com/dotnet/roslyn/pull/74277))
  * Localized file check-in by OneLocBuild Task: Build definition ID 327: Build ID 2490585 (#74287) (PR: [#74287](https://github.com/dotnet/roslyn/pull/74287))
  * 17.11: Add weak heuristics in our designer scanning code to improve experience during things like configuration switch. (#74152) (PR: [#74152](https://github.com/dotnet/roslyn/pull/74152))
  * fix (#74276) (PR: [#74276](https://github.com/dotnet/roslyn/pull/74276))
  * Remove (already disabled) command handlers related to 'add suppression' menu command.  (PR: [#74266](https://github.com/dotnet/roslyn/pull/74266))
  * fix (#74237) (PR: [#74237](https://github.com/dotnet/roslyn/pull/74237))
  * Reduce closures allocated during invocation of CapturedSymbolReplacement.Replacement (#74258) (PR: [#74258](https://github.com/dotnet/roslyn/pull/74258))
  * Reduce allocations in SymbolDeclaredCompilationEvent (#74250) (PR: [#74250](https://github.com/dotnet/roslyn/pull/74250))
  * Remove unused legacy-diagnostics-system type (part2). (PR: [#74265](https://github.com/dotnet/roslyn/pull/74265))
  * Pass along correct VS guid when reporting task list items (PR: [#74262](https://github.com/dotnet/roslyn/pull/74262))
  * Move settings updates into a queue. (PR: [#74249](https://github.com/dotnet/roslyn/pull/74249))
  * PR feedback on recent work to sync solutions consistently (PR: [#74260](https://github.com/dotnet/roslyn/pull/74260))
  * Fix flaky streaming FAR test (#74261) (PR: [#74261](https://github.com/dotnet/roslyn/pull/74261))
  * Dispose various locations using PEReader (#74226) (PR: [#74226](https://github.com/dotnet/roslyn/pull/74226))
  * New generator apis (#74127) (PR: [#74127](https://github.com/dotnet/roslyn/pull/74127))
  * Fix style binding failure in Document Outline (#74256) (PR: [#74256](https://github.com/dotnet/roslyn/pull/74256))
  * [main] Update dependencies from dotnet/arcade (#74233) (PR: [#74233](https://github.com/dotnet/roslyn/pull/74233))
  * Sync solution contents consistently (PR: [#72860](https://github.com/dotnet/roslyn/pull/72860))
  * Avoid recreating stateset objects continually. (#74246) (PR: [#74246](https://github.com/dotnet/roslyn/pull/74246))
  ```