### PR TITLE
Revert "Fix the build pipeline used by the PRTagger command"

### DIFF
--- a/src/dotnet-roslyn-tools/PRTagger/PRTagger.cs
+++ b/src/dotnet-roslyn-tools/PRTagger/PRTagger.cs
@@ -34,7 +34,7 @@ internal static class PRTagger
     {
         var cancellationToken = CancellationToken.None;
         var builds = await remoteConnections.DevDivConnection.TryGetBuildsAsync(
-            "DD-CB-ReleaseVS",
+            "DD-CB-TestSignVS",
             logger: logger,
             buildNumber: vsBuild,
             maxFetchingVsBuildNumber: maxFetchingVSBuildNumber,


### PR DESCRIPTION
Reverts dotnet/roslyn-tools#1503