### PR TITLE
revert 1eshardlink workaround now that artifact names have changed

### DIFF
--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
@@ -441,7 +441,6 @@ namespace Roslyn.Insertion
         private static Component[] GetLatestBuildComponents(Build newestBuild, InsertionArtifacts buildArtifacts, CancellationToken cancellationToken)
         {
             var components = Directory.EnumerateFiles(buildArtifacts.RootDirectory, "*.vsman", SearchOption.AllDirectories)
-                .Where(file => !Is1esHardlink(file))
                 .Select(GetComponentFromManifestFile)
                 .OfType<Component>()
                 .ToArray();
@@ -453,18 +452,6 @@ namespace Roslyn.Insertion
             }
 
             return components;
-
-            static bool Is1esHardlink(string path)
-            {
-                if (path.Contains("_hardlink"))
-                {
-                    // 1es creates duplicate <folder>_hardlink folders for scanning.  These should be ignored.
-                    Console.WriteLine($"Ignoring {path} as it appears to be a hardlink for 1es scanning");
-                    return true;
-                }
-
-                return false;
-            }
         }
 
         private static Component GetComponentFromManifestFile(string filePath)


### PR DESCRIPTION
See https://github.com/dotnet/roslyn/pull/79839 for context - the hardlink names have changed and we have a workaround on the roslyn side instead