### PR TITLE
Update GitHub PR skip logic

### DIFF
--- a/src/dotnet-roslyn-tools/.vscode/launch.json
+++ b/src/dotnet-roslyn-tools/.vscode/launch.json
@@ -1,113 +1,134 @@
 {
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Run `pr-finder`",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "build",
-            "program": "${workspaceFolder}/../../artifacts/bin/Microsoft.RoslynTools/Debug/net9.0/Microsoft.RoslynTools.dll",
-            "args": [
-              "pr-finder",
-              "-s",
-              "d7261529b43f4581fb47e8f4d3d9197095d44508",
-              "-e",
-              "main",
-              "--path",
-              "src/dotnet-roslyn-tools",
-              "-v",
-              "diag"
-            ],
-            "cwd": "${workspaceFolder}",
-            "console": "internalConsole",
-            "stopAtEntry": false
-        },
-        {
-            "name": "Run `pr-finder` on Razor",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "build",
-            "program": "${workspaceFolder}/../../artifacts/bin/Microsoft.RoslynTools/Debug/net9.0/Microsoft.RoslynTools.dll",
-            "args": [
-              "pr-finder",
-              "-s",
-              "e15fe5b8b38c1b1e1adb9c8a4d76567aa1c397db",
-              "-e",
-              "main",
-              "--format",
-              "changelog",
-              "-v",
-              "diag"
-            ],
-            "cwd": "${workspaceFolder}/../../../razor",
-            "console": "internalConsole",
-            "stopAtEntry": false
-        },
-        {
-            "name": "Run `vsbranchinfo`",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "build",
-            "program": "${workspaceFolder}/../../artifacts/bin/Microsoft.RoslynTools/Debug/net9.0/Microsoft.RoslynTools.dll",
-            "args": [
-              "vsbranchinfo",
-              "--branch",
-              "rel/d17.11",
-              "-v",
-              "diag"
-            ],
-            "cwd": "${workspaceFolder}",
-            "console": "internalConsole",
-            "stopAtEntry": false
-        },
-        {
-            "name": "Run `create-release-tags -p roslyn`",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "build",
-            "program": "${workspaceFolder}/../../artifacts/bin/Microsoft.RoslynTools/Debug/net9.0/Microsoft.RoslynTools.dll",
-            "args": [
-              "create-release-tags",
-              "-p",
-              "roslyn"
-            ],
-            "cwd": "${workspaceFolder}/../../../roslyn",
-            "console": "internalConsole",
-            "stopAtEntry": false
-        },
-        {
-            "name": "Run `create-release-tags -p razor`",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "build",
-            "program": "${workspaceFolder}/../../artifacts/bin/Microsoft.RoslynTools/Debug/net9.0/Microsoft.RoslynTools.dll",
-            "args": [
-              "create-release-tags",
-              "-p",
-              "razor"
-            ],
-            "cwd": "${workspaceFolder}/../../../razor",
-            "console": "internalConsole",
-            "stopAtEntry": false
-        },
-        {
-            "name": "Run `authenticate --clear`",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "build",
-            "program": "${workspaceFolder}/../../artifacts/bin/Microsoft.RoslynTools/Debug/net9.0/Microsoft.RoslynTools.dll",
-            "args": [
-              "authenticate",
-              "--clear"
-            ],
-            "cwd": "${workspaceFolder}",
-            "console": "internalConsole",
-            "stopAtEntry": false
-        },
-        {
-            "name": ".NET Core Attach",
-            "type": "coreclr",
-            "request": "attach"
-        }
-    ]
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run `pr-finder`",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "${workspaceFolder}/../../artifacts/bin/Microsoft.RoslynTools/Debug/net9.0/Microsoft.RoslynTools.dll",
+      "args": [
+        "pr-finder",
+        "-s",
+        "d7261529b43f4581fb47e8f4d3d9197095d44508",
+        "-e",
+        "main",
+        "--path",
+        "src/dotnet-roslyn-tools",
+        "-v",
+        "diag"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "internalConsole",
+      "stopAtEntry": false
+    },
+    {
+      "name": "Run `pr-finder` on Roslyn",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "${workspaceFolder}/../../artifacts/bin/Microsoft.RoslynTools/Debug/net9.0/Microsoft.RoslynTools.dll",
+      "args": [
+        "pr-finder",
+        "-s",
+        "b0b21b619712d4095afe5ab267efaf77a1e47bb0",
+        "-e",
+        "8e3d84569a17786744edc314614a99800ec3fd1f",
+        "--label",
+        "vscode",
+        "-v",
+        "diag"
+      ],
+      "cwd": "${workspaceFolder}/../../../roslyn",
+      "console": "internalConsole",
+      "stopAtEntry": false
+    },
+    {
+      "name": "Run `pr-finder` on Razor",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "${workspaceFolder}/../../artifacts/bin/Microsoft.RoslynTools/Debug/net9.0/Microsoft.RoslynTools.dll",
+      "args": [
+        "pr-finder",
+        "-s",
+        "e15fe5b8b38c1b1e1adb9c8a4d76567aa1c397db",
+        "-e",
+        "main",
+        "--format",
+        "changelog",
+        "-v",
+        "diag"
+      ],
+      "cwd": "${workspaceFolder}/../../../razor",
+      "console": "internalConsole",
+      "stopAtEntry": false
+    },
+    {
+      "name": "Run `vsbranchinfo`",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "${workspaceFolder}/../../artifacts/bin/Microsoft.RoslynTools/Debug/net9.0/Microsoft.RoslynTools.dll",
+      "args": [
+        "vsbranchinfo",
+        "--branch",
+        "rel/d17.11",
+        "-v",
+        "diag"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "internalConsole",
+      "stopAtEntry": false
+    },
+    {
+      "name": "Run `create-release-tags -p roslyn`",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "${workspaceFolder}/../../artifacts/bin/Microsoft.RoslynTools/Debug/net9.0/Microsoft.RoslynTools.dll",
+      "args": [
+        "create-release-tags",
+        "-p",
+        "roslyn"
+      ],
+      "cwd": "${workspaceFolder}/../../../roslyn",
+      "console": "internalConsole",
+      "stopAtEntry": false
+    },
+    {
+      "name": "Run `create-release-tags -p razor`",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "${workspaceFolder}/../../artifacts/bin/Microsoft.RoslynTools/Debug/net9.0/Microsoft.RoslynTools.dll",
+      "args": [
+        "create-release-tags",
+        "-p",
+        "razor"
+      ],
+      "cwd": "${workspaceFolder}/../../../razor",
+      "console": "internalConsole",
+      "stopAtEntry": false
+    },
+    {
+      "name": "Run `authenticate --clear`",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "${workspaceFolder}/../../artifacts/bin/Microsoft.RoslynTools/Debug/net9.0/Microsoft.RoslynTools.dll",
+      "args": [
+        "authenticate",
+        "--clear"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "internalConsole",
+      "stopAtEntry": false
+    },
+    {
+      "name": ".NET Core Attach",
+      "type": "coreclr",
+      "request": "attach"
+    }
+  ]
 }

--- a/src/dotnet-roslyn-tools/PRFinder/PRFinder.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/PRFinder.cs
@@ -100,6 +100,8 @@ internal class PRFinder
             return 1;
         }
 
+        builder ??= new();
+
         IRepositoryHost host = isGitHub
             ? new Hosts.GitHub(repoUrl, connections, logger)
             : new Hosts.Azure(repoUrl);
@@ -189,12 +191,13 @@ internal class PRFinder
             RecordLine(prLink, logger, builder);
         }
 
+        logger.LogInformation("{Builder}", builder);
+
         return 0;
     }
 
     private static void RecordLine(string line, ILogger logger, StringBuilder? builder)
     {
-        logger.LogInformation("{Line}", line);
         builder?.AppendLine(line);
     }
 


### PR DESCRIPTION
46 PRs before and 36 after
```diff
+    * [Cache diagnostic analyzer computation](https://github.com/dotnet/roslyn/pull/80045)
+    * [Remove parameter always passed the same value](https://github.com/dotnet/roslyn/pull/80042)
     * [Update doc for IMethodSymbol.IsExtensionMethod](https://github.com/dotnet/roslyn/pull/80016)
     * [Don't cache known-broken compositions](https://github.com/dotnet/roslyn/pull/80021)
     * [Cleanup methods in DiagAnalyzerService](https://github.com/dotnet/roslyn/pull/80013)
     * [Simplify processing of errors reported by the build](https://github.com/dotnet/roslyn/pull/79964)
     * [Additional cleanup of the DiagnosticAnalyzerServier](https://github.com/dotnet/roslyn/pull/80005)
     * [Fix Code Lens around source generated files](https://github.com/dotnet/roslyn/pull/79992)
     * [Remove superflous DiagService api that can be achieved with existing apis](https://github.com/dotnet/roslyn/pull/80007)
     * [Generate `init` accessor for required properties inside `readonly struct`s](https://github.com/dotnet/roslyn/pull/80004)
     * [Remove existing low level diag oop code now that it's all handled at higher levels.](https://github.com/dotnet/roslyn/pull/79994)
     * [Allow large InlineHint ArrayBuilder pooling](https://github.com/dotnet/roslyn/pull/79857)
     * [Reduce allocations obtaining classified spans in ClassifierHelper](https://github.com/dotnet/roslyn/pull/79856)
     * [Compute span diagnostics in oop](https://github.com/dotnet/roslyn/pull/79991)
     * [Allow Razor cohosting to work with non-Razor SDK projects](https://github.com/dotnet/roslyn/pull/79953)
     * [Move computation of deprioritized analyzers to oop](https://github.com/dotnet/roslyn/pull/79989)
     * [EnC: Fix symbol mapping of delegates with indexed name](https://github.com/dotnet/roslyn/pull/79837)
     * [Emit telemetry 'durations' with known radix point '.'](https://github.com/dotnet/roslyn/pull/79988)
     * [Move logic up into DiagService](https://github.com/dotnet/roslyn/pull/79985)
     * [Move the StateManager type up to the DiagnosticService from the DiagnosticIncrementalANalyzer](https://github.com/dotnet/roslyn/pull/79984)
     * [Immediately remote diagnostics call to OOP](https://github.com/dotnet/roslyn/pull/79983)
     * [Build Microsoft.CodeAnalysis.SemanticSearch.Extension ref assembly for use in semantic search queries](https://github.com/dotnet/roslyn/pull/79972)
     * [Only cache compilation if we have the same set of analyzers](https://github.com/dotnet/roslyn/pull/79978)
     * [Delete unused property](https://github.com/dotnet/roslyn/pull/79963)
     * [Update 'use expr body' to be a purely syntactic analyzer](https://github.com/dotnet/roslyn/pull/79979)
     * [Mark 'Use expr body' as a syntax-only fixer](https://github.com/dotnet/roslyn/pull/79971)
     * [♻️ MSBuildWorkspaceDirectory - Fallback to AppContext.BaseDirectory when Assembly Location is empty](https://github.com/dotnet/roslyn/pull/79934)
     * [Merge runtime async support into main](https://github.com/dotnet/roslyn/pull/79833)
     * [Implement "Simplify property accessor" feature](https://github.com/dotnet/roslyn/pull/79754)
-     * Merge main to runtime async branch (PR: [#79961](https://github.com/dotnet/roslyn/pull/79961))
     * [Redo how and when we report source generator telemetry](https://github.com/dotnet/roslyn/pull/79951)
     * [Allow MEF components to supply assembly path resolvers](https://github.com/dotnet/roslyn/pull/79218)
     * [Allow Razor to hook up the source generator in misc files](https://github.com/dotnet/roslyn/pull/79891)
     * [Block ENC for extension blocks](https://github.com/dotnet/roslyn/pull/79883)
     * [Upgrade servicehub.client to fix test source discovery](https://github.com/dotnet/roslyn/pull/79899)
     * [Update package restore error message.](https://github.com/dotnet/roslyn/pull/79876)
-    * Merge main (PR: [#79834](https://github.com/dotnet/roslyn/pull/79834))
-    * Merge main (PR: [#79830](https://github.com/dotnet/roslyn/pull/79830))
     * [Baseline struct lifting tests](https://github.com/dotnet/roslyn/pull/79505)
-    * Merge main to runtime async branch (PR: [#79582](https://github.com/dotnet/roslyn/pull/79582))
-    * Merge main (PR: [#79424](https://github.com/dotnet/roslyn/pull/79424))
-    * Merge main (PR: [#78994](https://github.com/dotnet/roslyn/pull/78994))
-    * Merge main to runtime async branch (PR: [#78740](https://github.com/dotnet/roslyn/pull/78740))
-    * Merge main to runtime async branch (PR: [#78517](https://github.com/dotnet/roslyn/pull/78517))
-    * Merge main to runtime async branch (PR: [#78114](https://github.com/dotnet/roslyn/pull/78114))
-    * Merge main to runtime async branch (PR: [#77700](https://github.com/dotnet/roslyn/pull/77700))
-    * Merge main to runtime async branch (PR: [#77533](https://github.com/dotnet/roslyn/pull/77533))
-    * Merge main to runtime async branch (PR: [#77265](https://github.com/dotnet/roslyn/pull/77265))
```