### PR TITLE
Update create-release-tags command to create tags for SDK releases

### DIFF
--- a/src/dotnet-roslyn-tools/.vscode/launch.json
+++ b/src/dotnet-roslyn-tools/.vscode/launch.json
@@ -40,6 +40,36 @@
             "stopAtEntry": false
         },
         {
+            "name": "Run `create-release-tags -p roslyn`",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/../../artifacts/bin/Microsoft.RoslynTools/Debug/net9.0/Microsoft.RoslynTools.dll",
+            "args": [
+              "create-release-tags",
+              "-p",
+              "roslyn"
+            ],
+            "cwd": "${workspaceFolder}/../../../roslyn",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": "Run `create-release-tags -p razor`",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/../../artifacts/bin/Microsoft.RoslynTools/Debug/net9.0/Microsoft.RoslynTools.dll",
+            "args": [
+              "create-release-tags",
+              "-p",
+              "razor"
+            ],
+            "cwd": "${workspaceFolder}/../../../razor",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
             "name": "Run `authenticate --clear`",
             "type": "coreclr",
             "request": "launch",

--- a/src/dotnet-roslyn-tools/Commands/CreateReleaseTagsCommand.cs
+++ b/src/dotnet-roslyn-tools/Commands/CreateReleaseTagsCommand.cs
@@ -4,6 +4,7 @@
 
 using System.CommandLine;
 using System.CommandLine.Invocation;
+using Microsoft.RoslynTools.Utilities;
 using Microsoft.RoslynTools.VS;
 
 namespace Microsoft.RoslynTools.Commands;
@@ -51,7 +52,11 @@ internal class CreateReleaseTagsCommand
 
             var product = parseResult.GetValue(ProductOption)!;
 
-            return await CreateReleaseTags.CreateReleaseTags.CreateReleaseTagsAsync(product, settings, logger);
+            using var remoteConnections = new RemoteConnections(settings);
+            return await CreateReleaseTags.CreateReleaseTags.CreateReleaseTagsAsync(
+                product,
+                remoteConnections,
+                logger);
         }
     }
 }

--- a/src/dotnet-roslyn-tools/CreateReleaseTags/AbstractReleaseTagger.cs
+++ b/src/dotnet-roslyn-tools/CreateReleaseTags/AbstractReleaseTagger.cs
@@ -1,0 +1,73 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the License.txt file in the project root for more information.
+
+using System.Collections.Immutable;
+using LibGit2Sharp;
+using Microsoft.Extensions.Logging;
+using Microsoft.RoslynTools.Products;
+using Microsoft.RoslynTools.Utilities;
+
+namespace Microsoft.RoslynTools.CreateReleaseTags;
+
+internal abstract class AbstractReleaseTagger<TRelease, TBuild>
+    where TRelease : ReleaseInformation
+    where TBuild : BuildInformation
+{
+    public abstract string Name { get; }
+    public abstract Task<ImmutableArray<TRelease>> GetReleasesAsync(RemoteConnections connections);
+    public abstract string GetTagName(TRelease release);
+    public abstract Task<TBuild?> TryGetBuildAsync(RemoteConnections connections, IProduct product, TRelease release);
+    public abstract string CreateTagMessage(IProduct product, TRelease release, TBuild build);
+
+    public async Task CreateReleaseTagsAsync(
+        RemoteConnections connections,
+        IProduct product,
+        Repository repository,
+        ImmutableHashSet<string> existingTags,
+        ILogger logger)
+    {
+        logger.LogInformation("Loading {Name} releases...", Name);
+
+        var releases = await GetReleasesAsync(connections);
+
+        logger.LogWarning("Tagging {ReleasesLength} releases...", releases.Length);
+
+        var tagsAdded = 0;
+
+        foreach (var release in releases)
+        {
+            var tagName = GetTagName(release);
+            if (existingTags.Contains(tagName))
+            {
+                logger.LogWarning("Tag '{TagName}' already exists.", tagName);
+                continue;
+            }
+
+            logger.LogTrace("Tag '{TagName}' is missing.", tagName);
+
+            var build = await TryGetBuildAsync(connections, product, release);
+            if (build is null)
+            {
+                logger.LogWarning("Unable to find the build for '{TagName}'.", tagName);
+                continue;
+            }
+
+            logger.LogInformation("Tagging {CommitSha} as '{TagName}'.", build.CommitSha, tagName);
+
+            var message = CreateTagMessage(product, release, build);
+
+            try
+            {
+                repository.ApplyTag(tagName, build.CommitSha, new Signature(product.GitUserName, product.GitEmail, when: release.CreationTime), message);
+                tagsAdded++;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Unable to tag the commit '{CommitSha}' with '{TagName}'.", build.CommitSha, tagName);
+            }
+        }
+
+        logger.LogInformation("Added {TagsAdded} tags. Tagging complete.", tagsAdded);
+    }
+}

--- a/src/dotnet-roslyn-tools/CreateReleaseTags/BuildInformation.cs
+++ b/src/dotnet-roslyn-tools/CreateReleaseTags/BuildInformation.cs
@@ -4,9 +4,8 @@
 
 namespace Microsoft.RoslynTools.CreateReleaseTags;
 
-internal sealed class BuildInformation(string commitSha, string sourceBranch, string buildId)
+internal abstract class BuildInformation(string commitSha, string buildId)
 {
     public readonly string CommitSha = commitSha;
-    public readonly string SourceBranch = sourceBranch;
     public readonly string BuildId = buildId;
 }

--- a/src/dotnet-roslyn-tools/CreateReleaseTags/ReleaseInformation.cs
+++ b/src/dotnet-roslyn-tools/CreateReleaseTags/ReleaseInformation.cs
@@ -4,11 +4,9 @@
 
 namespace Microsoft.RoslynTools.CreateReleaseTags;
 
-public readonly struct VisualStudioVersion(string mainVersion, string? previewVersion, string commitSha, DateTime creationTime, string buildId)
+public abstract class ReleaseInformation(string mainVersion, string? previewVersion, DateTime creationTime)
 {
     public readonly string MainVersion = mainVersion;
     public readonly string? PreviewVersion = previewVersion;
-    public readonly string CommitSha = commitSha;
     public readonly DateTime CreationTime = creationTime;
-    public readonly string BuildId = buildId;
 }

--- a/src/dotnet-roslyn-tools/CreateReleaseTags/SdkReleaseTagger.cs
+++ b/src/dotnet-roslyn-tools/CreateReleaseTags/SdkReleaseTagger.cs
@@ -1,0 +1,176 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the License.txt file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Microsoft.RoslynTools.Products;
+using Microsoft.RoslynTools.Utilities;
+
+namespace Microsoft.RoslynTools.CreateReleaseTags;
+
+internal sealed partial class SdkReleaseTagger
+    : AbstractReleaseTagger<SdkReleaseTagger.SdkReleaseInformation, SdkReleaseTagger.SdkBuildInformation>
+{
+    private const string SdkRepoBaseUrl = "https://api.github.com/repos/dotnet/sdk/";
+
+    public override string Name => ".NET SDK";
+
+    public override async Task<ImmutableArray<SdkReleaseInformation>> GetReleasesAsync(RemoteConnections connections)
+    {
+        var githubClient = connections.GitHubClient;
+
+        var gitRefs = await githubClient.GetFromJsonAsync<RefResponse[]>(SdkRepoBaseUrl + "git/matching-refs/tags/");
+        if (gitRefs is null)
+        {
+            return [];
+        }
+
+        var releases = ImmutableArray.CreateBuilder<SdkReleaseInformation>();
+
+        foreach (var gitRef in gitRefs)
+        {
+            if (gitRef is not { Object: { Type: "commit", Sha: { } sha } })
+            {
+                continue;
+            }
+
+            var match = VersionTag().Match(gitRef.Ref);
+            if (!match.Success)
+            {
+                continue;
+            }
+
+            var mainVersion = match.Groups["mainVersion"].Value;
+            var majorVersion = int.Parse(mainVersion.Split('.')[0]);
+            // Only return tags for .NET 8+
+            if (majorVersion < 8)
+            {
+                continue;
+            }
+
+            var previewVersion = match.Groups["previewVersion"].Value;
+
+            var gitCommit = await githubClient.GetFromJsonAsync<CommitResponse>(SdkRepoBaseUrl + $"git/commits/{sha}");
+            if (gitCommit is null)
+            {
+                continue;
+            }
+
+            var tagName = match.Groups["tagName"].Value;
+
+            releases.Add(new SdkReleaseInformation(mainVersion, previewVersion, gitCommit.Author.Date, tagName));
+        }
+
+        return releases.ToImmutable();
+    }
+
+    public override async Task<SdkBuildInformation?> TryGetBuildAsync(RemoteConnections connections, IProduct product, SdkReleaseInformation release)
+    {
+        var versionDetailsXml = await connections.GitHubClient
+            .GetStringAsync($"https://raw.githubusercontent.com/dotnet/sdk/refs/tags/{release.SdkTagName}/eng/Version.Details.xml");
+        var versionDetails = XDocument.Parse(versionDetailsXml);
+
+        var dependencyElement = versionDetails.Descendants("Dependency")
+            .SingleOrDefault(element => element.Attribute("Name")?.Value == product.SdkPackageName);
+        if (dependencyElement is null)
+        {
+            return null;
+        }
+
+        var version = dependencyElement.Attribute("Version")?.Value;
+        if (version is null)
+        {
+            return null;
+        }
+
+        var buildId = ConvertVersionToBuildId(version);
+
+        return dependencyElement.Element("Sha")?.Value is { } sha
+            ? new SdkBuildInformation(sha, buildId, version)
+            : null;
+
+        static string ConvertVersionToBuildId(string version)
+        {
+            // Take 4.12.0-3.24574.8 or 4.12.0-preview.3.24574.8 and construct 20241124.8
+            var previewParts = version.Split('-')[1].Split('.');
+            var buildDate = previewParts.Length == 3
+                ? previewParts[1]
+                : previewParts[2];
+            var run = previewParts.Length == 3
+                ? previewParts[2]
+                : previewParts[3];
+
+            var buildYear = buildDate[..2];
+            var buildMonth = int.Parse(buildDate[2..]) / 50;
+            var buildDay = int.Parse(buildDate[2..]) % 50;
+
+            return $"20{buildYear}{buildMonth:D2}{buildDay:D2}.{run}";
+        }
+    }
+
+    public override string GetTagName(SdkReleaseInformation release)
+    {
+        var tag = "NET-SDK-" + release.MainVersion;
+        return string.IsNullOrEmpty(release.PreviewVersion)
+            ? tag
+            : tag + "-" + release.PreviewVersion;
+    }
+
+    public override string CreateTagMessage(IProduct product, SdkReleaseInformation release, SdkBuildInformation build)
+    {
+        return $"{product.Name} Version: {build.ProductVersion}\r\nInternal ID: {build.BuildId}\r\nSDK Tag: {release.SdkTagName}";
+    }
+
+    public class RefResponse
+    {
+        [JsonPropertyName("ref")]
+        public string Ref { get; set; } = null!;
+        [JsonPropertyName("object")]
+        public RefObject Object { get; set; } = null!;
+    }
+
+    public class RefObject
+    {
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = null!;
+        [JsonPropertyName("sha")]
+        public string Sha { get; set; } = null!;
+    }
+
+    public class CommitResponse
+    {
+        [JsonPropertyName("sha")]
+        public string Sha { get; set; } = null!;
+        public Author Author { get; set; } = null!;
+    }
+
+    public class Author
+    {
+        [JsonPropertyName("date")]
+        public DateTime Date { get; set; }
+    }
+
+    internal class SdkReleaseInformation(
+        string mainVersion,
+        string? previewVersion,
+        DateTime creationTime,
+        string sdkTagName) : ReleaseInformation(mainVersion, previewVersion, creationTime)
+    {
+        public readonly string SdkTagName = sdkTagName;
+    }
+
+    internal class SdkBuildInformation(
+        string commitSha,
+        string buildId,
+        string productVersion) : BuildInformation(commitSha, buildId)
+    {
+        public readonly string ProductVersion = productVersion;
+    }
+
+    [GeneratedRegex(@"^refs/tags/(?<tagName>v(?<mainVersion>\d+\.\d+\.\d+)(?:-(?<previewVersion>.+))?)$")]
+    private static partial Regex VersionTag();
+}

--- a/src/dotnet-roslyn-tools/CreateReleaseTags/VsReleaseTagger.cs
+++ b/src/dotnet-roslyn-tools/CreateReleaseTags/VsReleaseTagger.cs
@@ -1,0 +1,309 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the License.txt file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Net;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Microsoft.RoslynTools.Products;
+using Microsoft.RoslynTools.Utilities;
+using Microsoft.TeamFoundation.SourceControl.WebApi;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.RoslynTools.CreateReleaseTags;
+
+internal sealed partial class VsReleaseTagger
+    : AbstractReleaseTagger<VsReleaseTagger.VsReleaseInformation, VsReleaseTagger.VsBuildInformation>
+{
+    public override string Name => "VS";
+
+    // Only tag VS builds that are under support.
+    // See https://learn.microsoft.com/en-us/visualstudio/productinfo/vs-servicing#long-term-servicing-channel-ltsc-support
+    private readonly ImmutableDictionary<string, string> _vsVersionMap = new Dictionary<string, string>
+    {
+        { "16.11.", "2019" },
+        { "17.", "2022" },
+    }.ToImmutableDictionary();
+
+    public override async Task<ImmutableArray<VsReleaseInformation>> GetReleasesAsync(RemoteConnections connections)
+    {
+        var gitClient = connections.DevDivConnection.GitClient;
+        var vsRepository = await GetVSRepositoryAsync(gitClient);
+        var tags = await gitClient.GetRefsAsync(vsRepository.Id, filterContains: "release/vs", peelTags: true);
+
+        var builder = ImmutableArray.CreateBuilder<VsReleaseInformation>();
+
+        foreach (var tag in tags)
+        {
+            const string TagPrefix = "refs/tags/release/vs/";
+
+            if (!tag.Name.StartsWith(TagPrefix))
+            {
+                continue;
+            }
+
+            var parts = tag.Name[TagPrefix.Length..].Split('-');
+
+            if (parts.Length != 1 && parts.Length != 2)
+            {
+                continue;
+            }
+
+            if (!IsDottedVersion().IsMatch(parts[0]))
+            {
+                continue;
+            }
+
+            // If there is no peeled object, it means it's a simple tag versus an annotated tag; those aren't usually how
+            // VS releases are tagged so skip it
+            if (tag.PeeledObjectId == null)
+            {
+                continue;
+            }
+
+            var sha = tag.PeeledObjectId;
+
+            var annotatedTag = await gitClient.GetAnnotatedTagAsync(vsRepository.ProjectReference.Id, vsRepository.Id, tag.ObjectId);
+            if (annotatedTag == null)
+            {
+                continue;
+            }
+
+            JObject buildInformation;
+
+            try
+            {
+                buildInformation = JObject.Parse(annotatedTag.Message);
+            }
+            catch
+            {
+                continue;
+            }
+
+            var mainVersion = parts[0];
+            if (!_vsVersionMap.Any(pair => mainVersion.StartsWith(pair.Key)))
+            {
+                // We only support tagging builds specified in the version map.
+                continue;
+            }
+
+            // It's not entirely clear to me how this format was chosen, but for consistency with old tags, we'll keep it
+            var buildId = $"{buildInformation["Branch"]?.ToString().Replace("/", ".")}-{buildInformation["BuildNumber"]}";
+
+            string? possiblePreviewVersion = null;
+            if (parts.Length == 2)
+            {
+                const string PreviewPrefix = "preview.";
+                if (!parts[1].StartsWith(PreviewPrefix))
+                {
+                    continue;
+                }
+
+                possiblePreviewVersion = parts[1][PreviewPrefix.Length..];
+                if (!IsDottedVersion().IsMatch(possiblePreviewVersion))
+                {
+                    continue;
+                }
+            }
+
+            builder.Add(new VsReleaseInformation(mainVersion, possiblePreviewVersion, annotatedTag.TaggedBy.Date, sha, buildId));
+        }
+
+        return builder.ToImmutable();
+
+        static Task<GitRepository> GetVSRepositoryAsync(GitHttpClient gitClient)
+            => gitClient.GetRepositoryAsync("DevDiv", "VS");
+    }
+
+    public override async Task<VsBuildInformation?> TryGetBuildAsync(RemoteConnections connections, IProduct product, VsReleaseInformation release)
+    {
+        var devdivConnection = connections.DevDivConnection;
+
+        VsBuildInformation? build = null;
+        foreach (var connection in new[] { connections.DncEngConnection, devdivConnection })
+        {
+            build = await TryGetBuildInfoForReleaseAsync(product, release, devdivConnection, connection);
+            if (build is not null)
+            {
+                return build;
+            }
+        }
+
+        return build;
+    }
+
+    private static async Task<VsBuildInformation?> TryGetBuildInfoForReleaseAsync(IProduct product, VsReleaseInformation release, AzDOConnection vsConnection, AzDOConnection connection)
+    {
+        try
+        {
+            var url = await VisualStudioRepository.GetUrlFromComponentJsonFileAsync(release.CommitSha, GitVersionType.Commit, vsConnection, product.ComponentJsonFileName, product.ComponentName);
+            if (url is null)
+            {
+                return default;
+            }
+
+            // First we try to get the info we want from the build directly, if we can find it
+            var buildNumber = VisualStudioRepository.GetBuildNumberFromUrl(url);
+            var pipelineName = product.GetBuildPipelineName(connection.BuildProjectName);
+            if (pipelineName is not null)
+            {
+                var builds = await connection.TryGetBuildsAsync(pipelineName, buildNumber);
+                if (builds is not null)
+                {
+                    foreach (var build in builds)
+                    {
+                        if (!string.IsNullOrWhiteSpace(build.SourceBranch))
+                        {
+                            return new VsBuildInformation(build.SourceVersion, build.SourceBranch, build.BuildNumber);
+                        }
+                    }
+                }
+            }
+
+            // Fallback if we can't get the info from the build, to parse the url or nuspec file
+            var branchName = TryGetRoslynBranchForRelease(url);
+            if (string.IsNullOrEmpty(branchName) || string.IsNullOrEmpty(buildNumber))
+            {
+                return null;
+            }
+
+            var commitSha = await TryGetCommitShaFromBuildAsync(product, connection, buildNumber)
+                ?? await TryGetRoslynCommitShaFromNuspecAsync(vsConnection, release);
+            if (string.IsNullOrEmpty(commitSha))
+            {
+                return null;
+            }
+
+            var buildId = product.GetBuildPipelineName(connection.BuildProjectName) + "_" + buildNumber;
+
+            return new VsBuildInformation(commitSha, branchName, buildId);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string? TryGetRoslynBranchForRelease(string url)
+    {
+        try
+        {
+            var parts = url.Split(';');
+            if (parts.Length != 2)
+            {
+                return null;
+            }
+
+            if (!parts[1].EndsWith(".vsman"))
+            {
+                return null;
+            }
+
+            var urlSegments = new Uri(parts[0]).Segments;
+            var branchName = string.Join("", urlSegments.SkipWhile(segment => !segment.EndsWith("roslyn/")).Skip(1).TakeWhile(segment => segment.EndsWith('/'))).TrimEnd('/');
+
+            return branchName;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static async Task<string?> TryGetCommitShaFromBuildAsync(
+        IProduct product,
+        AzDOConnection buildConnection,
+        string buildNumber)
+    {
+        var build = (await buildConnection.TryGetBuildsAsync(product.GetBuildPipelineName(buildConnection.BuildProjectName)!, buildNumber))?.SingleOrDefault();
+
+        if (build == null)
+        {
+            return null;
+        }
+
+        return build.SourceVersion;
+    }
+
+    private static async Task<string?> TryGetRoslynCommitShaFromNuspecAsync(
+        AzDOConnection vsConnection,
+        VsReleaseInformation release)
+    {
+        var defaultConfigContents = await VisualStudioRepository.GetFileContentsAsync(release.CommitSha, GitVersionType.Commit, vsConnection, @".corext\Configs\default.config");
+        var defaultConfig = XDocument.Parse(defaultConfigContents);
+
+        var packageElement = defaultConfig.Descendants("package")
+            .SingleOrDefault(element => element.Attribute("id")?.Value == "VS.ExternalAPIs.Roslyn");
+        if (packageElement == null)
+        {
+            return null;
+        }
+
+        var version = packageElement.Attribute("version")?.Value;
+        if (version is null)
+        {
+            return null;
+        }
+
+        var nuspecUrl = $@"https://devdiv.pkgs.visualstudio.com/_packaging/VS-CoreXtFeeds/nuget/v3/flat2/vs.externalapis.roslyn/{version}/vs.externalapis.roslyn.nuspec";
+
+        var nuspecResult = await vsConnection.NuGetClient.GetAsync(nuspecUrl);
+        if (nuspecResult.StatusCode != HttpStatusCode.OK)
+        {
+            return null;
+        }
+
+        var nuspecContent = await nuspecResult.Content.ReadAsStringAsync();
+        var nuspec = XElement.Parse(nuspecContent);
+
+        var respository = nuspec.Elements()
+            .SingleOrDefault()
+            ?.Elements(XName.Get("repository", nuspec.Name.NamespaceName))
+            .SingleOrDefault();
+        if (respository == null)
+        {
+            return null;
+        }
+
+        return respository.Attribute("commit")?.Value;
+    }
+
+    public override string GetTagName(VsReleaseInformation release)
+    {
+        // This is verified to have a value when we create the release information
+        var vsVersion = _vsVersionMap.First(pair => release.MainVersion.StartsWith($"{pair.Key}.")).Value;
+        var tag = $"Visual-Studio-{vsVersion}-Version-{release.MainVersion}";
+
+        return string.IsNullOrEmpty(release.PreviewVersion)
+            ? tag
+            : tag + "-Preview-" + release.PreviewVersion;
+    }
+
+    public override string CreateTagMessage(IProduct product, VsReleaseInformation release, VsBuildInformation build)
+    {
+        return $"Build Branch: {build.SourceBranch}\r\nInternal ID: {build.BuildId}\r\nInternal VS ID: {release.BuildId}";
+    }
+
+    public class VsReleaseInformation(
+        string mainVersion,
+        string? previewVersion,
+        DateTime creationTime,
+        string commitSha,
+        string buildId) : ReleaseInformation(mainVersion, previewVersion, creationTime)
+    {
+        public readonly string CommitSha = commitSha;
+        public readonly string BuildId = buildId;
+    }
+
+    internal class VsBuildInformation(
+        string commitSha,
+        string sourceBranch,
+        string buildId) : BuildInformation(commitSha, buildId)
+    {
+        public readonly string SourceBranch = sourceBranch;
+    }
+
+    [GeneratedRegex("^[0-9]+(\\.[0-9]+)*$")]
+    private static partial Regex IsDottedVersion();
+}

--- a/src/dotnet-roslyn-tools/Logging/ConsoleLoggerExtensions.cs
+++ b/src/dotnet-roslyn-tools/Logging/ConsoleLoggerExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the.NET Foundation under one or more agreements.
+﻿// Licensed to the.NET Foundation under one or more agreements.
 // The.NET Foundation licenses this file to you under the MIT license.
 // See the License.txt file in the project root for more information.
 

--- a/src/dotnet-roslyn-tools/Logging/SimplerConsoleFormatter.cs
+++ b/src/dotnet-roslyn-tools/Logging/SimplerConsoleFormatter.cs
@@ -1,4 +1,4 @@
-// Licensed to the.NET Foundation under one or more agreements.
+﻿// Licensed to the.NET Foundation under one or more agreements.
 // The.NET Foundation licenses this file to you under the MIT license.
 // See the License.txt file in the project root for more information.
 

--- a/src/dotnet-roslyn-tools/Products/FSharp.cs
+++ b/src/dotnet-roslyn-tools/Products/FSharp.cs
@@ -17,11 +17,12 @@ internal class FSharp : IProduct
 
     public string ComponentJsonFileName => @".corext\Configs\components.json";
     public string ComponentName => "Microsoft.FSharp";
-    public string? PackageName => null;
-    public string? PackagePropsFileName => null;
+    public string? VsPackageName => null;
+    public string? VsPackagePropsFileName => null;
     public string? DartLabPipelineName => null;
     public string? ArtifactsFolderName => null;
     public string[] ArtifactsSubFolderNames => [];
+    public string SdkPackageName => "Microsoft.FSharp.Compiler";
 
 
     public string? GetBuildPipelineName(string buildProjectName)

--- a/src/dotnet-roslyn-tools/Products/IProduct.cs
+++ b/src/dotnet-roslyn-tools/Products/IProduct.cs
@@ -18,11 +18,13 @@ internal interface IProduct
 
     string ComponentJsonFileName { get; }
     string ComponentName { get; }
-    string? PackageName { get; }
-    string? PackagePropsFileName { get; }
+    string? VsPackageName { get; }
+    string? VsPackagePropsFileName { get; }
     string? DartLabPipelineName { get; }
     string? ArtifactsFolderName { get; }
     string[] ArtifactsSubFolderNames { get; }
+
+    string? SdkPackageName { get; }
 
     string? GetBuildPipelineName(string buildProjectName);
 }

--- a/src/dotnet-roslyn-tools/Products/Razor.cs
+++ b/src/dotnet-roslyn-tools/Products/Razor.cs
@@ -17,11 +17,13 @@ internal class Razor : IProduct
 
     public string ComponentJsonFileName => @".corext\Configs\aspnet-components.json";
     public string ComponentName => "Microsoft.VisualStudio.RazorExtension";
-    public string? PackageName => null;
-    public string? PackagePropsFileName => null;
+    public string? VsPackageName => null;
+    public string? VsPackagePropsFileName => null;
     public string? DartLabPipelineName => null;
     public string? ArtifactsFolderName => null;
     public string[] ArtifactsSubFolderNames => [];
+
+    public string SdkPackageName => "Microsoft.CodeAnalysis.Razor.Tooling.Internal";
 
     public string? GetBuildPipelineName(string buildProjectName)
         => buildProjectName switch

--- a/src/dotnet-roslyn-tools/Products/Roslyn.cs
+++ b/src/dotnet-roslyn-tools/Products/Roslyn.cs
@@ -17,11 +17,13 @@ internal class Roslyn : IProduct
 
     public string ComponentJsonFileName => @".corext\Configs\dotnetcodeanalysis-components.json";
     public string ComponentName => "Microsoft.CodeAnalysis.LanguageServices";
-    public string? PackageName => "VS.ExternalAPIs.Roslyn";
-    public string? PackagePropsFileName => "src/ConfigData/Packages/roslyn.props";
+    public string? VsPackageName => "VS.ExternalAPIs.Roslyn";
+    public string? VsPackagePropsFileName => "src/ConfigData/Packages/roslyn.props";
     public string? DartLabPipelineName => "Roslyn Integration CI DartLab";
     public string? ArtifactsFolderName => "PackageArtifacts";
     public string[] ArtifactsSubFolderNames => ["PackageArtifacts/PreRelease", "PackageArtifacts/Release"];
+
+    public string SdkPackageName => "Microsoft.Net.Compilers.Toolset";
 
     public string? GetBuildPipelineName(string buildProjectName)
         => buildProjectName switch

--- a/src/dotnet-roslyn-tools/Products/TypeScript.cs
+++ b/src/dotnet-roslyn-tools/Products/TypeScript.cs
@@ -16,12 +16,13 @@ internal class TypeScript : IProduct
 
     public string ComponentJsonFileName => @".corext\Configs\components.json";
     public string ComponentName => "TypeScript_Tools";
-    public string? PackageName => "VS.ExternalAPIs.TypeScript.SourceMapReader.dev15";
+    public string? VsPackageName => "VS.ExternalAPIs.TypeScript.SourceMapReader.dev15";
+    public string? VsPackagePropsFileName => "src/ConfigData/Packages/TypeScriptSupport.props";
     public string? DartLabPipelineName => null;
     public string? ArtifactsFolderName => null;
     public string[] ArtifactsSubFolderNames => [];
 
-    public string? PackagePropsFileName => "src/ConfigData/Packages/TypeScriptSupport.props";
+    public string? SdkPackageName => null;
 
     public string? GetBuildPipelineName(string buildProjectName)
         => buildProjectName switch

--- a/src/dotnet-roslyn-tools/VS/VSBranchInfo.cs
+++ b/src/dotnet-roslyn-tools/VS/VSBranchInfo.cs
@@ -59,19 +59,19 @@ internal static class VSBranchInfo
 
     private static async Task WritePackageInfo(IProduct product, string gitVersion, GitVersionType gitVersionType, AzDOConnection devdiv)
     {
-        if (product.PackageName is null)
+        if (product.VsPackageName is null)
         {
             return;
         }
 
-        var packageVersion = await VisualStudioRepository.GetPackageVersionFromDefaultConfigAsync(gitVersion, gitVersionType, devdiv, product.PackageName);
+        var packageVersion = await VisualStudioRepository.GetPackageVersionFromDefaultConfigAsync(gitVersion, gitVersionType, devdiv, product.VsPackageName);
 
         if (packageVersion is null)
         {
-            if (product.PackagePropsFileName is null)
-                throw new Exception($"No package props file name is specified for {product.PackageName}");
+            if (product.VsPackagePropsFileName is null)
+                throw new Exception($"No package props file name is specified for {product.VsPackageName}");
 
-            packageVersion = await VisualStudioRepository.GetPackageVersionFromRoslynPropsAsync(gitVersion, gitVersionType, devdiv, product.PackageName, product.PackagePropsFileName);
+            packageVersion = await VisualStudioRepository.GetPackageVersionFromRoslynPropsAsync(gitVersion, gitVersionType, devdiv, product.VsPackageName, product.VsPackagePropsFileName);
         }
 
         WriteNameAndValue("Package Version", packageVersion);


### PR DESCRIPTION
Roslyn is already creating tags for VS and the C# extension. This adds tagging for SDK releases.

I have already run this and pushed tags for both Roslyn and Razor repos.