### PR TITLE
Add roslyn-analyzer packages to the `nuget` command

### DIFF
--- a/src/dotnet-roslyn-tools/NuGet/NuGetPrepare.cs
+++ b/src/dotnet-roslyn-tools/NuGet/NuGetPrepare.cs
@@ -12,29 +12,39 @@ internal class NuGetPrepare
     private const string NotPublishedDirectoryName = "NotPublished";
 
     internal static readonly string[] RoslynPackageIds =
-        [
-            "Microsoft.CodeAnalysis",
-            "Microsoft.CodeAnalysis.Common",
-            "Microsoft.CodeAnalysis.Compilers",
-            "Microsoft.CodeAnalysis.CSharp",
-            "Microsoft.CodeAnalysis.CSharp.CodeStyle",
-            "Microsoft.CodeAnalysis.CSharp.Features",
-            "Microsoft.CodeAnalysis.CSharp.Scripting",
-            "Microsoft.CodeAnalysis.CSharp.Workspaces",
-            "Microsoft.CodeAnalysis.EditorFeatures.Text",
-            "Microsoft.CodeAnalysis.Features",
-            "Microsoft.CodeAnalysis.Scripting",
-            "Microsoft.CodeAnalysis.Scripting.Common",
-            "Microsoft.CodeAnalysis.VisualBasic",
-            "Microsoft.CodeAnalysis.VisualBasic.CodeStyle",
-            "Microsoft.CodeAnalysis.VisualBasic.Features",
-            "Microsoft.CodeAnalysis.VisualBasic.Workspaces",
-            "Microsoft.CodeAnalysis.Workspaces.Common",
-            "Microsoft.CodeAnalysis.Workspaces.MSBuild",
-            "Microsoft.Net.Compilers.Toolset",
-            "Microsoft.Net.Compilers.Toolset.Framework",
-            "Microsoft.VisualStudio.LanguageServices"
-        ];
+    [
+        "Microsoft.CodeAnalysis",
+        "Microsoft.CodeAnalysis.Analyzers",
+        "Microsoft.CodeAnalysis.AnalyzerUtilities",
+        "Microsoft.CodeAnalysis.BannedApiAnalyzers",
+        "Microsoft.CodeAnalysis.Common",
+        "Microsoft.CodeAnalysis.Compilers",
+        "Microsoft.CodeAnalysis.CSharp",
+        "Microsoft.CodeAnalysis.CSharp.CodeStyle",
+        "Microsoft.CodeAnalysis.CSharp.Features",
+        "Microsoft.CodeAnalysis.CSharp.Scripting",
+        "Microsoft.CodeAnalysis.CSharp.Workspaces",
+        "Microsoft.CodeAnalysis.EditorFeatures.Text",
+        "Microsoft.CodeAnalysis.Features",
+        "Microsoft.CodeAnalysis.Metrics",
+        "Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers",
+        "Microsoft.CodeAnalysis.PublicApiAnalyzers",
+        "Microsoft.CodeAnalysis.ResxSourceGenerator",
+        "Microsoft.CodeAnalysis.RulesetToEditorconfigConverter",
+        "Microsoft.CodeAnalysis.Scripting",
+        "Microsoft.CodeAnalysis.Scripting.Common",
+        "Microsoft.CodeAnalysis.VisualBasic",
+        "Microsoft.CodeAnalysis.VisualBasic.CodeStyle",
+        "Microsoft.CodeAnalysis.VisualBasic.Features",
+        "Microsoft.CodeAnalysis.VisualBasic.Workspaces",
+        "Microsoft.CodeAnalysis.Workspaces.Common",
+        "Microsoft.CodeAnalysis.Workspaces.MSBuild",
+        "Microsoft.Net.Compilers.Toolset",
+        "Microsoft.Net.Compilers.Toolset.Framework",
+        "Microsoft.VisualStudio.LanguageServices",
+        "Roslyn.Diagnostics.Analyzers",
+        "Text.Analyzers"
+    ];
 
     internal static async Task<int> PrepareAsync(ILogger logger)
     {

--- a/src/dotnet-roslyn-tools/NuGet/NuGetPublish.cs
+++ b/src/dotnet-roslyn-tools/NuGet/NuGetPublish.cs
@@ -16,6 +16,9 @@ internal class NuGetPublish
     internal static readonly string[] RoslynPackageIds =
     [
         "Microsoft.CodeAnalysis",
+        "Microsoft.CodeAnalysis.Analyzers",
+        "Microsoft.CodeAnalysis.AnalyzerUtilities",
+        "Microsoft.CodeAnalysis.BannedApiAnalyzers",
         "Microsoft.CodeAnalysis.Common",
         "Microsoft.CodeAnalysis.Compilers",
         "Microsoft.CodeAnalysis.CSharp",
@@ -25,6 +28,11 @@ internal class NuGetPublish
         "Microsoft.CodeAnalysis.CSharp.Workspaces",
         "Microsoft.CodeAnalysis.EditorFeatures.Text",
         "Microsoft.CodeAnalysis.Features",
+        "Microsoft.CodeAnalysis.Metrics",
+        "Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers",
+        "Microsoft.CodeAnalysis.PublicApiAnalyzers",
+        "Microsoft.CodeAnalysis.ResxSourceGenerator",
+        "Microsoft.CodeAnalysis.RulesetToEditorconfigConverter",
         "Microsoft.CodeAnalysis.Scripting",
         "Microsoft.CodeAnalysis.Scripting.Common",
         "Microsoft.CodeAnalysis.VisualBasic",
@@ -35,7 +43,9 @@ internal class NuGetPublish
         "Microsoft.CodeAnalysis.Workspaces.MSBuild",
         "Microsoft.Net.Compilers.Toolset",
         "Microsoft.Net.Compilers.Toolset.Framework",
-        "Microsoft.VisualStudio.LanguageServices"
+        "Microsoft.VisualStudio.LanguageServices",
+        "Roslyn.Diagnostics.Analyzers",
+        "Text.Analyzers"
     ];
 
     internal static readonly string[] RoslynSdkPackageIds =


### PR DESCRIPTION
Now that roslyn-analyzer packages are building out of the roslyn repo, we will need to publish them along with our other packages.