### PR TITLE
Generated 'View Complete Diff of Changes' URLs should function correctly in AzDO

### DIFF
--- a/.azure-ci.yaml
+++ b/.azure-ci.yaml
@@ -87,7 +87,7 @@ jobs:
     displayName: Install .NET SDK
     inputs:
       version: 8.x
-      installationPath: '$(Build.SourcesDirectory)\.dotnet'
+      installationPath: '$(Build.SourcesDirectory)/.dotnet'
 
   - script: ./eng/common/cibuild.sh --configuration $(_configuration) --prepareMachine /p:DotnetPublishUsingPipelines=true
 

--- a/.azure-ci.yaml
+++ b/.azure-ci.yaml
@@ -49,6 +49,7 @@ jobs:
     displayName: Install .NET SDK
     inputs:
       version: 8.x
+      installationPath: '$(Build.SourcesDirectory)\.dotnet'
 
   - script: .\eng\common\CIBuild.cmd -configuration $(_configuration) -prepareMachine  /p:DotnetPublishUsingPipelines=true
 
@@ -86,6 +87,7 @@ jobs:
     displayName: Install .NET SDK
     inputs:
       version: 8.x
+      installationPath: '$(Build.SourcesDirectory)\.dotnet'
 
   - script: ./eng/common/cibuild.sh --configuration $(_configuration) --prepareMachine /p:DotnetPublishUsingPipelines=true
 

--- a/.azure-ci.yaml
+++ b/.azure-ci.yaml
@@ -44,6 +44,12 @@ jobs:
       release:
         _configuration: Release
   steps:
+  # install .NET 8 for test projects targeting that version
+  - task: UseDotNet@2
+    displayName: Install .NET SDK
+    inputs:
+      version: 8.x
+
   - script: .\eng\common\CIBuild.cmd -configuration $(_configuration) -prepareMachine  /p:DotnetPublishUsingPipelines=true
 
   - task: PublishTestResults@2
@@ -75,6 +81,12 @@ jobs:
       release:
         _configuration: Release
   steps:
+  # install .NET 8 for test projects targeting that version
+  - task: UseDotNet@2
+    displayName: Install .NET SDK
+    inputs:
+      version: 8.x
+
   - script: ./eng/common/cibuild.sh --configuration $(_configuration) --prepareMachine /p:DotnetPublishUsingPipelines=true
 
   - task: PublishTestResults@2

--- a/RoslynTools.sln
+++ b/RoslynTools.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31710.301
@@ -69,6 +69,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.RoslynTools", "src\dotnet-roslyn-tools\Microsoft.RoslynTools.csproj", "{1D14C80C-B4C3-42C1-BA4C-8A81427CA44D}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProjectDependencies", "src\ProjectDependencies\ProjectDependencies.csproj", "{FB99AD63-B503-4B6D-AB2B-4A9E71DB4A86}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.RoslynTools.UnitTests", "src\dotnet-roslyn-tools-tests\Microsoft.RoslynTools.UnitTests.csproj", "{CF7C06C8-4BC7-4D18-AA29-D665E59E1A9D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -356,6 +358,18 @@ Global
 		{FB99AD63-B503-4B6D-AB2B-4A9E71DB4A86}.Release|x64.Build.0 = Release|Any CPU
 		{FB99AD63-B503-4B6D-AB2B-4A9E71DB4A86}.Release|x86.ActiveCfg = Release|Any CPU
 		{FB99AD63-B503-4B6D-AB2B-4A9E71DB4A86}.Release|x86.Build.0 = Release|Any CPU
+		{CF7C06C8-4BC7-4D18-AA29-D665E59E1A9D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CF7C06C8-4BC7-4D18-AA29-D665E59E1A9D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CF7C06C8-4BC7-4D18-AA29-D665E59E1A9D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CF7C06C8-4BC7-4D18-AA29-D665E59E1A9D}.Debug|x64.Build.0 = Debug|Any CPU
+		{CF7C06C8-4BC7-4D18-AA29-D665E59E1A9D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CF7C06C8-4BC7-4D18-AA29-D665E59E1A9D}.Debug|x86.Build.0 = Debug|Any CPU
+		{CF7C06C8-4BC7-4D18-AA29-D665E59E1A9D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CF7C06C8-4BC7-4D18-AA29-D665E59E1A9D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CF7C06C8-4BC7-4D18-AA29-D665E59E1A9D}.Release|x64.ActiveCfg = Release|Any CPU
+		{CF7C06C8-4BC7-4D18-AA29-D665E59E1A9D}.Release|x64.Build.0 = Release|Any CPU
+		{CF7C06C8-4BC7-4D18-AA29-D665E59E1A9D}.Release|x86.ActiveCfg = Release|Any CPU
+		{CF7C06C8-4BC7-4D18-AA29-D665E59E1A9D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -383,6 +397,7 @@ Global
 		{44B80D37-F395-40CF-8BB6-9AAEB5606672} = {821F3F43-E221-4507-95BD-64843868AC11}
 		{1D14C80C-B4C3-42C1-BA4C-8A81427CA44D} = {C68033E0-FB8F-4327-BFB5-B340A5A7778F}
 		{FB99AD63-B503-4B6D-AB2B-4A9E71DB4A86} = {732A897A-76AE-41E3-A7E4-55F16C1D56EB}
+		{CF7C06C8-4BC7-4D18-AA29-D665E59E1A9D} = {C68033E0-FB8F-4327-BFB5-B340A5A7778F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {738CC66D-49E2-4B21-835F-94170D22A29D}

--- a/RoslynTools.sln
+++ b/RoslynTools.sln
@@ -70,7 +70,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.RoslynTools", "sr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProjectDependencies", "src\ProjectDependencies\ProjectDependencies.csproj", "{FB99AD63-B503-4B6D-AB2B-4A9E71DB4A86}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.RoslynTools.UnitTests", "src\dotnet-roslyn-tools-tests\Microsoft.RoslynTools.UnitTests.csproj", "{CF7C06C8-4BC7-4D18-AA29-D665E59E1A9D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.RoslynTools.UnitTests", "src\dotnet-roslyn-tools-tests\Microsoft.RoslynTools.UnitTests.csproj", "{CF7C06C8-4BC7-4D18-AA29-D665E59E1A9D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
+++ b/src/RoslynInsertionTool/RoslynInsertionTool/RoslynInsertionTool.VisualStudioTeamServices.cs
@@ -547,8 +547,12 @@ namespace Roslyn.Insertion
                     })
                 .ToList();
 
-            // AzDO does not have a UI for comparing two commits. Instead generate the REST API call to retrieve commits between two SHAs.
-            return (commits, $"{tobuild.Repository.Url.OriginalString.Replace("_git", "_apis/git/repositories")}/commits?searchCriteria.itemVersion.version={fromSHA}&searchCriteria.itemVersion.versionType=commit&searchCriteria.compareVersion.version={toSHA}&searchCriteria.compareVersion.versionType=commit");
+            return (commits, ConstructAzDOCompareUrl(tobuild.Repository.Url.OriginalString, fromSHA, toSHA));
+        }
+
+        internal static string ConstructAzDOCompareUrl(string repoUrlString, string fromSHA, string toSHA)
+        {
+            return $"{repoUrlString}/branchCompare?baseVersion=GC{fromSHA}&targetVersion=GC{toSHA}";
         }
 
         private static async Task<(List<GitCommit> changes, string diffLink)> GetChangesBetweenBuildsFromGitHubAsync(string repoId, string fromSHA, string toSHA)

--- a/src/dotnet-roslyn-tools-tests/Insertion/RoslynInsertionToolTests.cs
+++ b/src/dotnet-roslyn-tools-tests/Insertion/RoslynInsertionToolTests.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the License.txt file in the project root for more information.
+
+using Microsoft.RoslynTools.Insertion;
+
+namespace Microsoft.RoslynTools.UnitTests.Insertion;
+
+public class RoslynInsertionToolTests
+{
+    [Fact]
+    public void AzDO_UrlConstructionShouldBeValidCompareLink()
+    {
+        // Arrange
+
+        // URLs and commits are generated for testing purposes only.
+        string repoUrl = "https://someserver.example.com/myorg/myproject/_git/myrepo";
+        string beforeCommit = "159abc3527def456cba852fed321654987654321";
+        string afterCommit = "fed456cba123987852147369abc258def4567893";
+        string expected = "https://someserver.example.com/myorg/myproject/_git/myrepo/branchCompare?baseVersion=GC159abc3527def456cba852fed321654987654321&targetVersion=GCfed456cba123987852147369abc258def4567893";
+
+        // Act
+        string actual = RoslynInsertionTool.ConstructAzDOCompareUrl(repoUrl, beforeCommit, afterCommit);
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+}

--- a/src/dotnet-roslyn-tools-tests/Microsoft.RoslynTools.UnitTests.csproj
+++ b/src/dotnet-roslyn-tools-tests/Microsoft.RoslynTools.UnitTests.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\dotnet-roslyn-tools\Microsoft.RoslynTools.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/src/dotnet-roslyn-tools/Insertion/RoslynInsertionTool.VisualStudioTeamServices.cs
+++ b/src/dotnet-roslyn-tools/Insertion/RoslynInsertionTool.VisualStudioTeamServices.cs
@@ -593,8 +593,12 @@ internal static partial class RoslynInsertionTool
                 })
             .ToList();
 
-        // AzDO does not have a UI for comparing two commits. Instead generate the REST API call to retrieve commits between two SHAs.
-        return (commits, $"{tobuild.Repository.Url.OriginalString.Replace("_git", "_apis/git/repositories")}/commits?searchCriteria.itemVersion.version={fromSHA}&searchCriteria.itemVersion.versionType=commit&searchCriteria.compareVersion.version={toSHA}&searchCriteria.compareVersion.versionType=commit");
+        return (commits, ConstructAzDOCompareUrl(tobuild.Repository.Url.OriginalString, fromSHA, toSHA));
+    }
+
+    internal static string ConstructAzDOCompareUrl(string repoUrlString, string fromSHA, string toSHA)
+    {
+        return $"{repoUrlString}/branchCompare?baseVersion=GC{fromSHA}&targetVersion=GC{toSHA}";
     }
 
     private static async Task<(List<GitCommit> changes, string diffLink)> GetChangesBetweenBuildsFromGitHubAsync(string repoId, string fromSHA, string toSHA)

--- a/src/dotnet-roslyn-tools/Microsoft.RoslynTools.csproj
+++ b/src/dotnet-roslyn-tools/Microsoft.RoslynTools.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
@@ -39,5 +39,9 @@
     <PackageReference Include="NuGet.Protocol" Version="6.12.5" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.25072.1" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.RoslynTools.UnitTests" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
ISSUE:
The "View Complete Diff of Changes" link, when used against an AzDO server, generated a URL that when you click gives the JSON result of an API call.  Instead, it should be a nice view, which AzDO now has.

FIX:
Update the url.  You can reach a similar URL by following the steps at: https://learn.microsoft.com/en-us/azure/devops/repos/git/manage-your-branches?view=azure-devops#change-the-compare-branch

VALIDATION:
Author a unittest (make a unittest project first) to verify exact existing behavior, then update the logic and the test.  Using a pre-commit pair of commits and an accurate repo URL, the string verified works correctly.

NOTE:
There are two versions (a net8 dotnet tool and a netfx executable); same change made in both, but only have tests for the dotnet tool.
Also, needed to install .net 8 on the CI machines in order to run the new tests.