### PR TITLE
Remove redundant F# release flow

### DIFF
--- a/src/GitHubCreateMergePRs/config.xml
+++ b/src/GitHubCreateMergePRs/config.xml
@@ -46,8 +46,6 @@
   </repo>
 
   <repo owner="dotnet" name="fsharp">
-    <!-- releases -->
-    <merge from="release/dev17.11" to="release/dev17.12" />
     <!-- regular branch flow -->
     <merge from="release/dev17.12" to="main" />
     <merge from="main" to="release/dev17.13" />


### PR DESCRIPTION
Hello there, this line creates redundant PRs in our repo, they usually end up either closed with conflicts or merged with no files. 

The rest of the flow (release -> main, main -> release) is enough for us now :)