### PR TITLE
Ignore GH Action code flow PRs in PRFinder.

### DIFF
--- a/src/dotnet-roslyn-tools/PRFinder/Hosts/GitHub.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/Hosts/GitHub.cs
@@ -55,7 +55,8 @@ internal partial class GitHub : IRepositoryHost
         }
 
         // Exclude merge commits from auto code-flow PRs (e.g. merges/main-to-main-vs-deps)
-        if (IsGitHubReleaseFlowCommit().Match(commit.MessageShort).Success)
+        if (IsGitHubReleaseFlowCommit().Match(commit.MessageShort).Success ||
+            IsGitHubActionCodeFlowCommit().Match(commit.MessageShort).Success)
         {
             mergePRFound = true;
             return true;
@@ -193,6 +194,8 @@ internal partial class GitHub : IRepositoryHost
 
     [GeneratedRegex(@"^Merge pull request #\d+ from dotnet/merges/")]
     private static partial Regex IsGitHubReleaseFlowCommit();
+    [GeneratedRegex(@"^[automated] Merge branch '.*' => '.*'")]
+    private static partial Regex IsGitHubActionCodeFlowCommit();
     [GeneratedRegex(@"^Merge pull request #(\d+) from")]
     private static partial Regex IsGitHubMergePRCommit();
     [GeneratedRegex(@"\(#(\d+)\)(?:\n|$)")]

--- a/src/dotnet-roslyn-tools/PRFinder/Hosts/GitHub.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/Hosts/GitHub.cs
@@ -194,7 +194,7 @@ internal partial class GitHub : IRepositoryHost
 
     [GeneratedRegex(@"^Merge pull request #\d+ from dotnet/merges/")]
     private static partial Regex IsGitHubReleaseFlowCommit();
-    [GeneratedRegex(@"^[automated] Merge branch '.*' => '.*' \(#\d+\)")]
+    [GeneratedRegex(@"^\[automated\] Merge branch '.*' => '.*' \(#\d+\)")]
     private static partial Regex IsGitHubActionCodeFlowCommit();
     [GeneratedRegex(@"^Merge pull request #(\d+) from")]
     private static partial Regex IsGitHubMergePRCommit();

--- a/src/dotnet-roslyn-tools/PRFinder/Hosts/GitHub.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/Hosts/GitHub.cs
@@ -194,7 +194,7 @@ internal partial class GitHub : IRepositoryHost
 
     [GeneratedRegex(@"^Merge pull request #\d+ from dotnet/merges/")]
     private static partial Regex IsGitHubReleaseFlowCommit();
-    [GeneratedRegex(@"^[automated] Merge branch '.*' => '.*'")]
+    [GeneratedRegex(@"^[automated] Merge branch '.*' => '.*' \(#\d+\)")]
     private static partial Regex IsGitHubActionCodeFlowCommit();
     [GeneratedRegex(@"^Merge pull request #(\d+) from")]
     private static partial Regex IsGitHubMergePRCommit();


### PR DESCRIPTION
The Arcade inter-branch merge GH action creates merge commits with a differently formatted message (ex. `[automated] Merge branch 'prerelease' => 'main' (#8039)`)

Tested by generating PR list between Roslyn main and Roslyn release/dev18.0:
*Before*:
```md
### Changes from [main](https://github.com/dotnet/roslyn/commit/main) to [release/dev18.0](https://github.com/dotnet/roslyn/commit/release/dev18.0):
[View Complete Diff of Changes](https://github.com/dotnet/roslyn/compare/main...release/dev18.0?w=1)
- [[automated] Merge branch 'main' => 'release/dev18.0' (77445)](https://github.com/dotnet/roslyn/pull/77445)
- [[automated] Merge branch 'main' => 'release/dev18.0' (77441)](https://github.com/dotnet/roslyn/pull/77441)
- [[automated] Merge branch 'main' => 'release/dev18.0' (77431)](https://github.com/dotnet/roslyn/pull/77431)
- [[automated] Merge branch 'main' => 'release/dev18.0' (77409)](https://github.com/dotnet/roslyn/pull/77409)
- [[automated] Merge branch 'main' => 'release/dev18.0' (77374)](https://github.com/dotnet/roslyn/pull/77374)
- [[automated] Merge branch 'main' => 'release/dev18.0' (77292)](https://github.com/dotnet/roslyn/pull/77292)
- [[automated] Merge branch 'main' => 'release/dev18.0' (77226)](https://github.com/dotnet/roslyn/pull/77226)
- [[automated] Merge branch 'main' => 'release/dev18.0' (77153)](https://github.com/dotnet/roslyn/pull/77153)
- [Update Versions.props for Dev18 (77138)](https://github.com/dotnet/roslyn/pull/77138)
```

*After*:
```md
### Changes from [main](https://github.com/dotnet/roslyn/commit/main) to [release/dev18.0](https://github.com/dotnet/roslyn/commit/release/dev18.0):
[View Complete Diff of Changes](https://github.com/dotnet/roslyn/compare/main...release/dev18.0?w=1)
- [Update Versions.props for Dev18 (77138)](https://github.com/dotnet/roslyn/pull/77138)
```