### PR TITLE
Update the GH squash commit RegEx to remove the PR number.

### DIFF
--- a/src/dotnet-roslyn-tools/.vscode/launch.json
+++ b/src/dotnet-roslyn-tools/.vscode/launch.json
@@ -23,6 +23,27 @@
             "stopAtEntry": false
         },
         {
+            "name": "Run `pr-finder` on Razor",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/../../artifacts/bin/Microsoft.RoslynTools/Debug/net9.0/Microsoft.RoslynTools.dll",
+            "args": [
+              "pr-finder",
+              "-s",
+              "e15fe5b8b38c1b1e1adb9c8a4d76567aa1c397db",
+              "-e",
+              "main",
+              "--format",
+              "changelog",
+              "-v",
+              "diag"
+            ],
+            "cwd": "${workspaceFolder}/../../../razor",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
             "name": "Run `vsbranchinfo`",
             "type": "coreclr",
             "request": "launch",

--- a/src/dotnet-roslyn-tools/PRFinder/Hosts/GitHub.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/Hosts/GitHub.cs
@@ -96,7 +96,7 @@ internal partial class GitHub : IRepositoryHost
                 var prNumber = match.Groups[2].Value;
 
                 // Squash PR Messages are in the form "Nullable annotate TypeCompilationState and MessageID (#39449)"
-                // Take the 1st line since it should be descriptive.
+                // Take the first line up until the PR number.
                 var comment = match.Groups[1].Value;
                 return new(prNumber, comment);
             }

--- a/src/dotnet-roslyn-tools/PRFinder/Hosts/GitHub.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/Hosts/GitHub.cs
@@ -93,11 +93,11 @@ internal partial class GitHub : IRepositoryHost
             match = IsGitHubSquashedPRCommit().Match(commit.MessageShort);
             if (match.Success)
             {
-                var prNumber = match.Groups[1].Value;
+                var prNumber = match.Groups[2].Value;
 
                 // Squash PR Messages are in the form "Nullable annotate TypeCompilationState and MessageID (#39449)"
                 // Take the 1st line since it should be descriptive.
-                var comment = commit.MessageShort;
+                var comment = match.Groups[1].Value;
                 return new(prNumber, comment);
             }
         }
@@ -198,6 +198,6 @@ internal partial class GitHub : IRepositoryHost
     private static partial Regex IsGitHubActionCodeFlowCommit();
     [GeneratedRegex(@"^Merge pull request #(\d+) from")]
     private static partial Regex IsGitHubMergePRCommit();
-    [GeneratedRegex(@"\(#(\d+)\)(?:\n|$)")]
+    [GeneratedRegex(@"^(.*) \(#(\d+)\)(?:\n|$)")]
     private static partial Regex IsGitHubSquashedPRCommit();
 }


### PR DESCRIPTION
Noticed that we were not removing PR numbers when [fixing up the C# ext. CHANGELOG](https://github.com/dotnet/vscode-csharp/pull/8071). Leaving the PR number in allows GH to turn it into a link when the number is in the range to be valid.

BEFORE:

  * React to NuGet package pruning warnings (#11496) (PR: [#11496](https://github.com/dotnet/razor/pull/11496))
  * Add a couple of "stress tests" to the integration test project (#11481) (PR: [#11481](https://github.com/dotnet/razor/pull/11481))
  * Fix a couple of options in the old options screen (#11486) (PR: [#11486](https://github.com/dotnet/razor/pull/11486))
  * Don't use Directory.Exists to check if a path is relative (#11483) (PR: [#11483](https://github.com/dotnet/razor/pull/11483))
  * Fix another IDE0040 violation (#11474) (PR: [#11474](https://github.com/dotnet/razor/pull/11474))
  * Remove accessibility modifiers from interface members (#11472) (PR: [#11472](https://github.com/dotnet/razor/pull/11472))

AFTER:

  * React to NuGet package pruning warnings (PR: [#11496](https://github.com/dotnet/razor/pull/11496))
  * Add a couple of "stress tests" to the integration test project (PR: [#11481](https://github.com/dotnet/razor/pull/11481))
  * Fix a couple of options in the old options screen (PR: [#11486](https://github.com/dotnet/razor/pull/11486))
  * Don't use Directory.Exists to check if a path is relative (PR: [#11483](https://github.com/dotnet/razor/pull/11483))
  * Fix another IDE0040 violation (PR: [#11474](https://github.com/dotnet/razor/pull/11474))
  * Remove accessibility modifiers from interface members (PR: [#11472](https://github.com/dotnet/razor/pull/11472))