### PR TITLE
Add bot exclusion for dotnet-oneloc-localization

### DIFF
--- a/src/dotnet-roslyn-tools/PRFinder/Hosts/GitHub.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/Hosts/GitHub.cs
@@ -52,7 +52,7 @@ internal partial class GitHub : IRepositoryHost
         // Exclude commits from bots
         if (commit.Author is "dotnet-maestro[bot]"
             or "dotnet-policy-service[bot]"
-            of "dotnet-oneloc-localization[bot]"
+            or "dotnet-oneloc-localization[bot]"
             or "dotnet-bot")
         {
             mergePRFound = true;

--- a/src/dotnet-roslyn-tools/PRFinder/Hosts/GitHub.cs
+++ b/src/dotnet-roslyn-tools/PRFinder/Hosts/GitHub.cs
@@ -52,6 +52,7 @@ internal partial class GitHub : IRepositoryHost
         // Exclude commits from bots
         if (commit.Author is "dotnet-maestro[bot]"
             or "dotnet-policy-service[bot]"
+            of "dotnet-oneloc-localization[bot]"
             or "dotnet-bot")
         {
             mergePRFound = true;


### PR DESCRIPTION
Need to investigate if we can just look for EndsWith('[bot]').