### PR TITLE
Adds an option to the pr-finder command to filter by path.

### DIFF
--- a/src/dotnet-roslyn-tools/.vscode/launch.json
+++ b/src/dotnet-roslyn-tools/.vscode/launch.json
@@ -18,7 +18,9 @@
               "-e",
               "main",
               "--path",
-              "src/dotnet-roslyn-tools"
+              "src/dotnet-roslyn-tools",
+              "-v",
+              "diag"
             ],
             "cwd": "${workspaceFolder}",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console

--- a/src/dotnet-roslyn-tools/.vscode/launch.json
+++ b/src/dotnet-roslyn-tools/.vscode/launch.json
@@ -1,0 +1,34 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // Use IntelliSense to find out which attributes exist for C# debugging
+            // Use hover for the description of the existing attributes
+            // For further information visit https://github.com/dotnet/vscode-csharp/blob/main/debugger-launchjson.md
+            "name": "Run pr-finder",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/../../artifacts/bin/Microsoft.RoslynTools/Debug/net9.0/Microsoft.RoslynTools.dll",
+            "args": [
+              "pr-finder",
+              "-s",
+              "d7261529b43f4581fb47e8f4d3d9197095d44508",
+              "-e",
+              "main",
+              "--path",
+              "src/dotnet-roslyn-tools"
+            ],
+            "cwd": "${workspaceFolder}",
+            // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ]
+}

--- a/src/dotnet-roslyn-tools/.vscode/tasks.json
+++ b/src/dotnet-roslyn-tools/.vscode/tasks.json
@@ -1,0 +1,41 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/Microsoft.RoslynTools.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary;ForceNoAlign"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/Microsoft.RoslynTools.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary;ForceNoAlign"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "--project",
+                "${workspaceFolder}/Microsoft.RoslynTools.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/src/dotnet-roslyn-tools/Commands/PRFinderCommand.cs
+++ b/src/dotnet-roslyn-tools/Commands/PRFinderCommand.cs
@@ -15,8 +15,9 @@ internal static class PRFinderCommand
 
     internal static readonly string[] SupportedFormats = [PRFinder.PRFinder.DefaultFormat, PRFinder.PRFinder.OmniSharpFormat, PRFinder.PRFinder.ChangelogFormat];
 
-    internal static readonly Option<string> PreviousCommitShaOption = new(["--previous", "-p"], "SHA of the commit you want to start looking for PRs from") { IsRequired = true };
-    internal static readonly Option<string> CurrentCommitSHAOption = new(["--current", "-c"], "SHA of commit you want to stop looking for PRs at") { IsRequired = true };
+    internal static readonly Option<string> StartRefOption = new(["--start", "-s"], "The ref to start looking for PRs from. This value can be a branch name, tag name, or commit SHA.") { IsRequired = true };
+    internal static readonly Option<string> EndRefOption = new(["--end", "-e"], "The ref to stop looking for PRs at. This value can be a branch name, tag name, or commit SHA.") { IsRequired = true };
+    internal static readonly Option<string?> PathOption = new(["--path"], "When set only PRs that touch the specified path will be included in the output.");
     internal static readonly Option<string> FormatOption = new Option<string>(["--format"], () => PRFinder.PRFinder.DefaultFormat, "The formatting to apply to the PR list.").FromAmong(SupportedFormats);
     internal static readonly Option<string?> RepoPathOption = new(["--repo"], () => null, "The directory of the repository to look for PRs. If none is provided, the current directory is used");
 
@@ -24,8 +25,9 @@ internal static class PRFinderCommand
     {
         var prFinderCommand = new Command("pr-finder", "Find merged PRs between two commits")
         {
-            PreviousCommitShaOption,
-            CurrentCommitSHAOption,
+            StartRefOption,
+            EndRefOption,
+            PathOption,
             FormatOption,
             VerbosityOption,
             RepoPathOption
@@ -40,12 +42,13 @@ internal static class PRFinderCommand
         {
             var logger = context.SetupLogging();
 
-            var previousCommit = context.ParseResult.GetValueForOption(PreviousCommitShaOption)!;
-            var currentCommit = context.ParseResult.GetValueForOption(CurrentCommitSHAOption)!;
+            var startRef = context.ParseResult.GetValueForOption(StartRefOption)!;
+            var endRef = context.ParseResult.GetValueForOption(EndRefOption)!;
+            var path = context.ParseResult.GetValueForOption(PathOption);
             var format = context.ParseResult.GetValueForOption(FormatOption)!;
             var repoPath = context.ParseResult.GetValueForOption(RepoPathOption);
 
-            return PRFinder.PRFinder.FindPRsAsync(previousCommit, currentCommit, format, logger, repoPath: repoPath);
+            return PRFinder.PRFinder.FindPRsAsync(startRef, endRef, path, format, logger, repoPath: repoPath);
         }
     }
 }

--- a/src/dotnet-roslyn-tools/PRFinder/Formatters/DefaultFormatter.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/Formatters/DefaultFormatter.cs
@@ -6,8 +6,10 @@ namespace Microsoft.RoslynTools.PRFinder.Formatters;
 
 public class DefaultFormatter : IPRLogFormatter
 {
-    public virtual string FormatChangesHeader(string start, string startUrl, string end, string endUrl)
-        => $"### Changes from [{start}]({startUrl}) to [{end}]({endUrl}):";
+    public virtual string FormatChangesHeader(string start, string startUrl, string end, string endUrl, string? path)
+        => path is null
+            ? $"### Changes from [{start}]({startUrl}) to [{end}]({endUrl}):"
+            : $"### Changes from [{start}]({startUrl}) to [{end}]({endUrl}) under `{path}`:";
 
     public virtual string FormatCommitListItem(string comment, string shortSHA, string commitUrl)
         => $"- [{comment} ({shortSHA})]({commitUrl})";

--- a/src/dotnet-roslyn-tools/PRFinder/Formatters/DefaultFormatter.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/Formatters/DefaultFormatter.cs
@@ -6,8 +6,8 @@ namespace Microsoft.RoslynTools.PRFinder.Formatters;
 
 public class DefaultFormatter : IPRLogFormatter
 {
-    public virtual string FormatChangesHeader(string previous, string previousUrl, string current, string currentUrl)
-        => $"### Changes from [{previous}]({previousUrl}) to [{current}]({currentUrl}):";
+    public virtual string FormatChangesHeader(string start, string startUrl, string end, string endUrl)
+        => $"### Changes from [{start}]({startUrl}) to [{end}]({endUrl}):";
 
     public virtual string FormatCommitListItem(string comment, string shortSHA, string commitUrl)
         => $"- [{comment} ({shortSHA})]({commitUrl})";

--- a/src/dotnet-roslyn-tools/PRFinder/Hosts/Azure.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/Hosts/Azure.cs
@@ -21,9 +21,9 @@ public class Azure : IRepositoryHost
     public string GetCommitUrl(string commitSha)
         => $"{_repoUrl}/commit/{commitSha}";
 
-    public string GetDiffUrl(string previousSha, string currentSha)
+    public string GetDiffUrl(string startRef, string endRef)
         // AzDO does not have a UI for comparing two commits. Instead generate the REST API call to retrieve commits between two SHAs.
-        => $"{_repoUrl.Replace("_git", "_apis/git/repositories")}/commits?searchCriteria.itemVersion.version={previousSha}&searchCriteria.itemVersion.versionType=commit&searchCriteria.compareVersion.version={currentSha}&searchCriteria.compareVersion.versionType=commit";
+        => $"{_repoUrl.Replace("_git", "_apis/git/repositories")}/commits?searchCriteria.itemVersion.version={startRef}&searchCriteria.itemVersion.versionType=commit&searchCriteria.compareVersion.version={endRef}&searchCriteria.compareVersion.versionType=commit";
 
     public string GetPullRequestUrl(string prNumber)
         => $"{_repoUrl}/pullrequest/{prNumber}";

--- a/src/dotnet-roslyn-tools/PRFinder/Hosts/GitHub.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/Hosts/GitHub.cs
@@ -43,8 +43,8 @@ public class GitHub : IRepositoryHost
     public string GetCommitUrl(string commitSha)
         => $"{_repoUrl}/commit/{commitSha}";
 
-    public string GetDiffUrl(string previousSha, string currentSha)
-        => $"{_repoUrl}/compare/{previousSha}...{currentSha}?w=1";
+    public string GetDiffUrl(string startRef, string endRef)
+        => $"{_repoUrl}/compare/{startRef}...{endRef}?w=1";
 
     public string GetPullRequestUrl(string prNumber)
         => $"{_repoUrl}/pull/{prNumber}";
@@ -136,7 +136,7 @@ public class GitHub : IRepositoryHost
         [JsonPropertyName("title")]
         public string Title { get; set; } = "";
 
-        [JsonPropertyName ("description")]
+        [JsonPropertyName("description")]
         public string Body { get; set; } = "";
     }
 

--- a/src/dotnet-roslyn-tools/PRFinder/IPRLogFormatter.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/IPRLogFormatter.cs
@@ -6,7 +6,7 @@ namespace Microsoft.RoslynTools.PRFinder;
 
 public interface IPRLogFormatter
 {
-    string FormatChangesHeader(string previous, string previousUrl, string current, string currentUrl);
+    string FormatChangesHeader(string start, string startUrl, string end, string endUrl);
     string FormatDiffHeader(string diffUrl);
     string GetCommitSectionHeader();
     string GetPRSectionHeader();

--- a/src/dotnet-roslyn-tools/PRFinder/IPRLogFormatter.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/IPRLogFormatter.cs
@@ -6,7 +6,7 @@ namespace Microsoft.RoslynTools.PRFinder;
 
 public interface IPRLogFormatter
 {
-    string FormatChangesHeader(string start, string startUrl, string end, string endUrl);
+    string FormatChangesHeader(string start, string startUrl, string end, string endUrl, string? path);
     string FormatDiffHeader(string diffUrl);
     string GetCommitSectionHeader();
     string GetPRSectionHeader();

--- a/src/dotnet-roslyn-tools/PRFinder/IRepositoryHost.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/IRepositoryHost.cs
@@ -12,7 +12,7 @@ public interface IRepositoryHost
     Task<MergeInfo?> TryParseMergeInfoAsync(Commit commit);
     string GetPullRequestUrl(string prNumber);
     string GetCommitUrl(string commitSha);
-    string GetDiffUrl(string previousSha, string currentSha);
+    string GetDiffUrl(string startRef, string endRef);
 }
 
 public record class MergeInfo(string PrNumber, string Comment);

--- a/src/dotnet-roslyn-tools/PRFinder/PRFinder.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/PRFinder.cs
@@ -122,7 +122,7 @@ internal class PRFinder
             : null;
         var commitLog = repo.Commits.QueryBy(commitFilter);
 
-        logger.LogDebug(formatter.FormatChangesHeader(startRef, host.GetCommitUrl(startRef), endRef, host.GetCommitUrl(endRef)));
+        logger.LogDebug(formatter.FormatChangesHeader(startRef, host.GetCommitUrl(startRef), endRef, host.GetCommitUrl(endRef), path));
 
         RecordLine(formatter.FormatDiffHeader(host.GetDiffUrl(startRef, endRef)), logger, builder);
 

--- a/src/dotnet-roslyn-tools/PRTagger/PRTagger.cs
+++ b/src/dotnet-roslyn-tools/PRTagger/PRTagger.cs
@@ -157,7 +157,7 @@ internal static class PRTagger
 
         // Find PRs between product commit SHAs
         var prDescription = new StringBuilder();
-        var isSuccess = await PRFinder.PRFinder.FindPRsAsync(previousProductCommitSha, currentProductCommitSha, PRFinder.PRFinder.DefaultFormat, logger, gitHubRepoPath, prDescription);
+        var isSuccess = await PRFinder.PRFinder.FindPRsAsync(previousProductCommitSha, currentProductCommitSha, path: null, PRFinder.PRFinder.DefaultFormat, logger, gitHubRepoPath, prDescription);
         if (isSuccess != 0)
         {
             // Error occurred; should be logged in FindPRs method


### PR DESCRIPTION
The PR Finder can now filter results based on changes to a specific relative path in the repo. Also, I cleaned up the verbiage where we were referring to refs as SHAs to make it more clear that branches and tags can also be passed as arguments.

Without path filter (3 results):
```
~/Source/roslyn-tools/src/dotnet-roslyn-tools [main ≡ +0 ~3 -0 !]> dotnet run pr-finder -s d7261529b43f4581fb47e8f4d3d9197095d44508 -e main
Restore complete (0.3s)
  Microsoft.RoslynTools succeeded (0.2s) → /Users/joeyrobichaud/Source/roslyn-tools/artifacts/bin/Microsoft.RoslynTools/Debug/net9.0/Microsoft.RoslynTools.dll

Build succeeded in 0.9s
[View Complete Diff of Changes](https://github.com/dotnet/roslyn-tools/compare/d7261529b43f4581fb47e8f4d3d9197095d44508...main?w=1)
- [Add a changelog format that makes it easier to add a changelog for VS Code (1433)](https://github.com/dotnet/roslyn-tools/pull/1433)
- [Don't update XAML version (1431)](https://github.com/dotnet/roslyn-tools/pull/1431)
- [Close down F# 17.11 branch (1432)](https://github.com/dotnet/roslyn-tools/pull/1432)
```

With path filter (1 results):
```
~/Source/roslyn-tools/src/dotnet-roslyn-tools [main ≡ +0 ~3 -0 !]> dotnet run pr-finder -s d7261529b43f4581fb47e8f4d3d9197095d44508 -e main --path src/dotnet-roslyn-tools
Restore complete (0.3s)
  Microsoft.RoslynTools succeeded (0.5s) → /Users/joeyrobichaud/Source/roslyn-tools/artifacts/bin/Microsoft.RoslynTools/Debug/net9.0/Microsoft.RoslynTools.dll

Build succeeded in 1.1s
[View Complete Diff of Changes](https://github.com/dotnet/roslyn-tools/compare/d7261529b43f4581fb47e8f4d3d9197095d44508...main?w=1)
- [Add a changelog format that makes it easier to add a changelog for VS Code (1433)](https://github.com/dotnet/roslyn-tools/pull/1433)
```