### PR TITLE
Revert 17.13 flow change for F#

### DIFF
--- a/src/GitHubCreateMergePRs/config.xml
+++ b/src/GitHubCreateMergePRs/config.xml
@@ -69,7 +69,8 @@
     <merge from="release/dev17.11" to="release/dev17.12" />
     <merge from="release/dev17.12" to="release/dev17.13" />
     <!-- regular branch flow -->
-    <merge from="release/dev17.13" to="main" />
+    <merge from="release/dev17.12" to="main" />
+    <merge from="main" to="release/dev17.13" />
 
     <!-- feature branches -->
     <merge from="main" to="lsp" owners="0101" frequency="daily" />


### PR DESCRIPTION
@RikkiGibson @akhera99 FYI, you have (accidentally?) changed F#'s flow in https://github.com/dotnet/roslyn-tools/pull/1449, this reverts it back.

Our flow is: 
1. Previous release (`17.12`) goes to `main`.
2. `main` goes to current release (`17.13`).