### PR TITLE
Allow create-release-tags to looks up repo SHA from vmr build

### DIFF
--- a/src/dotnet-roslyn-tools/CreateReleaseTags/CreateReleaseTags.cs
+++ b/src/dotnet-roslyn-tools/CreateReleaseTags/CreateReleaseTags.cs
@@ -28,8 +28,8 @@ internal static partial class CreateReleaseTags
 
         var existingTags = repository.Tags.Select(t => t.FriendlyName).ToImmutableHashSet();
 
-        await new SdkReleaseTagger().CreateReleaseTagsAsync(connections, product, repository, existingTags, logger);
-        await new VsReleaseTagger().CreateReleaseTagsAsync(connections, product, repository, existingTags, logger);
+        await new SdkReleaseTagger(logger).CreateReleaseTagsAsync(connections, product, repository, existingTags);
+        await new VsReleaseTagger(logger).CreateReleaseTagsAsync(connections, product, repository, existingTags);
 
         logger.LogInformation("Tagging complete.");
 

--- a/src/dotnet-roslyn-tools/CreateReleaseTags/SdkReleaseTagger.cs
+++ b/src/dotnet-roslyn-tools/CreateReleaseTags/SdkReleaseTagger.cs
@@ -7,13 +7,14 @@ using System.Net.Http.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
+using Microsoft.Extensions.Logging;
 using Microsoft.RoslynTools.Products;
 using Microsoft.RoslynTools.Utilities;
 
 namespace Microsoft.RoslynTools.CreateReleaseTags;
 
-internal sealed partial class SdkReleaseTagger
-    : AbstractReleaseTagger<SdkReleaseTagger.SdkReleaseInformation, SdkReleaseTagger.SdkBuildInformation>
+internal sealed partial class SdkReleaseTagger(ILogger logger)
+    : AbstractReleaseTagger<SdkReleaseTagger.SdkReleaseInformation, SdkReleaseTagger.SdkBuildInformation>(logger)
 {
     private const string SdkRepoBaseUrl = "https://api.github.com/repos/dotnet/sdk/";
 
@@ -123,7 +124,10 @@ internal sealed partial class SdkReleaseTagger
             sourceManifest = await connections.GitHubClient
                 .GetFromJsonAsync<VmrSourceManifest?>($"https://raw.githubusercontent.com/dotnet/dotnet/{vmrBuild.CommitSha}/src/source-manifest.json");
         }
-        catch (Exception) { }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Error fetching VMR source manifest");
+        }
 
         if (sourceManifest is null)
         {

--- a/src/dotnet-roslyn-tools/CreateReleaseTags/VsReleaseTagger.cs
+++ b/src/dotnet-roslyn-tools/CreateReleaseTags/VsReleaseTagger.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Net;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
+using Microsoft.Extensions.Logging;
 using Microsoft.RoslynTools.Products;
 using Microsoft.RoslynTools.Utilities;
 using Microsoft.TeamFoundation.SourceControl.WebApi;
@@ -13,8 +14,8 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.RoslynTools.CreateReleaseTags;
 
-internal sealed partial class VsReleaseTagger
-    : AbstractReleaseTagger<VsReleaseTagger.VsReleaseInformation, VsReleaseTagger.VsBuildInformation>
+internal sealed partial class VsReleaseTagger(ILogger logger)
+    : AbstractReleaseTagger<VsReleaseTagger.VsReleaseInformation, VsReleaseTagger.VsBuildInformation>(logger)
 {
     public override string Name => "VS";
 
@@ -28,6 +29,7 @@ internal sealed partial class VsReleaseTagger
         { "17.12.", "2022" },
         { "17.13.", "2022" },
         { "17.14.", "2022" },
+        { "18.", "2026" },
     }.ToImmutableDictionary();
 
     public override async Task<ImmutableArray<VsReleaseInformation>> GetReleasesAsync(RemoteConnections connections)


### PR DESCRIPTION
Starting with .NET 10 preview 5, the SDK has built out of the dotnet VMR. This broke release tagging for the SDK. The SDK release tagger is updated to look up the repo specific SHA from the VMR build commit. Tags from VMR builds call out specifically that the information is for the VMR build ([example](https://github.com/dotnet/roslyn/releases/tag/NET-SDK-10.0.100-preview.7.25380.108)).

```
NET-SDK-10.0.100-preview.7.25380.108: Roslyn VMR Version: 5.0.0-2.25373.105
VMR Commit SHA: b64f1193459ddeba61d78aa61f90604410734e0f
VMR Internal ID: 20250723.105
SDK Tag: v10.0.100-preview.7.25380.108
```